### PR TITLE
feat: add collaborator count tags to Sentry errors

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -14,7 +14,7 @@ import { simpleNotification } from './notification';
 import { ProjectManager } from './project-manager';
 import { CollabProvider } from './providers/collab-provider';
 import { DirtyDecorationProvider } from './providers/dirty-decoration-provider';
-import { closeSentry, setSentryProject, setSentryUser } from './sentry';
+import { closeSentry, setSentryCollaborators, setSentryProject, setSentryUser } from './sentry';
 import type { EventMap } from './typings/event-map';
 import type { Project } from './typings/models';
 import { EventEmitter } from './utils/event-emitter';
@@ -239,6 +239,12 @@ export const activate = async (context: vscode.ExtensionContext) => {
         }
     });
     context.subscriptions.push(vscode.window.registerTreeDataProvider('collab-view', collabProvider));
+    const updateCollabTags = () => {
+        const { same, other } = collabProvider.counts();
+        setSentryCollaborators(same, other);
+    };
+    relay.on('room:join', updateCollabTags);
+    relay.on('room:leave', updateCollabTags);
 
     // dirty decoration provider
     const dirtyProvider = new DirtyDecorationProvider({ events });

--- a/src/providers/collab-provider.ts
+++ b/src/providers/collab-provider.ts
@@ -110,6 +110,18 @@ class CollabProvider
         };
     }
 
+    counts() {
+        const room = this._rooms.get(this._room || '');
+        const same = room ? room.size : 0;
+        let other = 0;
+        for (const [name, users] of this._rooms) {
+            if (name !== this._room) {
+                other += users.size;
+            }
+        }
+        return { same, other };
+    }
+
     refresh(): void {
         this._onDidChangeTreeData.fire();
     }

--- a/src/sentry.ts
+++ b/src/sentry.ts
@@ -219,6 +219,11 @@ export const setSentryProject = (projectId: number, branchId: string) => {
     scope.setTag('branch_id', branchId);
 };
 
+export const setSentryCollaborators = (same: number, other: number) => {
+    scope.setTag('collab_same', String(same));
+    scope.setTag('collab_other', String(other));
+};
+
 export const closeSentry = async () => {
     await client.close(2000);
 };


### PR DESCRIPTION
## Summary
- Adds `collab_same` and `collab_other` Sentry tags tracking how many collaborators are in the same document vs other documents
- Enables filtering/correlating Sentry errors with collaboration state to identify concurrency-related bugs
- Follows existing `setSentryProject` pattern: setter in `sentry.ts`, wired from `extension.ts` via relay events

## Test plan
- [x] `npm run compile` passes
- [x] `npm run lint` passes
- [x] Open extension, join a project with collaborators, verify `collab_same`/`collab_other` tags appear on Sentry events