### PR TITLE
[FIX] Improve WebSocket reconnection logic

### DIFF
--- a/src/connections/constants.ts
+++ b/src/connections/constants.ts
@@ -1,0 +1,4 @@
+export const PING_INTERVAL_MS = 1000;
+export const PONG_TIMEOUT_MS = 5000;
+export const RECONNECT_BASE_MS = 1000;
+export const RECONNECT_MAX_MS = 30000;

--- a/src/connections/messenger.ts
+++ b/src/connections/messenger.ts
@@ -6,6 +6,8 @@ import { Deferred } from '../utils/deferred';
 import { EventEmitter } from '../utils/event-emitter';
 import { signal } from '../utils/signal';
 
+import { PING_INTERVAL_MS, PONG_TIMEOUT_MS, RECONNECT_BASE_MS, RECONNECT_MAX_MS } from './constants';
+
 type EventMap = {
     'asset.new': [
         {
@@ -75,6 +77,16 @@ class Messenger extends EventEmitter<EventMap> {
 
     private _alive: ReturnType<typeof setInterval> | null = null;
 
+    private _reconnectAttempt = 0;
+
+    private _reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+
+    private _disconnecting = false;
+
+    private _getToken: (() => string) | null = null;
+
+    private _lastPong = 0;
+
     url: string;
 
     origin: string;
@@ -90,7 +102,10 @@ class Messenger extends EventEmitter<EventMap> {
         this.origin = origin;
     }
 
-    private _connect(accessToken: string) {
+    private _connect() {
+        this._disconnecting = false;
+
+        const accessToken = this._getToken!();
         const options = WEB
             ? undefined
             : {
@@ -114,14 +129,14 @@ class Messenger extends EventEmitter<EventMap> {
         });
 
         // wait for auth response
-        const onmessage = async ({ data }: { data: Data }) => {
+        const onmessage = ({ data }: { data: Data }) => {
             try {
                 const json = JSON.parse(data.toString());
                 if (json.name === 'welcome') {
                     socket.removeEventListener('message', onmessage);
 
                     // authenticated
-                    await this._onauth(socket);
+                    this._onauth(socket);
                 }
             } catch (e) {
                 this._log.debug('messenger.message', e);
@@ -148,29 +163,42 @@ class Messenger extends EventEmitter<EventMap> {
                 this._alive = null;
             }
 
-            // if not internal error,try to reconnect
-            if (code !== 1011) {
-                setTimeout(() => {
-                    this._socket = this._connect(accessToken);
-                }, 1000);
+            // skip reconnect if intentionally disconnected
+            if (this._disconnecting) {
+                return;
             }
+
+            // schedule reconnection with backoff
+            this._scheduleReconnect();
         });
 
         return socket;
     }
 
     private _onauth(socket: WebSocket) {
+        // reset backoff on successful auth
+        this._reconnectAttempt = 0;
+        this._lastPong = Date.now();
+
         // reset keep alive
         if (this._alive) {
             clearInterval(this._alive);
         }
         this._alive = setInterval(() => {
+            // check for pong timeout
+            if (Date.now() - this._lastPong > PONG_TIMEOUT_MS) {
+                this._log.warn('pong timeout, closing socket');
+                socket.close(4001, 'pong timeout');
+                return;
+            }
+            // app-level ping — server responds with bare "pong" (not JSON-encoded)
             socket.send(JSON.stringify('ping'));
-        }, 1000);
+        }, PING_INTERVAL_MS);
 
         // on message handler
         socket.addEventListener('message', ({ data: raw }: { data: Data }) => {
             if (raw.toString() === 'pong') {
+                this._lastPong = Date.now();
                 return;
             }
             try {
@@ -181,6 +209,19 @@ class Messenger extends EventEmitter<EventMap> {
                 this._log.debug('socket.message', e);
             }
         });
+
+        // re-watch all tracked projects
+        for (const projectId of this.watchers) {
+            socket.send(
+                JSON.stringify({
+                    name: 'project.watch',
+                    target: { type: 'general' },
+                    env: ['*'],
+                    data: { id: projectId }
+                })
+            );
+            this._log.debug(`re-watching project ${projectId}`);
+        }
 
         // resolve active
         this._active.resolve(socket);
@@ -236,12 +277,43 @@ class Messenger extends EventEmitter<EventMap> {
         socket.send(JSON.stringify(data));
     }
 
-    async connect(accessToken: string) {
-        this._socket = this._connect(accessToken);
+    private _scheduleReconnect() {
+        const delay = Math.min(RECONNECT_BASE_MS * Math.pow(2, this._reconnectAttempt), RECONNECT_MAX_MS);
+        this._log.info(`reconnecting in ${delay}ms (attempt ${this._reconnectAttempt + 1})`);
+        this._reconnectAttempt++;
+        this._reconnectTimer = setTimeout(() => {
+            if (this._disconnecting) {
+                return;
+            }
+            this._socket = this._connect();
+        }, delay);
+    }
+
+    private _cancelReconnect() {
+        this._reconnectAttempt = 0;
+        if (this._reconnectTimer) {
+            clearTimeout(this._reconnectTimer);
+            this._reconnectTimer = null;
+        }
+    }
+
+    async connect(getToken: () => string) {
+        this._getToken = getToken;
+        this._socket = this._connect();
         await this._active.promise;
     }
 
     disconnect() {
+        // mark as intentional disconnect
+        this._disconnecting = true;
+        this._cancelReconnect();
+
+        // clear keep alive
+        if (this._alive) {
+            clearInterval(this._alive);
+            this._alive = null;
+        }
+
         // close socket
         this._socket?.close();
 

--- a/src/connections/relay.ts
+++ b/src/connections/relay.ts
@@ -6,6 +6,8 @@ import { Deferred } from '../utils/deferred';
 import { EventEmitter } from '../utils/event-emitter';
 import { signal } from '../utils/signal';
 
+import { PING_INTERVAL_MS, PONG_TIMEOUT_MS, RECONNECT_BASE_MS, RECONNECT_MAX_MS } from './constants';
+
 type EventMap = {
     'room:join': [{ name: string; userId: number; users?: number[] }];
     'room:leave': [{ name: string; userId: number }];
@@ -19,6 +21,18 @@ class Relay extends EventEmitter<EventMap> {
     private _socket: WebSocket | null = null;
 
     private _alive: ReturnType<typeof setInterval> | null = null;
+
+    private _authTimeout: ReturnType<typeof setTimeout> | null = null;
+
+    private _reconnectAttempt = 0;
+
+    private _reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+
+    private _disconnecting = false;
+
+    private _getToken: (() => string) | null = null;
+
+    private _lastPong = 0;
 
     url: string;
 
@@ -37,7 +51,10 @@ class Relay extends EventEmitter<EventMap> {
         this.origin = origin;
     }
 
-    private _connect(accessToken: string) {
+    private _connect() {
+        this._disconnecting = false;
+
+        const accessToken = this._getToken!();
         const options = WEB
             ? undefined
             : {
@@ -51,7 +68,8 @@ class Relay extends EventEmitter<EventMap> {
 
         // send request for auth
         // ! Invalid access tokens will hang here
-        const timeout = setTimeout(() => {
+        this._authTimeout = setTimeout(() => {
+            this._authTimeout = null;
             const reason = `[${this.constructor.name}] invalid access token`;
             // TODO: figure out why this triggers 1006 not 3000
             socket.close(3000, reason);
@@ -59,7 +77,10 @@ class Relay extends EventEmitter<EventMap> {
         }, 5000);
         socket.addEventListener('open', () => {
             this._log.debug('socket.open');
-            clearTimeout(timeout);
+            if (this._authTimeout) {
+                clearTimeout(this._authTimeout);
+                this._authTimeout = null;
+            }
 
             this._onauth(socket);
         });
@@ -73,6 +94,12 @@ class Relay extends EventEmitter<EventMap> {
         socket.addEventListener('close', ({ code, reason }: { code: number; reason: string }) => {
             this._log.debug('socket.close', code, reason.toString());
 
+            // clear auth timeout if still pending
+            if (this._authTimeout) {
+                clearTimeout(this._authTimeout);
+                this._authTimeout = null;
+            }
+
             // reset connected
             this._active = new Deferred();
             this.connected.set(() => false);
@@ -83,27 +110,42 @@ class Relay extends EventEmitter<EventMap> {
                 this._alive = null;
             }
 
-            // if closed abnormally, try to reconnect
-            setTimeout(() => {
-                this._socket = this._connect(accessToken);
-            }, 1000);
+            // skip reconnect if intentionally disconnected
+            if (this._disconnecting) {
+                return;
+            }
+
+            // schedule reconnection with backoff
+            this._scheduleReconnect();
         });
 
         return socket;
     }
 
     private _onauth(socket: WebSocket) {
+        // reset backoff on successful auth
+        this._reconnectAttempt = 0;
+        this._lastPong = Date.now();
+
         // reset keep alive
         if (this._alive) {
             clearInterval(this._alive);
         }
         this._alive = setInterval(() => {
+            // check for pong timeout
+            if (Date.now() - this._lastPong > PONG_TIMEOUT_MS) {
+                this._log.warn('pong timeout, closing socket');
+                socket.close(4001, 'pong timeout');
+                return;
+            }
+            // app-level ping — server responds with bare "pong" (not JSON-encoded)
             socket.send(JSON.stringify('ping'));
-        }, 1000);
+        }, PING_INTERVAL_MS);
 
         // on message handler
         socket.addEventListener('message', ({ data: raw }: { data: Data }) => {
             if (raw.toString() === 'pong') {
+                this._lastPong = Date.now();
                 return;
             }
             try {
@@ -119,6 +161,23 @@ class Relay extends EventEmitter<EventMap> {
                 this._log.debug('socket.message', e);
             }
         });
+
+        // re-join all tracked rooms
+        for (const [projectId, roomNames] of this.rooms) {
+            for (const name of roomNames) {
+                socket.send(
+                    JSON.stringify({
+                        t: 'room:join',
+                        name,
+                        authentication: {
+                            type: 'project',
+                            id: projectId
+                        }
+                    })
+                );
+                this._log.debug(`re-joining room ${name}`);
+            }
+        }
 
         // resolve active
         this._active.resolve(socket);
@@ -188,12 +247,49 @@ class Relay extends EventEmitter<EventMap> {
         socket.send(JSON.stringify(data));
     }
 
-    async connect(accessToken: string) {
-        this._socket = this._connect(accessToken);
+    private _scheduleReconnect() {
+        const delay = Math.min(RECONNECT_BASE_MS * Math.pow(2, this._reconnectAttempt), RECONNECT_MAX_MS);
+        this._log.info(`reconnecting in ${delay}ms (attempt ${this._reconnectAttempt + 1})`);
+        this._reconnectAttempt++;
+        this._reconnectTimer = setTimeout(() => {
+            if (this._disconnecting) {
+                return;
+            }
+            this._socket = this._connect();
+        }, delay);
+    }
+
+    private _cancelReconnect() {
+        this._reconnectAttempt = 0;
+        if (this._reconnectTimer) {
+            clearTimeout(this._reconnectTimer);
+            this._reconnectTimer = null;
+        }
+    }
+
+    async connect(getToken: () => string) {
+        this._getToken = getToken;
+        this._socket = this._connect();
         await this._active.promise;
     }
 
     disconnect() {
+        // mark as intentional disconnect
+        this._disconnecting = true;
+        this._cancelReconnect();
+
+        // clear auth timeout
+        if (this._authTimeout) {
+            clearTimeout(this._authTimeout);
+            this._authTimeout = null;
+        }
+
+        // clear keep alive
+        if (this._alive) {
+            clearInterval(this._alive);
+            this._alive = null;
+        }
+
         // close socket
         this._socket?.close();
 

--- a/src/connections/sharedb.ts
+++ b/src/connections/sharedb.ts
@@ -9,6 +9,8 @@ import { Deferred } from '../utils/deferred';
 import { EventEmitter } from '../utils/event-emitter';
 import { signal } from '../utils/signal';
 
+import { PING_INTERVAL_MS, PONG_TIMEOUT_MS, RECONNECT_BASE_MS, RECONNECT_MAX_MS } from './constants';
+
 // register text type
 sharedb.types.register(type);
 
@@ -35,6 +37,16 @@ class ShareDb extends EventEmitter<EventMap> {
 
     private _alive: ReturnType<typeof setInterval> | null = null;
 
+    private _reconnectAttempt = 0;
+
+    private _reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+
+    private _disconnecting = false;
+
+    private _getToken: (() => string) | null = null;
+
+    private _lastPong = 0;
+
     url: string;
 
     origin: string;
@@ -52,7 +64,10 @@ class ShareDb extends EventEmitter<EventMap> {
         this.origin = origin;
     }
 
-    private _connect(accessToken: string) {
+    private _connect() {
+        this._disconnecting = false;
+
+        const accessToken = this._getToken!();
         const options = WEB
             ? undefined
             : {
@@ -114,18 +129,23 @@ class ShareDb extends EventEmitter<EventMap> {
                 this._log.debug('paused', key);
             }
 
-            // if not unauthorized error,try to reconnect
-            if (code !== 3000) {
-                setTimeout(() => {
-                    this._socket = this._connect(accessToken);
-                }, 1000);
+            // skip reconnect if intentionally disconnected
+            if (this._disconnecting) {
+                return;
             }
+
+            // schedule reconnection with backoff
+            this._scheduleReconnect();
         });
 
         return socket;
     }
 
     private async _onauth(socket: WebSocket) {
+        // reset backoff on successful auth
+        this._reconnectAttempt = 0;
+        this._lastPong = Date.now();
+
         if (this._connection) {
             this._connection.bindToSocket(socket as Socket);
         } else {
@@ -140,12 +160,21 @@ class ShareDb extends EventEmitter<EventMap> {
             clearInterval(this._alive);
         }
         this._alive = setInterval(() => {
+            // check for pong timeout — server pings every 1s so we should always receive data
+            if (Date.now() - this._lastPong > PONG_TIMEOUT_MS) {
+                this._log.warn('pong timeout, closing socket');
+                socket.close(4001, 'pong timeout');
+                return;
+            }
             this._connection?.ping();
-        }, 1000);
+        }, PING_INTERVAL_MS);
 
         // intercept for custom messages
         const onmessage = socket.onmessage?.bind(socket);
         socket.onmessage = (msg) => {
+            // update last pong on any incoming message
+            this._lastPong = Date.now();
+
             // intercept custom messages
             const str = msg.data.toString();
             if (/^(\w+):/.test(str)) {
@@ -279,12 +308,43 @@ class ShareDb extends EventEmitter<EventMap> {
         socket.send(data);
     }
 
-    async connect(accessToken: string) {
-        this._socket = this._connect(accessToken);
+    private _scheduleReconnect() {
+        const delay = Math.min(RECONNECT_BASE_MS * Math.pow(2, this._reconnectAttempt), RECONNECT_MAX_MS);
+        this._log.info(`reconnecting in ${delay}ms (attempt ${this._reconnectAttempt + 1})`);
+        this._reconnectAttempt++;
+        this._reconnectTimer = setTimeout(() => {
+            if (this._disconnecting) {
+                return;
+            }
+            this._socket = this._connect();
+        }, delay);
+    }
+
+    private _cancelReconnect() {
+        this._reconnectAttempt = 0;
+        if (this._reconnectTimer) {
+            clearTimeout(this._reconnectTimer);
+            this._reconnectTimer = null;
+        }
+    }
+
+    async connect(getToken: () => string) {
+        this._getToken = getToken;
+        this._socket = this._connect();
         await this._active.promise;
     }
 
     disconnect() {
+        // mark as intentional disconnect
+        this._disconnecting = true;
+        this._cancelReconnect();
+
+        // clear keep alive
+        if (this._alive) {
+            clearInterval(this._alive);
+            this._alive = null;
+        }
+
         // close all docs
         for (const [_key, doc] of this.subscriptions) {
             doc.destroy();

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -485,7 +485,7 @@ export const activate = async (context: vscode.ExtensionContext) => {
 
         // connect sharedb, messenger, relay if not connected
         if (!sharedb.connected.get()) {
-            await sharedb.connect(accessToken);
+            await sharedb.connect(() => accessToken);
             context.subscriptions.push(
                 new vscode.Disposable(() => {
                     sharedb.disconnect();
@@ -493,7 +493,7 @@ export const activate = async (context: vscode.ExtensionContext) => {
             );
         }
         if (!messenger.connected.get()) {
-            await messenger.connect(accessToken);
+            await messenger.connect(() => accessToken);
             context.subscriptions.push(
                 new vscode.Disposable(() => {
                     messenger.disconnect();
@@ -501,7 +501,7 @@ export const activate = async (context: vscode.ExtensionContext) => {
             );
         }
         if (!relay.connected.get()) {
-            await relay.connect(accessToken);
+            await relay.connect(() => accessToken);
             context.subscriptions.push(
                 new vscode.Disposable(() => {
                     relay.disconnect();

--- a/src/test/mocks/messenger.ts
+++ b/src/test/mocks/messenger.ts
@@ -3,7 +3,7 @@ import type sinon from 'sinon';
 import { Messenger } from '../../connections/messenger';
 
 class MockMessenger extends Messenger {
-    connect: sinon.SinonSpy<[], Promise<void>>;
+    connect: sinon.SinonSpy<[() => string], Promise<void>>;
 
     disconnect: sinon.SinonSpy<[], void>;
 
@@ -19,7 +19,7 @@ class MockMessenger extends Messenger {
             origin: ''
         });
 
-        this.connect = sandbox.spy(async () => {
+        this.connect = sandbox.spy(async (_getToken: () => string) => {
             this.connected.set(() => true);
         });
         this.disconnect = sandbox.spy(() => {

--- a/src/test/mocks/relay.ts
+++ b/src/test/mocks/relay.ts
@@ -3,7 +3,7 @@ import type sinon from 'sinon';
 import { Relay } from '../../connections/relay';
 
 class MockRelay extends Relay {
-    connect: sinon.SinonSpy<[], Promise<void>>;
+    connect: sinon.SinonSpy<[() => string], Promise<void>>;
 
     disconnect: sinon.SinonSpy<[], void>;
 
@@ -19,7 +19,7 @@ class MockRelay extends Relay {
             origin: ''
         });
 
-        this.connect = sandbox.spy(async () => {
+        this.connect = sandbox.spy(async (_getToken: () => string) => {
             this.connected.set(() => true);
         });
         this.disconnect = sandbox.spy(() => {

--- a/src/test/mocks/sharedb.ts
+++ b/src/test/mocks/sharedb.ts
@@ -258,7 +258,7 @@ class MockDoc extends Doc {
 class MockShareDb extends ShareDb {
     subscriptions = new Map<string, MockDoc>();
 
-    connect: sinon.SinonSpy<[string], Promise<void>>;
+    connect: sinon.SinonSpy<[() => string], Promise<void>>;
 
     disconnect: sinon.SinonSpy<[], void>;
 
@@ -275,7 +275,7 @@ class MockShareDb extends ShareDb {
     constructor(sandbox: sinon.SinonSandbox, messenger: MockMessenger) {
         super({ url: '', origin: '' });
 
-        this.connect = sandbox.spy(async (_accessToken: string) => {
+        this.connect = sandbox.spy(async (_getToken: () => string) => {
             this.connected.set(() => true);
         });
         this.disconnect = sandbox.spy(() => {


### PR DESCRIPTION
Fixes #97

### What's Changed

- **Exponential backoff**: Replace fixed 1s retry delay with exponential backoff (1s → 2s → 4s → … → 30s cap) across ShareDB, Messenger, and Relay connections
- **Disconnect guard**: Prevent `disconnect()` from accidentally triggering reconnection via the close handler; guard the reconnect timer callback against a race with `disconnect()`
- **Pong timeout detection**: Track last pong/message timestamp and close zombie connections after 5s of silence, triggering reconnection with backoff
- **State re-establishment**: Re-send `project.watch` for Messenger watchers and `room:join` for Relay rooms in `_onauth()` on reconnect
- **Fresh token on reconnect**: `connect()` now accepts `() => string` getter so each reconnection attempt can use a fresh access token
- **Relay auth timeout cleanup**: Store auth timeout as a member, clear it in both the close handler and `disconnect()` to prevent stale timer firing on connection failure
- **Interval cleanup in disconnect**: Explicitly clear `_alive` ping interval in `disconnect()` instead of relying solely on the close event
- **Shared constants**: Extract timing constants (`PING_INTERVAL_MS`, `PONG_TIMEOUT_MS`, `RECONNECT_BASE_MS`, `RECONNECT_MAX_MS`) to `src/connections/constants.ts`