### PR TITLE
chore: bump playcanvas engine from 2.14.4 to 2.16.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -42,7 +42,7 @@
                 "eslint-plugin-prettier": "^5.5.4",
                 "globals": "^17.0.0",
                 "jsonc-eslint-parser": "^2.4.2",
-                "playcanvas": "2.14.4",
+                "playcanvas": "2.16.1",
                 "prettier": "^3.7.4",
                 "rollup": "^4.55.1",
                 "rollup-plugin-polyfill-node": "^0.13.0",
@@ -6789,9 +6789,9 @@
             }
         },
         "node_modules/playcanvas": {
-            "version": "2.14.4",
-            "resolved": "https://registry.npmjs.org/playcanvas/-/playcanvas-2.14.4.tgz",
-            "integrity": "sha512-US1gfdZNvcq1Q/kSn3zZlyXfw5509J0Gt5ctlT5BM8l1PVnoc0/sJFNImVZuT2NgbtVFCKhSNvaHP1URDdKOhg==",
+            "version": "2.16.1",
+            "resolved": "https://registry.npmjs.org/playcanvas/-/playcanvas-2.16.1.tgz",
+            "integrity": "sha512-3Ve1sTJ7drmc5OUNCIITigk/mranENJynN5pd0DXF+AIKg2WNYp5mJyP/FoWG5rLJl7XoxR3ngcIwtyBd4L//A==",
             "dev": true,
             "license": "MIT",
             "dependencies": {

--- a/package.json
+++ b/package.json
@@ -117,7 +117,7 @@
         "eslint-plugin-prettier": "^5.5.4",
         "globals": "^17.0.0",
         "jsonc-eslint-parser": "^2.4.2",
-        "playcanvas": "2.14.4",
+        "playcanvas": "2.16.1",
         "prettier": "^3.7.4",
         "rollup": "^4.55.1",
         "rollup-plugin-polyfill-node": "^0.13.0",


### PR DESCRIPTION
### What's Changed

- Bump `playcanvas` dev dependency from `2.14.4` to `2.16.1`
