### PR TITLE
feat: add op diff stats to change debug logs

### DIFF
--- a/src/disk.ts
+++ b/src/disk.ts
@@ -16,6 +16,7 @@ import {
     parsePath,
     sharedb2vscode,
     vscode2sharedb,
+    opdiff,
     relativePath,
     uriStartsWith,
     fileExists,
@@ -306,7 +307,7 @@ class Disk extends Linker<{ folderUri: vscode.Uri; projectManager: ProjectManage
             // mirror to disk (debounced)
             this._sync(uri, content);
 
-            this._log.debug(`change.remote.${viewing ? 'open' : 'closed'} ${uri}`);
+            this._log.debug(`change.remote.${viewing ? 'open' : 'closed'} ${uri} ${opdiff(op)}`);
         });
     }
 
@@ -567,7 +568,7 @@ class Disk extends Linker<{ folderUri: vscode.Uri; projectManager: ProjectManage
             // mark as dirty if any ops submitted (any unsaved changes)
             file.dirty ||= !!opOptions.length;
 
-            this._log.debug(`document.change ${document.uri.path}`);
+            this._log.debug(`document.change ${document.uri.path} ${opOptions.map(([o]) => opdiff(o)).join(' ')}`);
         });
         const onsave = vscode.workspace.onWillSaveTextDocument((e) => {
             const { document } = e;

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -153,6 +153,19 @@ export const sharedb2vscode = (doc: vscode.TextDocument, ops: ShareDbTextOp[]) =
     return edits;
 };
 
+export const opdiff = (op: ShareDbTextOp) => {
+    let ins = 0;
+    let del = 0;
+    for (const c of op) {
+        if (typeof c === 'string') {
+            ins += c.length;
+        } else if (typeof c === 'object') {
+            del += c.d;
+        }
+    }
+    return `+${ins} -${del}`;
+};
+
 export const minimalDiff = (a: string, b: string) => {
     const minLen = Math.min(a.length, b.length);
     let prefix = 0;


### PR DESCRIPTION
## Summary
- Adds `opdiff` utility that extracts insert/delete character counts from ShareDB ops
- Debug logs for local and remote changes now show `+N -N` stats (e.g. `document.change /path/file.js +5 -3`)

## Test plan
- [x] Verify `npm run lint` and `npm run compile` pass
- [x] Open a PlayCanvas project, make local and remote edits, confirm debug logs show op stats