### PR TITLE
fix: prevent phantom edits and open-file save reversion

### DIFF
--- a/src/disk.ts
+++ b/src/disk.ts
@@ -419,9 +419,21 @@ class Disk extends Linker<{ folderUri: vscode.Uri; projectManager: ProjectManage
                     const path = folderUri ? relativePath(uri, folderUri) : undefined;
                     const file = path ? this._projectManager?.files.get(path) : undefined;
                     if (file?.type === 'file') {
+                        // skip if user has new unsaved changes since save was confirmed
+                        if (file.dirty) {
+                            this._log.debug(`save.remote.skip ${uri} (dirty)`);
+                            return;
+                        }
+
                         const content = buffer.from(file.doc.data);
                         this._echo.set(`${uri}:change`, hash(content));
                         await vscode.workspace.fs.writeFile(uri, content);
+
+                        // recheck: user may have typed during writeFile await
+                        if (file.dirty) {
+                            this._log.debug(`save.remote.skip ${uri} (dirty after write)`);
+                            return;
+                        }
                     }
 
                     try {


### PR DESCRIPTION
## Summary

Two fixes for phantom edit / reversion bugs in `disk.ts`:

1. **Closed-file phantom edits**: `_syncing` Set tracks remote-originated disk writes; file watcher skips URIs in the set (200ms window covering FSEvents latency)

2. **Open-file save reversion**: `file.dirty` guards in `_save()` skip stale disk writes when user types between save confirmation and the async write. Two checks cover both await points (`openTextDocument` and `writeFile`).

Related to #123

## Test plan

- [x] `npm run pretest` / `npm run lint`
- [x] Rapidly edit closed file in online Editor → no phantom edits
- [x] Type "gimo", save, backspace + type "gizmo" → no reversion
- [x] Dirty indicator clears on save with no new edits