### PR TITLE
If the user provides a bad token, show an error message

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -27,10 +27,19 @@ class Api {
                 placeHolder: "Input your access token here.",
                 ignoreFocusOut: true,
             });
+
             if (!token) {
                 throw new Error('Unauthorized');
             }
+
             await this.context.secrets.store("playcanvas.accessToken", token);
+
+            // Test access token
+            try {
+                await this.fetchUserId()
+            } catch (error) {
+                throw new Error('Invalid access token. Please check your token and try again.');
+            }
         }
         return token;
     }


### PR DESCRIPTION
## Description

Right now, if the user enters an invalid access token, no message is shown. The only indicator is that trying "Add project" will just send you back to the "Enter access token" dialog.

This PR will have the extension show a notification message when the user enters a bad access token.

## Screenshots

![image](https://github.com/user-attachments/assets/f78a9d91-b53f-4804-b128-8cf28179c1d1)

Expanded:

![image](https://github.com/user-attachments/assets/d9475218-8aa3-4b62-93e9-ab75d06fda99)


fixes #28 