### PR TITLE
feat: color dirty files in explorer via FileDecorationProvider

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,6 +81,18 @@
                 "enableForWorkspaceTypeScriptVersions": true
             }
         ],
+        "colors": [
+            {
+                "id": "playcanvas.dirtyForeground",
+                "description": "Color for unsaved files in the explorer",
+                "defaults": {
+                    "dark": "#f4a62a",
+                    "light": "#c88520",
+                    "highContrast": "#f4a62a",
+                    "highContrastLight": "#c88520"
+                }
+            }
+        ],
         "views": {
             "explorer": [
                 {

--- a/src/disk.ts
+++ b/src/disk.ts
@@ -607,7 +607,11 @@ class Disk extends Linker<{ folderUri: vscode.Uri; projectManager: ProjectManage
             this._sync(document.uri, buffer.from(text));
 
             // mark as dirty if any ops submitted (any unsaved changes)
+            const prev = file.dirty;
             file.dirty ||= !!opOptions.length;
+            if (!prev && file.dirty) {
+                this._events.emit('asset:file:dirty', path, true);
+            }
 
             // external disk change — force dirty indicator
             if (!document.isDirty && opOptions.length) {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -13,6 +13,7 @@ import { Metrics } from './metrics';
 import { simpleNotification } from './notification';
 import { ProjectManager } from './project-manager';
 import { CollabProvider } from './providers/collab-provider';
+import { DirtyDecorationProvider } from './providers/dirty-decoration-provider';
 import { closeSentry, setSentryProject, setSentryUser } from './sentry';
 import type { EventMap } from './typings/event-map';
 import type { Project } from './typings/models';
@@ -185,6 +186,7 @@ export const activate = async (context: vscode.ExtensionContext) => {
             await projectManager.flushPending();
             const collabState = await collabProvider.unlink();
             const uriState = await uriHandler.unlink();
+            const dirtyState = await dirtyProvider.unlink();
             const diskState = await disk.unlink();
             const projectState = await projectManager.unlink();
             projectState.branchId = branchId ?? projectState.branchId;
@@ -201,6 +203,7 @@ export const activate = async (context: vscode.ExtensionContext) => {
             });
 
             await disk.link(diskState);
+            await dirtyProvider.link(dirtyState);
             await collabProvider.link(collabState);
             await uriHandler.link(uriState);
         })();
@@ -238,6 +241,16 @@ export const activate = async (context: vscode.ExtensionContext) => {
         }
     });
     context.subscriptions.push(vscode.window.registerTreeDataProvider('collab-view', collabProvider));
+
+    // dirty decoration provider
+    const dirtyProvider = new DirtyDecorationProvider({ events });
+    effect(() => {
+        const err = dirtyProvider.error.get();
+        if (err) {
+            void handleError(err, 'dirty-decoration-provider').catch((e) => log.error(e.message));
+        }
+    });
+    context.subscriptions.push(vscode.window.registerFileDecorationProvider(dirtyProvider));
 
     // connection status bar item
     const connectionStatusColors = {
@@ -721,6 +734,14 @@ export const activate = async (context: vscode.ExtensionContext) => {
         context.subscriptions.push(
             new vscode.Disposable(() => {
                 disk.unlink();
+            })
+        );
+
+        // link dirty decoration provider
+        await dirtyProvider.link({ folderUri, projectManager });
+        context.subscriptions.push(
+            new vscode.Disposable(() => {
+                dirtyProvider.unlink();
             })
         );
 

--- a/src/project-manager.ts
+++ b/src/project-manager.ts
@@ -1157,7 +1157,11 @@ class ProjectManager extends Linker<{ projectId: number; branchId: string }> {
         }
 
         // mark as dirty (ops submitted that aren't saved yet)
+        const prev = file.dirty;
         file.dirty = true;
+        if (!prev) {
+            this._events.emit('asset:file:dirty', path, true);
+        }
 
         this._log.debug(`wrote file ${path}`);
     }

--- a/src/providers/dirty-decoration-provider.ts
+++ b/src/providers/dirty-decoration-provider.ts
@@ -1,0 +1,126 @@
+import * as vscode from 'vscode';
+
+import type { ProjectManager } from '../project-manager';
+import type { EventMap } from '../typings/event-map';
+import type { EventEmitter } from '../utils/event-emitter';
+import { Linker } from '../utils/linker';
+import { signal } from '../utils/signal';
+
+const DIRTY_COLOR = new vscode.ThemeColor('playcanvas.dirtyForeground');
+
+class DirtyDecorationProvider
+    extends Linker<{ folderUri: vscode.Uri; projectManager: ProjectManager }>
+    implements vscode.FileDecorationProvider
+{
+    private _events: EventEmitter<EventMap>;
+
+    private _linked = false;
+
+    private _folderUri?: vscode.Uri;
+
+    private _projectManager?: ProjectManager;
+
+    private _onDidChangeFileDecorations = new vscode.EventEmitter<vscode.Uri | vscode.Uri[] | undefined>();
+    readonly onDidChangeFileDecorations = this._onDidChangeFileDecorations.event;
+
+    error = signal<Error | undefined>(undefined);
+
+    constructor({ events }: { events: EventEmitter<EventMap> }) {
+        super();
+        this._events = events;
+    }
+
+    provideFileDecoration(uri: vscode.Uri) {
+        const folderUri = this._folderUri;
+        const pm = this._projectManager;
+        if (!folderUri || !pm || !this._linked) {
+            return undefined;
+        }
+
+        // check uri is under folder
+        if (!uri.path.startsWith(folderUri.path + '/') && uri.path !== folderUri.path) {
+            return undefined;
+        }
+
+        const path = uri.path.slice(folderUri.path.length + 1);
+        const file = pm.files.get(path);
+        if (!file || file.type !== 'file' || !file.dirty) {
+            return undefined;
+        }
+
+        return { color: DIRTY_COLOR };
+    }
+
+    private _fire(path: string) {
+        const folderUri = this._folderUri;
+        if (!folderUri) {
+            return;
+        }
+        this._onDidChangeFileDecorations.fire(vscode.Uri.joinPath(folderUri, path));
+    }
+
+    async link({ folderUri, projectManager }: { folderUri: vscode.Uri; projectManager: ProjectManager }) {
+        if (this._linked) {
+            throw this.error.set(() => new Error('already linked'));
+        }
+
+        this._folderUri = folderUri;
+        this._projectManager = projectManager;
+
+        // listen for dirty transitions
+        const onDirty = this._events.on('asset:file:dirty', (path) => this._fire(path));
+        const onUpdate = this._events.on('asset:file:update', (path) => this._fire(path));
+        const onSave = this._events.on('asset:file:save', (path) => this._fire(path));
+        const onCreate = this._events.on('asset:file:create', (path) => this._fire(path));
+        const onDelete = this._events.on('asset:file:delete', (path) => this._fire(path));
+        const onRename = this._events.on('asset:file:rename', (from, to) => {
+            this._fire(from);
+            this._fire(to);
+        });
+
+        // fire initial decorations for already-dirty files
+        const uris: vscode.Uri[] = [];
+        for (const [path, file] of projectManager.files) {
+            if (file.type === 'file' && file.dirty) {
+                uris.push(vscode.Uri.joinPath(folderUri, path));
+            }
+        }
+        if (uris.length) {
+            this._onDidChangeFileDecorations.fire(uris);
+        }
+
+        this._cleanup.push(async () => {
+            this._events.off('asset:file:dirty', onDirty);
+            this._events.off('asset:file:update', onUpdate);
+            this._events.off('asset:file:save', onSave);
+            this._events.off('asset:file:create', onCreate);
+            this._events.off('asset:file:delete', onDelete);
+            this._events.off('asset:file:rename', onRename);
+
+            // clear all decorations
+            this._onDidChangeFileDecorations.fire(undefined);
+        });
+
+        this._linked = true;
+
+        this._log.info(`linked to ${folderUri.toString()}`);
+    }
+
+    async unlink() {
+        const folderUri = this._folderUri;
+        const projectManager = this._projectManager;
+        if (!this._linked) {
+            this._log.warn('unlink called when not linked');
+            if (!folderUri || !projectManager) {
+                throw this.error.set(() => new Error('unlink called before link'));
+            }
+            return { folderUri, projectManager };
+        }
+        await super.unlink();
+        this._linked = false;
+        this._log.info(`unlinked from ${folderUri!.toString()}`);
+        return { folderUri: folderUri!, projectManager: projectManager! };
+    }
+}
+
+export { DirtyDecorationProvider };

--- a/src/typings/event-map.d.ts
+++ b/src/typings/event-map.d.ts
@@ -10,6 +10,7 @@ export type EventMap = {
     'asset:file:delete': [string];
     'asset:file:rename': [string, string];
     'asset:file:save': [string];
+    'asset:file:dirty': [string, boolean];
 
     'asset:doc:open': [string];
     'asset:doc:close': [string];


### PR DESCRIPTION
## Summary
- Adds a `FileDecorationProvider` that colors file names in the VS Code explorer when files are dirty (unsaved to server), matching the web editor's muted yellow (`#f4a62a`)
- Introduces `asset:file:dirty` event emitted on clean→dirty transitions from both `ProjectManager.write()` and `Disk.onchange`
- Registers a `playcanvas.dirtyForeground` theme color with dark/light/high-contrast variants

## Test plan
- [x] Load extension, open a PlayCanvas project — verify dirty files from initial load show muted yellow
- [x] Edit a file locally — verify color appears in explorer
- [x] Save file (Cmd+S) — verify color clears after server confirms save
- [x] External tool modifies a file — verify color appears
- [x] Remote collaborator edits — verify color appears/clears correctly
- [x] Reload project — verify decorations reset and re-apply

### Preview

<img width="330" height="246" alt="image" src="https://github.com/user-attachments/assets/2cbad4a5-650b-4ef6-8cbf-1aa6cd9a2935" />
