### PR TITLE
fix: only send errors to Sentry, keep warnings local

### DIFF
--- a/src/log.ts
+++ b/src/log.ts
@@ -21,7 +21,6 @@ class Log {
 
     warn(...args: unknown[]) {
         Log.channel.warn(`[${this._source}]`, ...args);
-        captureMessage(args.map(String).join(' '), 'warning', this._source);
     }
 
     error(...args: unknown[]) {

--- a/src/project-manager.ts
+++ b/src/project-manager.ts
@@ -366,7 +366,9 @@ class ProjectManager extends Linker<{ projectId: number; branchId: string }> {
         }
 
         if (attempt > ProjectManager.MAX_RETRIES) {
-            this._log.warn(`giving up subscribing to document ${uniqueId} after ${ProjectManager.MAX_RETRIES} retries`);
+            this._log.error(
+                `giving up subscribing to document ${uniqueId} after ${ProjectManager.MAX_RETRIES} retries`
+            );
             return;
         }
 
@@ -420,7 +422,7 @@ class ProjectManager extends Linker<{ projectId: number; branchId: string }> {
         // enforce retry limit
         const attempt = (this._saveRetryCounts.get(uniqueId) ?? 0) + 1;
         if (attempt > ProjectManager.MAX_RETRIES) {
-            this._log.warn(`giving up saving document ${uniqueId} after ${ProjectManager.MAX_RETRIES} retries`);
+            this._log.error(`giving up saving document ${uniqueId} after ${ProjectManager.MAX_RETRIES} retries`);
             this._saveRetryCounts.delete(uniqueId);
             return;
         }


### PR DESCRIPTION
## Summary
- Remove `captureMessage()` from `warn()` in `log.ts` so warnings stay in the VS Code output channel and don't pollute Sentry
- Upgrade exhausted-retry warnings to `error()` in `project-manager.ts` so permanent subscription/save failures are reported to Sentry

## Test plan
- [x] `npm run compile` passes
- [x] `npm run lint` passes