### PR TITLE
Added a new TypeScript definition setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ The extension has just 2 settings:
 
 * `playcanvas.usePlaycanvasTypes`: Automatically adds a reference to PlayCanvas types files for code suggestions. Line is not saved. Default is true.
 * `playcanvas.maxSearchResults`: Maximum number of search results to display.
+* `playcanvas.additionalTypeScriptDefinitionFiles`: Automatically adds references to user specified TypeScript definition files (.d.ts). These references are not saved. Paths must be absolute.
 
 A PlayCanvas Access Token is requested when you add a project. Generate an access token on your [account page](https://playcanvas.com/account).
 

--- a/package.json
+++ b/package.json
@@ -67,6 +67,10 @@
           "minimum": 1,
           "maximum": 100,
           "description": "Maximum number of search results to show [1..100]"
+        },
+        "playcanvas.additionalTypeScriptDefinitionFiles":{
+          "type":"array",
+          "description": "An array of file paths to TypeScript definition files (.d.ts). These reference paths will be prefixed to a source file. Paths must be absolute."
         }
       }
     },


### PR DESCRIPTION
I have added a new setting to allow users to specify their own TypeScript definition files that will be prefixed to source files.

This has been extremely useful in my work as we have a large number of PlayCanvas scripts that call each other and I found myself having to continually refer to other files to ensure that I was typing out field and functions names correctly. So, I created a .d.ts file that declares TypeScript classes for the script files that I commonly use.

For example this is how I would declare a script that has a single attribute 'textEntity' that is an entity:

declare class {ScriptName} extends pc.ScriptType {
    textEntity: pc.Entity;
}

Now when using Visual Studio Code I can use intellisense to reduce the change of an error when I'm working with that script.