### PR TITLE
fix: prevent lines merging after save

### DIFF
--- a/src/disk.ts
+++ b/src/disk.ts
@@ -293,6 +293,7 @@ class Disk extends Linker<{ folderUri: vscode.Uri; projectManager: ProjectManage
                             const docData = file.doc.data as string;
                             const currentText = document.getText();
                             if (!applied || docData !== currentText) {
+                                const dropped = applied && docData !== currentText;
                                 const fullReplace = new vscode.WorkspaceEdit();
                                 fullReplace.replace(
                                     uri,
@@ -304,7 +305,10 @@ class Disk extends Linker<{ folderUri: vscode.Uri; projectManager: ProjectManage
                                     this._log.error(`resync also failed for ${uri}`);
                                 }
                                 this._sync(uri, buffer.from(docData));
-                                this._log.warn(`reconcile.remote.resync ${uri} applied=${applied}`);
+                                if (dropped) {
+                                    this._log.error(`reconcile.remote.dropped_keystrokes ${uri}`);
+                                }
+                                this._log.warn(`reconcile.remote.resync ${uri} applied=${applied} dropped=${dropped}`);
                                 return;
                             }
                         }


### PR DESCRIPTION
## Summary

- Remove reconciliation block in `_update()` that called `projectManager.write()` to push VS Code buffer into ShareDB — `minimalDiff` on a diverged buffer could produce ops that delete newline characters, merging lines
- Compare buffer against **live `doc.data`** (source of truth) and force-reset on any drift, never pushing buffer state into ShareDB (mirrors online editor behavior)
- Log dropped keystrokes to Sentry when the async `applyEdit` window causes buffer drift, for monitoring

## Test plan

- [x] Edit a file, save while remote edits arrive — lines should not merge
- [x] Type rapidly while remote ops arrive — no phantom edits or character omissions
- [x] Verify `reconcile.remote.resync` log appears when buffer drift is detected
- [x] Verify `reconcile.remote.dropped_keystrokes` error fires in Sentry when keystrokes are lost during resync