### PR TITLE
Fix: disable autosave when PlayCanvas project is loaded

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -690,6 +690,7 @@ export const activate = async (context: vscode.ExtensionContext) => {
         const disableAutosave = () => {
             const f = vscode.workspace.getConfiguration('files');
             if (f.get('autoSave') !== 'off') {
+                log.debug('disabling files.autoSave for workspace');
                 f.update('autoSave', 'off', vscode.ConfigurationTarget.Workspace);
             }
         };


### PR DESCRIPTION
## Summary
- Disables `files.autoSave` at the workspace level when a PlayCanvas project is loaded
- Autosave interferes with realtime collaborative editing by writing to disk unnecessarily and causing dirty indicator flicker
- Only sets the value if not already `"off"`, placed after `disk.link()` when the project is fully loaded

## Test plan
- [x] Open a PlayCanvas project with autosave enabled → confirm `files.autoSave` gets set to `"off"` in workspace settings
- [x] Confirm manual save (Cmd+S) still works and triggers `projectManager.save()`
- [x] Confirm no reload prompt is triggered (extension only watches `playcanvas.*` config changes)