### PR TITLE
remove api key from plan text storage

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "playcanvas",
-  "version": "0.1.1",
+  "version": "0.1.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "playcanvas",
-      "version": "0.1.1",
+      "version": "0.1.6",
       "dependencies": {
         "form-data": "^4.0.0",
         "node-fetch": "^2.1.2",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "playcanvas",
   "displayName": "PlayCanvas",
   "description": "Official PlayCanvas extension from the team",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "publisher": "playcanvas",
   "icon": "images/PlayCanvasLogo.png",
   "engines": {
@@ -13,7 +13,12 @@
     "url": "https://github.com/playcanvas/vscode-extension.git"
   },
   "capabilities": {
-    "virtualWorkspaces": true
+    "untrustedWorkspaces": {
+      "supported": "limited"
+    },
+    "virtualWorkspaces": {
+      "supported": "limited"
+    }
   },
   "categories": [
     "Other"

--- a/src/cloudStorageProvider.js
+++ b/src/cloudStorageProvider.js
@@ -3,7 +3,8 @@ const Api = require('./api');
 const path = require('path');
 
 class CloudStorageProvider {
-    constructor() {
+    constructor(context) {
+        this.context = context;
         this.projects = [];
         this.userId = null;
         this.currentProject = null;
@@ -381,7 +382,7 @@ class CloudStorageProvider {
     }
 
     refresh(clearProjects = true) {
-        this.api = new Api();
+        this.api = new Api(this.context);
 
         if (clearProjects) {
             this.projects = [];


### PR DESCRIPTION
remove api key from plan text storage and put it into VSCode secrets storage

VSCode settings are saved into settings.json in a plain text, so we shouldn't keep API key there

existing token in config is automatically moved into secrets storage