### PR TITLE
fix: recover dropped keystrokes during remote edit application

### DIFF
--- a/src/disk.ts
+++ b/src/disk.ts
@@ -26,9 +26,6 @@ import {
     minimalDiff
 } from './utils/utils';
 
-const fullRange = (doc: vscode.TextDocument) =>
-    new vscode.Range(doc.positionAt(0), doc.positionAt(doc.getText().length));
-
 const readDirRecursive = async (uri: vscode.Uri) => {
     const entries = await vscode.workspace.fs.readDirectory(uri);
     const result: vscode.Uri[] = [];
@@ -306,8 +303,15 @@ class Disk extends Linker<{ folderUri: vscode.Uri; projectManager: ProjectManage
                             if (!applied) {
                                 // applyEdit failed — force-reset to server state
                                 const reset = new vscode.WorkspaceEdit();
-                                reset.replace(uri, fullRange(document), docData);
-                                await vscode.workspace.applyEdit(reset);
+                                const range = new vscode.Range(
+                                    document.positionAt(0),
+                                    document.positionAt(currentText.length)
+                                );
+                                reset.replace(uri, range, docData);
+                                const resyncApplied = await vscode.workspace.applyEdit(reset);
+                                if (!resyncApplied) {
+                                    this._log.error(`resync.remote.failed ${uri}`);
+                                }
                                 this._sync(uri, buffer.from(docData));
                                 this._log.warn(`sync.remote.resync ${uri} applied=false`);
                                 return;
@@ -325,6 +329,11 @@ class Disk extends Linker<{ folderUri: vscode.Uri; projectManager: ProjectManage
                                           ? [prefix, { d: delLen }]
                                           : [prefix, insText];
                                 file.doc.submitOp(recovered, { source: ShareDb.SOURCE });
+                                const prev = file.dirty;
+                                file.dirty = true;
+                                if (!prev) {
+                                    this._events.emit('asset:file:dirty', path, true);
+                                }
                                 this._sync(document.uri, buffer.from(file.doc.data as string));
                                 this._log.info(
                                     `sync.remote.recovered ${uri} ${opdiff(op)} recovered=${opdiff(recovered)}`


### PR DESCRIPTION
Fixes #147

### What's Changed

- When a remote ShareDB op arrives for an open file, `applyEdit()` is async — user keystrokes during the gap update VS Code's buffer but the lock prevents `onDidChangeTextDocument` from submitting ops. Previously this force-reset the buffer to server state, silently dropping keystrokes (`sync.remote.dropped`).
- Instead of dropping, the reconciliation now diffs `doc.data` against the VS Code buffer after `applyEdit` resolves. The diff captures the user's net edit (naturally merged by VS Code) and submits it as a single ShareDB op.
- Recovered keystrokes correctly mark the file as dirty and emit `asset:file:dirty`.
- The `!applied` fallback path retains the `resync.remote.failed` error log.

### Why diff-based instead of OT queue+transform

An earlier iteration queued raw ops with phase tracking (pre/post remote echo) and used `type.compose()`/`type.transform()` to resubmit them. This had multiple correctness issues:
- Echo detection via content matching was fragile (false positives on undo, missed on no-op edits)
- `_drain` called `applyEdit` while the pending queue was still active, causing re-entrant queueing
- The noop dirtify path could leak synthetic space insert/delete as real ops (phantom edits)

The diff-based approach avoids all of these by leveraging VS Code's native edit merging and computing the recovery op directly against `doc.data`. No OT compose/transform, no phase tracking, no extra `applyEdit` calls.