### PR TITLE
fix: guard against null doc data after hard reset

### DIFF
--- a/src/project-manager.ts
+++ b/src/project-manager.ts
@@ -297,7 +297,12 @@ class ProjectManager extends Linker<{ projectId: number; branchId: string }> {
             return false;
         }
 
-        // compute dirty state by comparing hash of doc content vs S3 hash
+        // after hard reset, collab server nullifies inactive doc data — skip until reload
+        if (doc.data === null) {
+            this._log.debug(`skipped file ${path} (null data, pending reload)`);
+            return false;
+        }
+
         const asset = this._assets.get(uniqueId);
         if (!asset?.file) {
             throw this.error.set(() => new Error(`missing file data for asset ${uniqueId}`));


### PR DESCRIPTION
## Summary
- During a hard reset (checkpoint restore), the collab server nullifies `_data` for inactive documents in MongoDB
- When the extension reconnects, `doc.data` is `null`, crashing `buffer.from()` and `hash()`
- Added a null guard in `_addFile()` that skips the file until the post-reset project reload fetches fresh data from S3

## Test plan
- [x] `npm run pretest` passes
- [x] `npm run lint` passes
- [x] Perform a hard reset in PlayCanvas Editor while VS Code extension is connected — should not crash, files reload cleanly after project reload