### PR TITLE
Add additional error handling for errors with HTML body

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -70,12 +70,8 @@ class Api {
                 if (contentType && contentType.includes('application/json')) {
                     const res = await response.json();
                     throw new Error(res.error ? res.error : 'apiCall failed');
-                } else if (contentType && contentType.includes('text/html')) {
-                    // Handle HTML response (seen with 504 errors)
-                    const text = await response.text();
-                    throw new Error(`[${response.status}] ${response.statusText}: ${text}`);
                 } else {
-                    // Fallback
+                    // Fallback (HTML, and other)
                     const text = await response.text();
                     throw new Error(`[${response.status}] ${response.statusText}: ${text}`);
                 }


### PR DESCRIPTION
## Description

This PR attempts to fix the situation where some errors, like 504s, return HTML responses that this extension isn't prepared to handle.

Since I only saw it with 504s and I cannot reliably reproduce that error, I'm unable to test the situation where an HTML error is returned.

But, this code _should_ produce more readable error messages for unexpected error responses.

fixes #24 