### PR TITLE
Improve File Asset Syncing

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -9,10 +9,13 @@
 			"name": "Run Extension",
 			"type": "extensionHost",
 			"request": "launch",
-			"cwd":"${workspaceFolder}",
+			"cwd": "${workspaceFolder}",
 			"args": [
 				"--extensionDevelopmentPath=${workspaceFolder}"
-			]
+			],
+			"env": {
+				"VSCODE_DEBUG_MODE": "true"
+			}
 		},
 		{
 			"name": "Extension Tests",
@@ -21,7 +24,10 @@
 			"args": [
 				"--extensionDevelopmentPath=${workspaceFolder}",
 				"--extensionTestsPath=${workspaceFolder}/test/suite/index"
-			]
+			],
+			"env": {
+				"VSCODE_DEBUG_MODE": "true"
+			}
 		}
 	]
 }

--- a/src/api.js
+++ b/src/api.js
@@ -78,7 +78,7 @@ class Api {
                 await this.context.secrets.delete('playcanvas.accessToken');
                 throw new Error('Unauthorized. Please try again.');
             } else if (error.message.includes(AssetModifiedError.message)) {
-                throw new Error('Asset was modified on server')
+                throw AssetModifiedError;
             }
 
             console.error('API call failed:', error);

--- a/src/cloudStorageProvider.js
+++ b/src/cloudStorageProvider.js
@@ -5,6 +5,7 @@ const FileDecorationProvider = require('./fileDecorationProvider');
 
 let fileDecorationProvider;
 
+const DEBUG = process.env.VSCODE_DEBUG_MODE === 'true';
 const SEARCH_RESULT_MAX_LENGTH = 80;
 
 class CloudStorageProvider {
@@ -27,7 +28,7 @@ class CloudStorageProvider {
     }
 
     get onDidChangeFile() {
-        console.log('playcanvas: onDidChangeFile');
+        if (DEBUG) console.log('playcanvas: onDidChangeFile');
         return this._onDidChangeFile.event;
     }
 
@@ -36,7 +37,7 @@ class CloudStorageProvider {
     }
 
     async stat(uri) {
-        console.log(`playcanvas: stat ${uri.path}`);
+        if (DEBUG) console.log(`playcanvas: stat ${uri.path}`);
 
         if (uri.path.includes('.vscode') || uri.path.includes('.git') ||
             uri.path.includes('.devcontainer') || uri.path.includes('node_modules') ||
@@ -48,14 +49,14 @@ class CloudStorageProvider {
         if (!project) {
             // if projects are not synced yet
             if (this.projects.length === 0) {
-                console.log(`playcanvas: stat ${uri.path} no projects`);
+                if (DEBUG) console.log(`playcanvas: stat ${uri.path} no projects`);
                 await this.ensureSyncProjects();
                 project = this.getProject(uri.path);
             }
         }
 
         if (!project) {
-            console.log(`playcanvas: stat ${uri.path} not found`);
+            if (DEBUG) console.log(`playcanvas: stat ${uri.path} not found`);
             throw vscode.FileSystemError.FileNotFound();
         }
 
@@ -67,7 +68,7 @@ class CloudStorageProvider {
 
         let asset = this.lookup(uri);
         if (!asset) {
-            console.log(`playcanvas: stat ${uri.path} not found`);
+            if (DEBUG) console.log(`playcanvas: stat ${uri.path} not found`);
             throw vscode.FileSystemError.FileNotFound();
         }
 
@@ -82,7 +83,7 @@ class CloudStorageProvider {
     }
 
     async readFile(uri) {
-        console.log(`playcanvas: readFile ${uri.path}`);
+        if (DEBUG) console.log(`playcanvas: readFile ${uri.path}`);
 
         if (uri.path.includes('.vscode') || uri.path.includes('.git') || uri.path.includes('.devcontainer')) {
             throw vscode.FileSystemError.FileNotFound();
@@ -92,7 +93,7 @@ class CloudStorageProvider {
         if (!project) {
             // if projects are not synced yet
             if (this.projects.length === 0) {
-                console.log(`playcanvas: stat ${uri.path} no projects`);
+                if (DEBUG) console.log(`playcanvas: stat ${uri.path} no projects`);
                 await this.ensureSyncProjects();
                 project = this.getProject(uri.path);
             }
@@ -164,7 +165,7 @@ class CloudStorageProvider {
     }
 
     async writeFile(uri, content, options) {
-        console.log(`playcanvas: writeFile ${uri.path}`);
+        if (DEBUG) console.log(`playcanvas: writeFile ${uri.path}`);
 
         const project = this.getProject(uri.path);
         const asset = this.lookup(uri);

--- a/src/cloudStorageProvider.js
+++ b/src/cloudStorageProvider.js
@@ -253,7 +253,7 @@ class CloudStorageProvider {
 
             // We must handle a difference in metadata because the PUT will fail
             if (!isAssetSynced) {
-                if (DEBUG) console.log(`playcanvas: writeFile ${uri.path} - asset modifed on server, but file content is synced. Pulling new metadata from server...`);
+                if (DEBUG) console.log(`playcanvas: writeFile ${uri.path} - asset modified on server, but file content is synced. Pulling new metadata from server...`);
 
                 asset = {
                     ...asset,

--- a/src/cloudStorageProvider.js
+++ b/src/cloudStorageProvider.js
@@ -165,15 +165,18 @@ class CloudStorageProvider {
         }
     }
 
-    async isAssetSynced(uri, newContent) {
+    async checkAssetSynced(uri, newContent) {
         const project = this.getProject(uri.path);
 
         let localAsset = this.lookup(uri);
         const serverAsset = await this.api.fetchAsset(localAsset.id, project.branchId);
 
+        if (DEBUG) console.log(`playcanvas: writeFile ${uri.path}\nlocalAsset:`, localAsset);
+        if (DEBUG) console.log(`playcanvas: writeFile ${uri.path}\nserverAsset:`, serverAsset);
+
         // Important to know if modifiedAt matches, because PUT calls will fail if not matching
         // This makes the assumption that only the server updates modifiedAt
-        const isAssetSynced = serverAsset.modifiedAt !== localAsset.modifiedAt
+        const isAssetSynced = serverAsset.modifiedAt === localAsset.modifiedAt
 
         // Calculate file content hashes to determine if we need to stop
         // the user from pushing new changes.
@@ -241,7 +244,7 @@ class CloudStorageProvider {
                 isContentSynced, // Does file content match the server?
                 isAssetSynced, // Does asset metadata match the server?
                 serverAsset
-            } = await this.isAssetSynced(uri, strContent);
+            } = await this.checkAssetSynced(uri, strContent);
 
             if (!isContentSynced) {
                 if (DEBUG) console.log(`playcanvas: writeFile ${uri.path} - Latest file changes on the server have not been pulled yet.`);


### PR DESCRIPTION
## Description

The goal of this PR is reduce the frequency of "Asset was modified, please pull the latest version" errors.

![A Visual Studio Code error notification stating, "Failed to save 'test.js': Unable to write file 'playcanvas:/Audio Test/test.js' (Error: Asset was modified, please pull the latest version)," with options to Retry, Save As, or Revert.](https://github.com/user-attachments/assets/7003f5e3-54f2-4978-919e-b1b7f41d5a54)

This error frequently occurs when metadata on the script asset was changed, but the actual script hasn't been changed. Specifically—when you run <kbd>Parse</kbd> on a script, you must repull changes every time because the <kbd>Parse</kbd> updates the `modifiedAt` on the asset.

### Major changes

`cloudStorageProvider.js`

:heavy_plus_sign: Added a `checkAssetSynced` function to learn 2 things:

1. Is the script file contents actually different?
2. Has the server made new changes to the asset metadata?

Those send the code down 2 paths:

1. If the file contents are different, we still show the "Asset was modified, please pull the latest version" as before.
2. If the server has updated the metadata, BUT the file contents were not changed by the server:
  a. We update the local script asset with the new server metadata.
  b. This allows the `PUT` operation to succeed since the `modifiedAt` matches the server.

### Minor changes

- Created an error object, `AssetModifiedError`. The logic actually doesn't really do much with this error. But, for known errors that we expect to write logic for, creating those error objects will improve maintainability.
- Added a `DEBUG` constant that only shows debug logging when running the extension in the VS Code debugger.

## Screencast example

https://github.com/user-attachments/assets/2fd3dce6-e85a-4c06-a5d0-8d6a193cb55e

## Risk Mitigation

Some amount of complexity felt inevitable with this syncing logic. So, below is out potential risks are mitigated:

- **Risk:** Clobbering server asset file contents
  - **Mitigation:** Since the logic expects the server file hash to always match the file hash of the last server pull (the local `asset` in the logic), it will always stop the `writeFile` operation if we haven't pulled the latest file contents.
- **Risk:** Clobbering server asset metadata
  - **Mitigation:** When the server metadata is found to be different, we always pull the latest metadata and overwrite the local asset before making any `uploadFile` operations.
    - We also update the local asset using the `uploadFile` response.

## Future work

A feature this logic helps enable and I'd love to add is the ability to inform the user when the script changed on the server and they need to repull—BEFORE they spend a lot of time making new script changes.
