### PR TITLE
Custom Find in Files support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,4 +22,5 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 
 ## [v0.1.9]
 
-- Find In Files implemented, issue with opened files during VS Code startup is fixed. 
+- Find In Files implemented.
+- Issue with opened files during VS Code startup is fixed. 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,3 +15,11 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 ## [v0.1.7]
 
 - Authentication is reworked, only auth token from PlayCanvas account page is needed. Username and auth token settings removed from VS Code settings for PlayCanvas. Token is requested in a dialog. Issue with failing 'Add Project' command is fixed.
+
+## [v0.1.8]
+
+- Hotfix for the previous release.
+
+## [v0.1.9]
+
+- Hotfix for the previous release.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,8 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 
 ## [v0.1.7]
 
-- Authentication is reworked, only auth token from PlayCanvas account page is needed. Username and auth token settings removed from VS Code settings for PlayCanvas. Token is requested in a dialog. Issue with failing 'Add Project' command is fixed.
+- Authentication is reworked, only auth token from PlayCanvas account page is needed. Username and auth token settings removed from VS Code settings for PlayCanvas. Token is requested in a dialog.
+- Issue with failing 'Add Project' command is fixed.
 
 ## [v0.1.8]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,4 +22,4 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 
 ## [v0.1.9]
 
-- Hotfix for the previous release.
+- Find In Files implemented, issue with opened files during VS Code startup is fixed. 

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ The extension has just 2 settings:
 ## Extension Settings
 
 * `playcanvas.usePlaycanvasTypes`: Automatically adds a reference to PlayCanvas types files for code suggestions. Line is not saved. Default is true.
-* `playcanvas.maxSearchResults`: Maximum search results to display
+* `playcanvas.maxSearchResults`: Maximum number of search results to display.
 
 A PlayCanvas Access Token is requested when you add a project. Generate an access token on your [account page](https://playcanvas.com/account).
 

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ The extension supports collaboration features of PlayCanvas. Multiple users can 
 
 #### Find in Files
 
-The extension supports searching in project files - use `PlayCanvas: Search` to search in the current project or `PlayCanvas:Find In Files` from the context menu to search for a pattern. The search is case-insensitive, the maximum number of results controlled by `maxSearchResults` setting. As soon as standard Search Dialog [supported by vscode API](https://github.com/microsoft/vscode/issues/73524), we will reimplement it. Currently standard Find dialog searched in the opened files only, so please use Playcanvas' one. Default shortcut is Cmd+Shift+', change it in VS Code settings - search for PlayCanvas: Search command.
+The extension supports searching in project files - use `PlayCanvas: Search` to search in the current project or `PlayCanvas:Find In Files` from the context menu to search for a pattern. The search is case-insensitive and the maximum number of results is controlled by the `maxSearchResults` setting. As soon as the standard Search Dialog is [supported by the VS Code API](https://github.com/microsoft/vscode/issues/73524), we will reimplement it. Currently, the standard Find dialog searches in opened files only, so please use the PlayCanvas one instead. The default shortcut is `Cmd+Shift+'`. Customize this shortcut in the VS Code settings (search for the `PlayCanvas: Search` command).
 
 #### Settings
 

--- a/README.md
+++ b/README.md
@@ -44,9 +44,16 @@ The extension integrates with PlayCanvas' version control system, allowing users
 
 The extension supports collaboration features of PlayCanvas. Multiple users can edit a PlayCanvas project simultaneously, with changes being synchronized manually between users. Users are prevented from overwriting files, edited by others by checking modification base time in update requests on the backend - if it’s different, it means that file was modified by someone else. After that, a customer can pull the latest version of the file by choosing ‘Pull latest’ from the context menu for the file. 
 
+#### Search
+
+The extension supports searching in project files - use `PlayCanvas: Search` to search in the current project or `PlayCanvas:Find In Files` from the context menu to search for a pattern. The search is case-insensitive, the maximum number of results controlled by `maxSearchResults` setting. As soon as standard Search Dialog [supported by vscode API](https://github.com/microsoft/vscode/issues/73524), we will reimplement it. Currently standard Find dialog searched in the opened files only, so please use Playcanvas' one. 
+
 #### Settings
 
-The extension has just 1 setting: `usePlaycanvasTypes` (to add types support). An Access Token is requested when you are adding a project.
+The extension has just 2 settings: 
+
+* `usePlaycanvasTypes` (to add types support). An Access Token is requested when you are adding a project.
+* `maxSearchResults` - maximum search results to display
 
 ## Requirements
 
@@ -55,6 +62,7 @@ The extension has just 1 setting: `usePlaycanvasTypes` (to add types support). A
 ## Extension Settings
 
 * `playcanvas.usePlaycanvasTypes`: Automatically adds a reference to PlayCanvas types files for code suggestions. Line is not saved. Default is true.
+* `playcanvas.maxSearchResults`: Maximum search results to display
 
 A PlayCanvas Access Token is requested when you add a project. Generate an access token on your [account page](https://playcanvas.com/account).
 

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ The extension supports searching in project files - use `PlayCanvas: Search` to 
 The extension has just 2 settings: 
 
 * `usePlaycanvasTypes` (to add types support). An Access Token is requested when you are adding a project.
-* `maxSearchResults` - maximum search results to display
+* `maxSearchResults` - the maximum number of search results to display.
 
 ## Requirements
 

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ The extension supports collaboration features of PlayCanvas. Multiple users can 
 
 #### Search
 
-The extension supports searching in project files - use `PlayCanvas: Search` to search in the current project or `PlayCanvas:Find In Files` from the context menu to search for a pattern. The search is case-insensitive, the maximum number of results controlled by `maxSearchResults` setting. As soon as standard Search Dialog [supported by vscode API](https://github.com/microsoft/vscode/issues/73524), we will reimplement it. Currently standard Find dialog searched in the opened files only, so please use Playcanvas' one. 
+The extension supports searching in project files - use `PlayCanvas: Search` to search in the current project or `PlayCanvas:Find In Files` from the context menu to search for a pattern. The search is case-insensitive, the maximum number of results controlled by `maxSearchResults` setting. As soon as standard Search Dialog [supported by vscode API](https://github.com/microsoft/vscode/issues/73524), we will reimplement it. Currently standard Find dialog searched in the opened files only, so please use Playcanvas' one. Default shortcut is Cmd+Shift+', change it in VS Code settings - search for PlayCanvas: Search command.
 
 #### Settings
 

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ The extension integrates with PlayCanvas' version control system, allowing users
 
 The extension supports collaboration features of PlayCanvas. Multiple users can edit a PlayCanvas project simultaneously, with changes being synchronized manually between users. Users are prevented from overwriting files, edited by others by checking modification base time in update requests on the backend - if it’s different, it means that file was modified by someone else. After that, a customer can pull the latest version of the file by choosing ‘Pull latest’ from the context menu for the file. 
 
-#### Search
+#### Find in Files
 
 The extension supports searching in project files - use `PlayCanvas: Search` to search in the current project or `PlayCanvas:Find In Files` from the context menu to search for a pattern. The search is case-insensitive, the maximum number of results controlled by `maxSearchResults` setting. As soon as standard Search Dialog [supported by vscode API](https://github.com/microsoft/vscode/issues/73524), we will reimplement it. Currently standard Find dialog searched in the opened files only, so please use Playcanvas' one. Default shortcut is Cmd+Shift+', change it in VS Code settings - search for PlayCanvas: Search command.
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "playcanvas",
   "displayName": "PlayCanvas",
   "description": "Official PlayCanvas extension from the team",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "publisher": "playcanvas",
   "icon": "images/PlayCanvasLogo.png",
   "engines": {
@@ -16,7 +16,7 @@
     "Other"
   ],
   "activationEvents": [
-    "onStartupFinished"    
+    "onFileSystem:playcanvas"
   ],
   "main": "./src/extension.js",
   "contributes": {
@@ -37,7 +37,14 @@
           "type": "boolean",
           "default": true,
           "description": "Automatically adds PlayCanvas types reference to a source file"
-        }        
+        },
+        "playcanvas.maxSearchResults": {
+          "type": "number",
+          "default": 50,
+          "minimum": 1,
+          "maximum": 100,
+          "description": "Maximum number of search results to show [1..100]"
+        }
       }
     },
     "commands": [
@@ -53,8 +60,22 @@
       {
         "command": "playcanvas.pullLatest",
         "title": "PlayCanvas: Pull Latest"
-      }
+      },
+      {
+        "command": "playcanvas.search",
+        "title": "PlayCanvas: Search"
+      },
+      {
+        "command": "playcanvas.findInFolder",
+        "title": "PlayCanvas: Find In Folder",
+        "when": "explorerResourceIsFolder && resourceScheme == 'playcanvas'"
+      }      
     ],
+    "keybindings": [{
+        "command": "playcanvas.search",
+        "key": "ctrl+shift+'",
+        "mac": "cmd+shift+'"        
+    }],
     "menus": {
       "explorer/context": [
         {
@@ -68,6 +89,10 @@
         {
           "command": "playcanvas.pullLatest",
           "when": "resourceScheme == playcanvas"
+        },
+        {
+          "command": "playcanvas.findInFolder",
+          "when": "explorerResourceIsFolder && resourceScheme == 'playcanvas'"
         }
       ]
     }

--- a/src/cloudStorageProvider.js
+++ b/src/cloudStorageProvider.js
@@ -228,6 +228,9 @@ class CloudStorageProvider {
     }
 
     getProjectByName(name) {
+        if (!name) {
+            return null;
+        }
         const projectBranch = name.split(':');
         return this.projects.find(p => p.name === projectBranch[0]);
     }

--- a/src/extension.js
+++ b/src/extension.js
@@ -203,7 +203,9 @@ async function activate(context) {
 			selectedText = document.getText(selection);
 			const uri = document.uri;
 			project = fileProvider.getProject(uri.path);
-			selectedPath = `/${project.name}`;
+			if (project) {
+				selectedPath = `/${project.name}`;
+			}
 		}
 
 		const searchPattern = await vscode.window.showInputBox({ prompt: 'Enter search pattern', value: selectedText  });

--- a/src/extension.js
+++ b/src/extension.js
@@ -125,12 +125,6 @@ async function activate(context) {
 
 				// Refresh the tree view to reflect the file rename.
 				vscode.commands.executeCommand('workbench.files.action.refreshFilesExplorer');
-
-				// vscode.window.visibleTextEditors.forEach(editor => {
-				// 	if (editor.document.uri.scheme === 'playcanvas') {
-				// 		fileProvider.refreshUri(editor.document.uri);			
-				// 	}
-				// });
 			}
 		} catch (error) {
 			console.error('Add Project failed:', error);

--- a/src/extension.js
+++ b/src/extension.js
@@ -5,6 +5,7 @@ const CloudStorageProvider = require('./cloudStorageProvider');
 
 let fileProvider;
 let workspaceFolderChangeListener;
+let outputChannel;
 
 async function selectProject(fileProvider) {
 	const projects = await fileProvider.fetchProjects();
@@ -48,6 +49,31 @@ function renameWorkspaceFolder(oldName, newName) {
 
     // Remove old folder and add new folder
     vscode.workspace.updateWorkspaceFolders(folder.index, 1, { uri: newUri, name: newName });
+}
+
+function displaySearchResults(results) {
+	const config = vscode.workspace.getConfiguration('playcanvas');
+	const maxSearchResults = config.get('maxSearchResults');
+
+	let count = 0;
+	for (const result of results) {
+		const filePath = result.uri.fsPath;
+		const line = result.line;
+		if (count < maxSearchResults) {
+			outputChannel.appendLine(`${filePath}:${line} - ${result.lineText}`);
+		}
+		count += 1;
+	}
+	
+	if (results.length) {
+		outputChannel.appendLine('');
+	}
+
+	if (count === maxSearchResults) {
+		outputChannel.appendLine(`Done. Displaying first ${maxSearchResults} results.`);
+	} else {
+		outputChannel.appendLine(`Done. Found ${results.length} results.`);
+	}
 }
 
 /**
@@ -163,7 +189,82 @@ async function activate(context) {
 		}
 	}));
 
-	// await fileProvider.syncProjects();
+	context.subscriptions.push(vscode.commands.registerCommand('playcanvas.search', async () => {
+
+		// Get the currently selected text
+		const editor = vscode.window.activeTextEditor;
+		let project;
+		let selectedText = '';
+		let selectedPath = '';
+		
+		if (editor) {
+			const selection = editor.selection;
+			const document = editor.document;
+			selectedText = document.getText(selection);
+			const uri = document.uri;
+			project = fileProvider.getProject(uri.path);
+			selectedPath = `/${project.name}`;
+		}
+
+		const searchPattern = await vscode.window.showInputBox({ prompt: 'Enter search pattern', value: selectedText  });
+		if (!searchPattern) {
+		  	return;
+		}
+
+		if (searchPattern.length < 3) {
+			vscode.window.showErrorMessage('Search pattern must be at least 3 characters long.');
+			return;
+	  	}	
+
+		if (!outputChannel) {
+			outputChannel = vscode.window.createOutputChannel('PlayCanvas File Search');
+		} else {
+			outputChannel.clear();
+		}
+
+		outputChannel.show();
+
+		if (project) {
+			outputChannel.appendLine(`Searching for '${searchPattern}' in ${project.name}...`);
+		} else {
+			outputChannel.appendLine(`Searching for '${searchPattern}'...`);
+		}
+		outputChannel.appendLine('');
+	
+		const results = await fileProvider.searchFiles(searchPattern, selectedPath);
+
+		displaySearchResults(results);
+	}));
+
+	context.subscriptions.push(vscode.commands.registerCommand('playcanvas.findInFolder', async (item) => {
+		// Get the currently selected text
+		const editor = vscode.window.activeTextEditor;
+		let selectedText = '';
+		if (editor) {
+			const selection = editor.selection;
+			selectedText = editor.document.getText(selection);
+		}
+
+		const searchPattern = await vscode.window.showInputBox({ prompt: 'Enter search pattern', value: selectedText  });
+		if (!searchPattern) {
+		  	return;
+		}		
+
+		if (!outputChannel) {
+			outputChannel = vscode.window.createOutputChannel('PlayCanvas File Search');
+		} else {
+			outputChannel.clear();
+		}
+
+		outputChannel.show();
+
+		outputChannel.appendLine(`Searching for '${searchPattern}' in ${item.path}...`);
+		outputChannel.appendLine('');
+	
+		const results = await fileProvider.searchFiles(searchPattern, item.path);
+
+		displaySearchResults(results);	
+	}));
 
 	fileProvider.getToken().catch(err => {
 		vscode.window.showInformationMessage('Failed to authorize. Error: ' + err.message);


### PR DESCRIPTION
Search in files is implemented for the extension. 

Unfortunately searching in virtual filesystems is not yet officially supported by VS Code https://github.com/microsoft/vscode/issues/73524 - the ticket exists for 5 years. Recently it got some attention from Microsoft so there is a hope. Meanwhile I implemented custom searching functionality, which is invoked by running command 'Playcanvas: Search' (Cmd+Shift+' - reassign it in settings if needed). Find In Folder is also supported in context menu. 

<img width="1472" alt="image" src="https://github.com/playcanvas/vscode-extension/assets/141647456/dc99fc50-97f4-4425-b129-5a0194ccf6de">


The issue where files failed to open on VS Code startup is fixed. 