### PR TITLE
fix a customer error

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -16,7 +16,7 @@ class Api {
         const accessToken = config.get("accessToken");
         if (accessToken && accessToken !== "") {
             await this.context.secrets.store("playcanvas.accessToken", accessToken);
-            config.update("accessToken", "", vscode.ConfigurationTarget.Global);
+            config.update("accessToken", undefined, vscode.ConfigurationTarget.Global);
         }
 
         // get a secret


### PR DESCRIPTION
We've got a customer report about non-working vs-code extension - https://github.com/playcanvas/vscode-extension/issues/21

Customer provided logs:
![image](https://github.com/user-attachments/assets/ea3450de-6795-4f8c-93eb-3024dfadc108)

After investigation I found that in some circumstances config.update("accessToken", "", vscode.ConfigurationTarget.Global); call was failing so I fixed it in this PR

using undefined doesn't require the setting to be registered, so it should fix the issue
