### PR TITLE
fix: update local state not working on nested assets

### DIFF
--- a/src/cloudStorageProvider.js
+++ b/src/cloudStorageProvider.js
@@ -280,7 +280,7 @@ class CloudStorageProvider {
             }
 
             // Update local state
-            project.files.set(this.getFilename(asset), asset);
+            this.updateLocalAsset(uri, asset);
 
             if (DEBUG) console.log('playcanvas: local asset updated to:', this.lookup(uri))
         }
@@ -540,6 +540,34 @@ class CloudStorageProvider {
             files = folder.files;
         }
         return files.get(parts[parts.length - 1]);
+    }
+
+    /**
+     * Updates an asset in the local project file structure. Only updates the local state.
+     * 
+     * @param {vscode.Uri} uri - The URI of the asset to update
+     * @param {Object} asset - The updated asset data
+     * @returns {Object|null} - The updated asset or null if project or parent folder wasn't found
+     */
+    updateLocalAsset(uri, asset) {
+        const parts = uri.path.split('/');
+        const project = this.getProjectByName(parts[1]);
+        if (!project || parts.length === 0) {
+            return null;
+        }
+
+        // Either find the parent asset, or the project root
+        let files = project.files;
+        for (let i = 2; i < parts.length - 1; ++i) {
+            const folder = files.get(parts[i]);
+            if (!folder) {
+                return null;
+            }
+            files = folder.files;
+        }
+
+        // Update the asset in the local state
+        files.set(parts[parts.length - 1], asset);
     }
 
     refresh(clearProjects = true) {


### PR DESCRIPTION
## Description

This PR fixes [the bug](https://github.com/playcanvas/vscode-extension/pull/26#issuecomment-2828073006) found in #26

### Bug

On some projects, the extension keeps saying "Error: Asset was modified, please pull the latest version". Specifically, the bug appears on projects where the scripts are inside a folder.

### Cause

This was due to the following code:

```js
// Update local state
project.files.set(this.getFilename(asset), asset);
```

#26 borrowed that code from the `fetchAssets` function; however, an important difference I missed is that `project.files.set()` is only used for top-level assets. `buildPaths` is used for nested assets.

So, using that code on any asset won't work because `project.files` only holds the top-level assets.

### Solution

Since there was no logic in place to selectively update assets, other than to repull everything and rebuild the paths, I added a new function, `updateLocalAsset`. This function updates a specific asset on the local state.

### Misc

I added jsdoc comments to this function. It's not used anywhere else on this project. But, I think it would be a good thing to incrementally add to the codebase. Using jsdoc would be inline with other PlayCanvas codebases that use jsdoc.

Partly why this is useful is because there's a difference in the server asset objects and the local asset objects. Local assets have `files` and `paths` added onto their objects.