### PR TITLE
support for playcanvas types

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -9,6 +9,7 @@
 			"name": "Run Extension",
 			"type": "extensionHost",
 			"request": "launch",
+			"cwd":"${workspaceFolder}",
 			"args": [
 				"--extensionDevelopmentPath=${workspaceFolder}"
 			]

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ The extension includes a "Find In Files" feature. Users can search for a text st
 
 #### Settings
 
-The extension has 2 settings - Access Token and PlayCanvas username. 
+The extension has 3 settings - Access Token, PlayCanvas username and usePlaycanvasTypes to add types support. 
 
 ## Requirements
 
@@ -62,6 +62,7 @@ The extension has 2 settings - Access Token and PlayCanvas username.
 
 * `playcanvas.accessToken`: Generate an access token on your [account page](https://playcanvas.com/account).
 * `playcanvas.username`: Set to your PlayCanvas username.
+* `playcanvas.usePlaycanvasTypes`: Automatically adds a reference to Playcanvas types files for code suggestions. Line is not saved. Default is true.
 
 ## Known Issues
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,18 +9,19 @@
       "version": "0.1.1",
       "dependencies": {
         "form-data": "^4.0.0",
-        "node-fetch": "^2.1.2"
+        "node-fetch": "^2.1.2",
+        "playcanvas": "^1.69.2"
       },
       "devDependencies": {
         "@types/glob": "^8.1.0",
         "@types/mocha": "^10.0.1",
-        "@types/node": "20.2.5",
+        "@types/node": "^20.2.5",
         "@types/vscode": "^1.80.0",
         "@vscode/test-electron": "^2.3.2",
         "eslint": "^8.41.0",
         "glob": "^8.1.0",
         "mocha": "^10.2.0",
-        "typescript": "^5.1.3"
+        "typescript": "^5.4.2"
       },
       "engines": {
         "vscode": "^1.80.0"
@@ -192,7 +193,7 @@
     },
     "node_modules/@types/node": {
       "version": "20.2.5",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.2.5.tgz",
+      "resolved": "https://registry.snapchat.com/node/virtual/@types/node/-/node-20.2.5.tgz",
       "integrity": "sha512-JJulVEQXmiY9Px5axXHeYGLSjhkZEnD+MDPDGbCbIAbMslkKwmygtZFy1X6s/075Yo94sf8GuSlFfPzysQrWZQ==",
       "dev": true
     },
@@ -201,6 +202,11 @@
       "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.82.0.tgz",
       "integrity": "sha512-VSHV+VnpF8DEm8LNrn8OJ8VuUNcBzN3tMvKrNpbhhfuVjFm82+6v44AbDhLvVFgCzn6vs94EJNTp7w8S6+Q1Rw==",
       "dev": true
+    },
+    "node_modules/@types/webxr": {
+      "version": "0.5.14",
+      "resolved": "https://registry.snapchat.com/node/virtual/@types/webxr/-/webxr-0.5.14.tgz",
+      "integrity": "sha512-UEMMm/Xn3DtEa+gpzUrOcDj+SJS1tk5YodjwOxcqStNhCfPcwgyC5Srg2ToVKyg2Fhq16Ffpb0UWUQHqoT9AMA=="
     },
     "node_modules/@vscode/test-electron": {
       "version": "2.3.4",
@@ -216,6 +222,11 @@
       "engines": {
         "node": ">=16"
       }
+    },
+    "node_modules/@webgpu/types": {
+      "version": "0.1.40",
+      "resolved": "https://registry.snapchat.com/node/virtual/@webgpu/types/-/types-0.1.40.tgz",
+      "integrity": "sha512-/BBkHLS6/eQjyWhY2H7Dx5DHcVrS2ICj9owvSRdgtQT6KcafLZA86tPze0xAOsd4FbsYKCUBUQyNi87q7gV7kw=="
     },
     "node_modules/acorn": {
       "version": "8.10.0",
@@ -1577,6 +1588,15 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/playcanvas": {
+      "version": "1.69.2",
+      "resolved": "https://registry.snapchat.com/node/virtual/playcanvas/-/playcanvas-1.69.2.tgz",
+      "integrity": "sha512-UOjfvzkDHWHnyL9wSaFCYs04W/2owZoPS7pOZDKHneMlEE/OMg0bvdwYuWfy1mZRiGT00TFvqrP2Mla+BYgu9w==",
+      "dependencies": {
+        "@types/webxr": "^0.5.7",
+        "@webgpu/types": "^0.1.38"
+      }
+    },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -1907,9 +1927,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
-      "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
+      "version": "5.4.2",
+      "resolved": "https://registry.snapchat.com/node/virtual/typescript/-/typescript-5.4.2.tgz",
+      "integrity": "sha512-+2/g0Fds1ERlP6JsakQQDXjZdZMM+rqpamFZJEKh4kwTIn3iDkgKtby0CeNd5ATNZ4Ry1ax15TMx0W2V+miizQ==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
@@ -2186,7 +2206,7 @@
     },
     "@types/node": {
       "version": "20.2.5",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.2.5.tgz",
+      "resolved": "https://registry.snapchat.com/node/virtual/@types/node/-/node-20.2.5.tgz",
       "integrity": "sha512-JJulVEQXmiY9Px5axXHeYGLSjhkZEnD+MDPDGbCbIAbMslkKwmygtZFy1X6s/075Yo94sf8GuSlFfPzysQrWZQ==",
       "dev": true
     },
@@ -2195,6 +2215,11 @@
       "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.82.0.tgz",
       "integrity": "sha512-VSHV+VnpF8DEm8LNrn8OJ8VuUNcBzN3tMvKrNpbhhfuVjFm82+6v44AbDhLvVFgCzn6vs94EJNTp7w8S6+Q1Rw==",
       "dev": true
+    },
+    "@types/webxr": {
+      "version": "0.5.14",
+      "resolved": "https://registry.snapchat.com/node/virtual/@types/webxr/-/webxr-0.5.14.tgz",
+      "integrity": "sha512-UEMMm/Xn3DtEa+gpzUrOcDj+SJS1tk5YodjwOxcqStNhCfPcwgyC5Srg2ToVKyg2Fhq16Ffpb0UWUQHqoT9AMA=="
     },
     "@vscode/test-electron": {
       "version": "2.3.4",
@@ -2208,6 +2233,11 @@
         "semver": "^7.5.2"
       }
     },
+    "@webgpu/types": {
+      "version": "0.1.40",
+      "resolved": "https://registry.snapchat.com/node/virtual/@webgpu/types/-/types-0.1.40.tgz",
+      "integrity": "sha512-/BBkHLS6/eQjyWhY2H7Dx5DHcVrS2ICj9owvSRdgtQT6KcafLZA86tPze0xAOsd4FbsYKCUBUQyNi87q7gV7kw=="
+    },
     "acorn": {
       "version": "8.10.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.10.0.tgz",
@@ -2218,7 +2248,8 @@
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
       "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "agent-base": {
       "version": "6.0.2",
@@ -3220,6 +3251,15 @@
       "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
       "dev": true
     },
+    "playcanvas": {
+      "version": "1.69.2",
+      "resolved": "https://registry.snapchat.com/node/virtual/playcanvas/-/playcanvas-1.69.2.tgz",
+      "integrity": "sha512-UOjfvzkDHWHnyL9wSaFCYs04W/2owZoPS7pOZDKHneMlEE/OMg0bvdwYuWfy1mZRiGT00TFvqrP2Mla+BYgu9w==",
+      "requires": {
+        "@types/webxr": "^0.5.7",
+        "@webgpu/types": "^0.1.38"
+      }
+    },
     "prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -3454,9 +3494,9 @@
       "dev": true
     },
     "typescript": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
-      "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
+      "version": "5.4.2",
+      "resolved": "https://registry.snapchat.com/node/virtual/typescript/-/typescript-5.4.2.tgz",
+      "integrity": "sha512-+2/g0Fds1ERlP6JsakQQDXjZdZMM+rqpamFZJEKh4kwTIn3iDkgKtby0CeNd5ATNZ4Ry1ax15TMx0W2V+miizQ==",
       "dev": true
     },
     "uri-js": {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   },
   "capabilities": {
     "virtualWorkspaces": true
-  },  
+  },
   "categories": [
     "Other"
   ],
@@ -26,6 +26,16 @@
   "contributes": {
     "configuration": {
       "title": "PlayCanvas",
+      "languages": [{
+        "id": "typescript",
+        "extensions": [".ts", ".tsx"],
+        "aliases": ["TypeScript", "ts", "typescript"]
+      }],
+      "grammars": [{
+        "language": "typescript",
+        "scopeName": "source.ts",
+        "path": "./syntaxes/typescript.json"
+      }],      
       "properties": {
         "playcanvas.accessToken": {
           "type": "string",
@@ -36,7 +46,12 @@
           "type": "string",
           "default": "",
           "description": "Username for PlayCanvas"
-        }
+        },
+        "playcanvas.usePlaycanvasTypes": {
+          "type": "boolean",
+          "default": true,
+          "description": "Automatically adds PlayCanvas types reference to a source file"
+        }        
       }
     },
     "commands": [
@@ -52,13 +67,13 @@
       {
         "command": "playcanvas.pullLatest",
         "title": "PlayCanvas: Pull Latest"
-      }                  
+      }
     ],
     "menus": {
       "explorer/context": [
         {
-            "command": "playcanvas.addProject",
-            "when": "resourceScheme == playcanvas"
+          "command": "playcanvas.addProject",
+          "when": "resourceScheme == playcanvas"
         },
         {
           "command": "playcanvas.switchBranch",
@@ -67,7 +82,7 @@
         {
           "command": "playcanvas.pullLatest",
           "when": "resourceScheme == playcanvas"
-        }       
+        }
       ]
     }
   },
@@ -79,16 +94,17 @@
   "devDependencies": {
     "@types/glob": "^8.1.0",
     "@types/mocha": "^10.0.1",
-    "@types/node": "20.2.5",
+    "@types/node": "^20.2.5",
     "@types/vscode": "^1.80.0",
     "@vscode/test-electron": "^2.3.2",
     "eslint": "^8.41.0",
     "glob": "^8.1.0",
     "mocha": "^10.2.0",
-    "typescript": "^5.1.3"
+    "typescript": "^5.4.2"
   },
   "dependencies": {
     "form-data": "^4.0.0",
-    "node-fetch": "^2.1.2"
+    "node-fetch": "^2.1.2",
+    "playcanvas": "^1.69.2"
   }
 }

--- a/src/cloudStorageProvider.js
+++ b/src/cloudStorageProvider.js
@@ -161,8 +161,10 @@ class CloudStorageProvider {
 
             if (config.get('usePlaycanvasTypes') && (asset.file.filename.endsWith('.js') || asset.file.filename.endsWith('.mjs'))) {
                 let strContent = new TextDecoder().decode(content);
-                strContent = strContent.substring(this.typesReference.length);
-                content.set(new TextEncoder().encode(strContent));
+                if (strContent.startsWith(this.typesReference)) {
+                    strContent = strContent.substring(this.typesReference.length);
+                    content.set(new TextEncoder().encode(strContent));
+                }
             }
 
             const updatedAsset = await this.api.uploadFile(asset.id, asset.file.filename, asset.modifiedAt, project.branchId, content);
@@ -401,7 +403,7 @@ class CloudStorageProvider {
 
     async pullLatest(path) {
         const project = this.getProject(path);
-        this.refreshProject(project);
+        await this.refreshProject(project);
     }    
 }
 

--- a/src/cloudStorageProvider.js
+++ b/src/cloudStorageProvider.js
@@ -89,7 +89,7 @@ class CloudStorageProvider {
 
         const config = vscode.workspace.getConfiguration('playcanvas');
 
-        if (config.get('usePlaycanvasTypes') && asset.file.filename.endsWith('.js')) {
+        if (config.get('usePlaycanvasTypes') && (asset.file.filename.endsWith('.js') || asset.file.filename.endsWith('.mjs'))) {
             return new TextEncoder().encode(this.typesReference + asset.content);
         }
 
@@ -159,7 +159,7 @@ class CloudStorageProvider {
             // remove reference line before saving
             const config = vscode.workspace.getConfiguration('playcanvas');
 
-            if (config.get('usePlaycanvasTypes') && asset.file.filename.endsWith('.js')) {
+            if (config.get('usePlaycanvasTypes') && (asset.file.filename.endsWith('.js') || asset.file.filename.endsWith('.mjs'))) {
                 let strContent = new TextDecoder().decode(content);
                 strContent = strContent.substring(this.typesReference.length);
                 content.set(new TextEncoder().encode(strContent));

--- a/src/cloudStorageProvider.js
+++ b/src/cloudStorageProvider.js
@@ -8,6 +8,10 @@ class CloudStorageProvider {
         this.userId = null;
         this.currentProject = null;
         this._onDidChangeFile = new vscode.EventEmitter();
+
+        const filePath = path.join(__dirname, '..', 'node_modules', 'playcanvas', 'build/playcanvas.d.ts');
+        this.typesReference = '///<reference path="' + filePath + '" />;\n';
+
         this.refresh();
     }
 
@@ -82,6 +86,13 @@ class CloudStorageProvider {
         if (asset.content === null) {       
             throw vscode.FileSystemError.FileNotFound();
         }
+
+        const config = vscode.workspace.getConfiguration('playcanvas');
+
+        if (config.get('usePlaycanvasTypes') && asset.file.filename.endsWith('.js')) {
+            return new TextEncoder().encode(this.typesReference + asset.content);
+        }
+
         return new TextEncoder().encode(asset.content);
     }   
 
@@ -145,6 +156,15 @@ class CloudStorageProvider {
                 vscode.window.showErrorMessage(`Failed to create a file: ${error.message}`);
             }
         } else {
+            // remove reference line before saving
+            const config = vscode.workspace.getConfiguration('playcanvas');
+
+            if (config.get('usePlaycanvasTypes') && asset.file.filename.endsWith('.js')) {
+                let strContent = new TextDecoder().decode(content);
+                strContent = strContent.substring(this.typesReference.length);
+                content.set(new TextEncoder().encode(strContent));
+            }
+
             const updatedAsset = await this.api.uploadFile(asset.id, asset.file.filename, asset.modifiedAt, project.branchId, content);
             asset.modifiedAt = updatedAsset.modifiedAt;
             asset.content = new TextDecoder().decode(content);

--- a/src/extension.js
+++ b/src/extension.js
@@ -110,11 +110,10 @@ async function activate(context) {
 		context.subscriptions.push(vscode.commands.registerCommand('playcanvas.pullLatest', async (item) => {
 
 			// make sure that we have the latest list of projects
-			await this.fetchProjects();
+			await fileProvider.fetchProjects();
 			await fileProvider.pullLatest(item.path);
-					
-			// Refresh the tree view to reflect the file rename.
-			vscode.commands.executeCommand('workbench.files.action.refreshFilesExplorer');
+			const uri = vscode.Uri.parse(`playcanvas:/${item.path}`);
+			await fileProvider.refreshUri(uri);
 		}));		
 
 		context.subscriptions.push(vscode.commands.registerCommand('playcanvas.switchBranch', async (item) => {


### PR DESCRIPTION
* Adds playcanvas as npm dependency
* Introduces new option - usePlaycanvasTypes (true by default). If set, it adds a reference for the local playcanvas types file for auto-completion and code suggestions 
* The line with types reference is removed automatically (if not edited) on upload

![image](https://github.com/playcanvas/vscode-extension/assets/141647456/c49d7c37-20dd-46aa-aba5-a57ca42e7d3a)


This is the only way I discovered to support Playcanvas types in files downloaded by filesystem provider. This could be disabled in settings.

Some explanation from forum post: 

_“Virtual JS/TS files have single file IntelliSense, not project wide IntelliSense. The TypeScript server which provides IntelliSense runs as a separate process, and therefore it cannot read or watch files from a VS Code file system provider. Enabling project wide IntelliSense would require significant engineering work on both the VS Code and TypeScript side. We don’t have a good use case to undertake this at this time.”_

**Note:**

the virtual line will create an offset for errors reported on the launch page, they will be shifted by 1