### PR TITLE
refactor: simplify ProjectManager retry and collision logic

### DIFF
--- a/src/collision-manager.ts
+++ b/src/collision-manager.ts
@@ -10,7 +10,7 @@ type PathOverride = {
     name?: string;
 };
 
-class CollisionTracker {
+class CollisionManager {
     private _files: Map<string, CollisionFile>;
 
     private _assetPath: (uniqueId: number, override?: PathOverride) => string;
@@ -135,4 +135,4 @@ class CollisionTracker {
     }
 }
 
-export { CollisionTracker };
+export { CollisionManager };

--- a/src/collision-manager.ts
+++ b/src/collision-manager.ts
@@ -23,7 +23,7 @@ class CollisionManager {
 
     private _collidedByPath = new Map<string, Set<number>>();
 
-    collisions = signal(0);
+    count = signal(0);
 
     constructor({
         files,
@@ -111,7 +111,7 @@ class CollisionManager {
             this.remove(uniqueId);
         }
 
-        this.collisions.set(() => this._collidedByPath.size);
+        this.count.set(() => this._collidedByPath.size);
     }
 
     snapshot() {
@@ -131,7 +131,7 @@ class CollisionManager {
     clear() {
         this._collided.clear();
         this._collidedByPath.clear();
-        this.collisions.set(() => 0);
+        this.count.set(() => 0);
     }
 }
 

--- a/src/connections/sharedb.ts
+++ b/src/connections/sharedb.ts
@@ -290,20 +290,6 @@ class ShareDb extends EventEmitter<EventMap> {
         return value;
     }
 
-    /**
-     * Destroy an existing subscription (if any) and re-subscribe from scratch.
-     * Any ops delivered between destroy and the new subscribe completing will be
-     * lost. Only use when the prior subscription is known to be broken.
-     */
-    async resubscribe(type: string, key: string): Promise<sharedb.Doc | undefined> {
-        const existing = this.subscriptions.get(`${type}:${key}`);
-        if (existing) {
-            existing.destroy();
-            this.subscriptions.delete(`${type}:${key}`);
-        }
-        return this.subscribe(type, key);
-    }
-
     async bulkSubscribe(subscriptions: [string, string][]) {
         const [connection] = await this._active.promise;
         connection.startBulk();

--- a/src/disk.ts
+++ b/src/disk.ts
@@ -983,6 +983,9 @@ class Disk extends Linker<{ folderUri: vscode.Uri; projectManager: ProjectManage
             throw this.error.set(() => new Error('manager already linked'));
         }
 
+        // drain stale cleanup from a previously failed link
+        await super.unlink();
+
         // read files to disk
         const updatingDiskDone = await simpleNotification('Updating Disk');
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -562,7 +562,7 @@ export const activate = async (context: vscode.ExtensionContext) => {
                 return;
             }
 
-            const collisions = projectManager.collided();
+            const collisions = projectManager.collisions.snapshot();
             if (collisions.size === 0) {
                 return;
             }
@@ -707,7 +707,7 @@ export const activate = async (context: vscode.ExtensionContext) => {
             }
         });
         effect(() => {
-            const count = projectManager.collisions.get();
+            const count = projectManager.collisions.count.get();
             collisionStatusItem.color = count > 0 ? collisionStatusColors.found : collisionStatusColors.none;
             collisionStatusItem.text = `$(${count > 0 ? 'warning' : 'check'}) Path Collisions: ${count}`;
         });

--- a/src/handlers/uri-handler.ts
+++ b/src/handlers/uri-handler.ts
@@ -247,6 +247,9 @@ class UriHandler
             throw this.error.set(() => new Error('manager already linked'));
         }
 
+        // drain stale cleanup from a previously failed link
+        await super.unlink();
+
         this._cleanup.push(async () => this._clearErrorDecoration());
 
         await this._openFile(folderUri, projectManager);

--- a/src/project-manager.ts
+++ b/src/project-manager.ts
@@ -83,7 +83,7 @@ class ProjectManager extends Linker<{ projectId: number; branchId: string }> {
 
     private _idUniqueId: Bimap<number, number> = new Bimap<number, number>();
 
-    private _collisions: CollisionManager;
+    collisions: CollisionManager;
 
     error = signal<Error | undefined>(undefined);
 
@@ -108,7 +108,7 @@ class ProjectManager extends Linker<{ projectId: number; branchId: string }> {
         this._relay = relay;
         this._rest = rest;
 
-        this._collisions = new CollisionManager({
+        this.collisions = new CollisionManager({
             files: this._files,
             assetPath: this._assetPath.bind(this),
             assetId: (uniqueId) => this._idUniqueId.getR(uniqueId),
@@ -118,10 +118,6 @@ class ProjectManager extends Linker<{ projectId: number; branchId: string }> {
 
     get files() {
         return this._files;
-    }
-
-    get collisions() {
-        return this._collisions.collisions;
     }
 
     private _assetPath(uniqueId: number, override: { path?: number[]; name?: string } = {}) {
@@ -226,7 +222,7 @@ class ProjectManager extends Linker<{ projectId: number; branchId: string }> {
         const path = this._assetPath(uniqueId);
 
         // check for file path collision
-        const check = this._collisions.check(uniqueId);
+        const check = this.collisions.check(uniqueId);
         if (check.skip) {
             return check;
         }
@@ -292,7 +288,7 @@ class ProjectManager extends Linker<{ projectId: number; branchId: string }> {
         }
 
         // check for file path collision
-        const check = this._collisions.check(uniqueId);
+        const check = this.collisions.check(uniqueId);
         if (check.skip) {
             return check;
         }
@@ -540,7 +536,7 @@ class ProjectManager extends Linker<{ projectId: number; branchId: string }> {
 
             // show any path collisions if found
             if (skipsDirty) {
-                this._collisions.refresh();
+                this.collisions.refresh();
             }
         });
         const assetDeleteHandle = this._messenger.on('assets.delete', async ({ data: { assets } }) => {
@@ -583,7 +579,7 @@ class ProjectManager extends Linker<{ projectId: number; branchId: string }> {
                 }
 
                 // check if collisions updated
-                if (this._collisions.remove(uniqueId)) {
+                if (this.collisions.remove(uniqueId)) {
                     skipsDirty = true;
                 }
 
@@ -614,7 +610,7 @@ class ProjectManager extends Linker<{ projectId: number; branchId: string }> {
 
             // update collisions if any were modified
             if (skipsDirty) {
-                this._collisions.refresh();
+                this.collisions.refresh();
             }
         });
         return () => {
@@ -643,7 +639,7 @@ class ProjectManager extends Linker<{ projectId: number; branchId: string }> {
                     let skipsDirty = false;
 
                     // check if new path will be a collision
-                    if (this._collisions.check(uniqueId, { [key]: after }).skip) {
+                    if (this.collisions.check(uniqueId, { [key]: after }).skip) {
                         skipsDirty = true;
 
                         // collect paths to remove (don't modify map during iteration)
@@ -661,7 +657,7 @@ class ProjectManager extends Linker<{ projectId: number; branchId: string }> {
                             this._events.emit('asset:file:delete', path);
                         }
 
-                        this._collisions.refresh();
+                        this.collisions.refresh();
                         break;
                     }
 
@@ -681,13 +677,13 @@ class ProjectManager extends Linker<{ projectId: number; branchId: string }> {
                         this._files.set(newPath, file);
 
                         // check if collisions updated
-                        if (this._collisions.remove(file.uniqueId)) {
+                        if (this.collisions.remove(file.uniqueId)) {
                             skipsDirty = true;
                         }
                     }
 
                     // check if collisions updated
-                    if (this._collisions.remove(uniqueId)) {
+                    if (this.collisions.remove(uniqueId)) {
                         skipsDirty = true;
                     }
 
@@ -697,7 +693,7 @@ class ProjectManager extends Linker<{ projectId: number; branchId: string }> {
 
                     // show collisions if dirty
                     if (skipsDirty) {
-                        this._collisions.refresh();
+                        this.collisions.refresh();
                     }
                     break;
                 }
@@ -1172,10 +1168,6 @@ class ProjectManager extends Linker<{ projectId: number; branchId: string }> {
         return file?.uniqueId === uniqueId;
     }
 
-    collided() {
-        return this._collisions.snapshot();
-    }
-
     async link({ projectId, branchId }: { projectId: number; branchId: string }) {
         if (this._projectId !== undefined) {
             throw this.error.set(() => new Error('project already linked'));
@@ -1196,7 +1188,7 @@ class ProjectManager extends Linker<{ projectId: number; branchId: string }> {
             this._files.clear();
             this._assets.clear();
             this._idUniqueId.clear();
-            this._collisions.clear();
+            this.collisions.clear();
         }
 
         // fetch project asset metadata
@@ -1371,7 +1363,7 @@ class ProjectManager extends Linker<{ projectId: number; branchId: string }> {
 
         // show collisions if dirty
         if (skipsDirty) {
-            this._collisions.refresh();
+            this.collisions.refresh();
         }
 
         // watchers
@@ -1398,7 +1390,7 @@ class ProjectManager extends Linker<{ projectId: number; branchId: string }> {
             this._files.clear();
             this._assets.clear();
             this._idUniqueId.clear();
-            this._collisions.clear();
+            this.collisions.clear();
         });
 
         this._projectId = projectId;

--- a/src/project-manager.ts
+++ b/src/project-manager.ts
@@ -46,18 +46,11 @@ type VirtualFile = {
 );
 
 class ProjectManager extends Linker<{ projectId: number; branchId: string }> {
-    private static readonly MAX_RETRIES = 5;
-
-    private static readonly DOC_RETRY_MS = 1000;
+    private static readonly SAVE_MAX_RETRIES = 5;
 
     private static readonly SAVE_RETRY_DELAY_MS = 2 * 1000;
 
     private static readonly FLUSH_TIMEOUT_MS = 5 * 1000;
-
-    // increments on each link/unlink cycle so stale retries can bail out
-    private _epoch = 0;
-
-    private _pendingDocRetries = new Set<number>();
 
     private _pendingSaveRetries = new Map<number, NodeJS.Timeout>();
 
@@ -308,55 +301,6 @@ class ProjectManager extends Linker<{ projectId: number; branchId: string }> {
         return { skip: false, changed: false };
     }
 
-    private async _retrySubscription(type: string, uniqueId: number, epoch: number) {
-        // skip if already retrying this uniqueId
-        if (this._pendingDocRetries.has(uniqueId)) {
-            return undefined;
-        }
-        this._pendingDocRetries.add(uniqueId);
-
-        let doc: Doc | undefined;
-        let cancelled = false;
-        for (let attempt = 1; attempt <= ProjectManager.MAX_RETRIES; attempt++) {
-            const delay = ProjectManager.DOC_RETRY_MS * Math.pow(2, attempt - 1);
-            this._log.debug(`retrying subscription to ${type} ${uniqueId} in ${delay}ms (attempt ${attempt})`);
-            await new Promise<void>((r) => setTimeout(r, delay));
-
-            if (this._epoch !== epoch) {
-                cancelled = true;
-                break;
-            }
-
-            // re-open documents on the server before resubscribing
-            if (type === 'documents') {
-                await this._sharedb.sendRaw(`doc:reconnect:${uniqueId}`);
-            }
-
-            doc = await this._sharedb.resubscribe(type, `${uniqueId}`);
-
-            if (this._epoch !== epoch) {
-                if (doc) {
-                    doc.destroy();
-                }
-                doc = undefined;
-                cancelled = true;
-                break;
-            }
-
-            if (doc) {
-                break;
-            }
-        }
-
-        this._pendingDocRetries.delete(uniqueId);
-
-        if (!doc && !cancelled) {
-            const kind = type === 'assets' ? 'asset' : 'document';
-            this._log.error(`giving up subscribing to ${kind} ${uniqueId} after ${ProjectManager.MAX_RETRIES} retries`);
-        }
-        return doc;
-    }
-
     private _retrySave(uniqueId: number) {
         // skip if already retrying this doc
         if (this._pendingSaveRetries.has(uniqueId)) {
@@ -365,8 +309,8 @@ class ProjectManager extends Linker<{ projectId: number; branchId: string }> {
 
         // enforce retry limit
         const attempt = (this._saveRetryCounts.get(uniqueId) ?? 0) + 1;
-        if (attempt > ProjectManager.MAX_RETRIES) {
-            this._log.error(`giving up saving document ${uniqueId} after ${ProjectManager.MAX_RETRIES} retries`);
+        if (attempt > ProjectManager.SAVE_MAX_RETRIES) {
+            this._log.error(`giving up saving document ${uniqueId} after ${ProjectManager.SAVE_MAX_RETRIES} retries`);
             this._saveRetryCounts.delete(uniqueId);
             return;
         }
@@ -506,13 +450,10 @@ class ProjectManager extends Linker<{ projectId: number; branchId: string }> {
                 }
 
                 // subscribe to asset document
-                let doc2 = await this._sharedb.subscribe('documents', `${uniqueId}`);
+                const doc2 = await this._sharedb.subscribe('documents', `${uniqueId}`);
                 if (!doc2) {
-                    this._log.warn(`failed to subscribe to new document ${uniqueId}, scheduling retry`);
-                    doc2 = await this._retrySubscription('documents', uniqueId, this._epoch);
-                    if (!doc2) {
-                        return;
-                    }
+                    this._log.error(`failed to subscribe to new document ${uniqueId}`);
+                    return;
                 }
 
                 // check if asset was deleted during doc subscribe
@@ -1173,13 +1114,10 @@ class ProjectManager extends Linker<{ projectId: number; branchId: string }> {
             throw this.error.set(() => new Error('project already linked'));
         }
 
-        const epoch = ++this._epoch;
-
         // clean up partial state from a previously failed link attempt
         if (this._cleanup.length > 0) {
             await Promise.allSettled(this._cleanup.map((fn) => fn()));
             this._cleanup.length = 0;
-            this._pendingDocRetries.clear();
             for (const timeout of this._pendingSaveRetries.values()) {
                 clearTimeout(timeout);
             }
@@ -1209,7 +1147,6 @@ class ProjectManager extends Linker<{ projectId: number; branchId: string }> {
 
         // subscribe to all assets in batches
         const ordered: { uniqueId: number; data: Record<string, unknown> }[] = [];
-        const failed: number[] = [];
         for (let i = 0; i < assets.length; i += BATCH_SIZE) {
             const batch = assets.slice(i, i + BATCH_SIZE);
             const subscriptions: [string, string][] = batch.map((asset) => ['assets', `${asset.uniqueId}`]);
@@ -1221,7 +1158,7 @@ class ProjectManager extends Linker<{ projectId: number; branchId: string }> {
                 const doc = docs[j];
                 const uniqueId = batch[j].uniqueId;
                 if (!doc) {
-                    failed.push(uniqueId);
+                    this._log.error(`failed to subscribe to asset ${uniqueId}`);
                     loadAssetNext();
                     continue;
                 }
@@ -1234,19 +1171,6 @@ class ProjectManager extends Linker<{ projectId: number; branchId: string }> {
 
                 loadAssetNext();
             }
-        }
-
-        // retry failed asset subscriptions individually
-        for (const uniqueId of failed) {
-            const doc = await this._retrySubscription('assets', uniqueId, epoch);
-            if (!doc) {
-                continue;
-            }
-            this._cleanup.push(async () => {
-                await this._sharedb.unsubscribe('assets', `${uniqueId}`);
-            });
-            this._addAsset(uniqueId, doc);
-            ordered.push({ uniqueId, data: doc.data });
         }
 
         // split folder and files
@@ -1310,7 +1234,7 @@ class ProjectManager extends Linker<{ projectId: number; branchId: string }> {
         folders0.sort(sortByPathDepth);
         files0.sort(sortByPathDepth);
 
-        // drop assets whose parent chain is broken (subscription failed even after retries)
+        // drop assets whose parent chain is broken
         const reachable = (a: (typeof ordered)[0]) => {
             const depth = getDepth(a.uniqueId);
             if (depth === Infinity) {
@@ -1342,15 +1266,12 @@ class ProjectManager extends Linker<{ projectId: number; branchId: string }> {
                 await this._sharedb.bulkUnsubscribe(subscriptions);
             });
             for (let j = 0; j < docs.length; j++) {
-                let doc = docs[j];
+                const doc = docs[j];
                 const { uniqueId } = batch[j];
                 if (!doc) {
-                    this._log.warn(`failed to subscribe to document ${uniqueId}, scheduling retry`);
-                    doc = await this._retrySubscription('documents', uniqueId, epoch);
-                    if (!doc) {
-                        loadFileNext();
-                        continue;
-                    }
+                    this._log.error(`failed to subscribe to document ${uniqueId}`);
+                    loadFileNext();
+                    continue;
                 }
 
                 // add file to file system
@@ -1377,9 +1298,6 @@ class ProjectManager extends Linker<{ projectId: number; branchId: string }> {
             unwatchSharedb();
             unwatchMessenger();
 
-            // cancel pending retries (in-flight retries check _epoch and bail out)
-            this._pendingDocRetries.clear();
-
             // cancel pending save retries
             for (const timeout of this._pendingSaveRetries.values()) {
                 clearTimeout(timeout);
@@ -1405,7 +1323,6 @@ class ProjectManager extends Linker<{ projectId: number; branchId: string }> {
         if (projectId === undefined || branchId === undefined) {
             throw this.error.set(() => new Error('unlink called before link'));
         }
-        this._epoch++;
         await this._flush();
         await super.unlink();
         this._projectId = undefined;

--- a/src/project-manager.ts
+++ b/src/project-manager.ts
@@ -1,6 +1,6 @@
 import type { Doc } from 'sharedb';
 
-import { CollisionTracker } from './collision-tracker';
+import { CollisionManager } from './collision-manager';
 import { EVENT_TIMEOUT_MS } from './connections/constants';
 import type { Messenger } from './connections/messenger';
 import type { Relay } from './connections/relay';
@@ -83,9 +83,7 @@ class ProjectManager extends Linker<{ projectId: number; branchId: string }> {
 
     private _idUniqueId: Bimap<number, number> = new Bimap<number, number>();
 
-    private _collisions: CollisionTracker;
-
-    collisions = signal<number>(0);
+    private _collisions: CollisionManager;
 
     error = signal<Error | undefined>(undefined);
 
@@ -109,17 +107,21 @@ class ProjectManager extends Linker<{ projectId: number; branchId: string }> {
         this._messenger = messenger;
         this._relay = relay;
         this._rest = rest;
-        this._collisions = new CollisionTracker({
+
+        this._collisions = new CollisionManager({
             files: this._files,
-            assetPath: (uniqueId, override) => this._assetPath(uniqueId, override),
+            assetPath: this._assetPath.bind(this),
             assetId: (uniqueId) => this._idUniqueId.getR(uniqueId),
             log: this._log
         });
-        this.collisions = this._collisions.collisions;
     }
 
     get files() {
         return this._files;
+    }
+
+    get collisions() {
+        return this._collisions.collisions;
     }
 
     private _assetPath(uniqueId: number, override: { path?: number[]; name?: string } = {}) {

--- a/src/project-manager.ts
+++ b/src/project-manager.ts
@@ -1083,6 +1083,9 @@ class ProjectManager extends Linker<{ projectId: number; branchId: string }> {
             throw this.error.set(() => new Error('project already linked'));
         }
 
+        // drain stale cleanup from a previously failed link
+        await super.unlink();
+
         // fetch project asset metadata
         const assets = await guard(this._rest.projectAssets(projectId, branchId, 'codeeditor'), this.error);
 

--- a/src/project-manager.ts
+++ b/src/project-manager.ts
@@ -299,12 +299,10 @@ class ProjectManager extends Linker<{ projectId: number; branchId: string }> {
         return { skip: false, changed: false };
     }
 
-    private _verifySave(state: string, uniqueId: number) {
+    private _verifySave(state: 'success' | 'error', uniqueId: number) {
         if (state === 'success') {
             const entry = this._saveRetries.get(uniqueId);
-            if (entry?.timeout) {
-                clearTimeout(entry.timeout);
-            }
+            clearTimeout(entry?.timeout);
             this._saveRetries.delete(uniqueId);
             return true;
         }
@@ -1254,7 +1252,7 @@ class ProjectManager extends Linker<{ projectId: number; branchId: string }> {
             unwatchSharedb();
             unwatchMessenger();
 
-            Array.from(this._saveRetries.values()).forEach(({ timeout }) => clearTimeout(timeout));
+            this._saveRetries.forEach(({ timeout }) => clearTimeout(timeout));
             this._saveRetries.clear();
 
             this._files.clear();

--- a/src/project-manager.ts
+++ b/src/project-manager.ts
@@ -52,7 +52,7 @@ class ProjectManager extends Linker<{ projectId: number; branchId: string }> {
 
     private static readonly FLUSH_TIMEOUT_MS = 5 * 1000;
 
-    private _pendingSaveRetries = new Map<number, NodeJS.Timeout>();
+    private _saveRetryTimeouts = new Map<number, NodeJS.Timeout>();
 
     private _saveRetryCounts = new Map<number, number>();
 
@@ -303,7 +303,7 @@ class ProjectManager extends Linker<{ projectId: number; branchId: string }> {
 
     private _retrySave(uniqueId: number) {
         // skip if already retrying this doc
-        if (this._pendingSaveRetries.has(uniqueId)) {
+        if (this._saveRetryTimeouts.has(uniqueId)) {
             return;
         }
 
@@ -317,7 +317,7 @@ class ProjectManager extends Linker<{ projectId: number; branchId: string }> {
         this._saveRetryCounts.set(uniqueId, attempt);
 
         const timeout = setTimeout(async () => {
-            this._pendingSaveRetries.delete(uniqueId);
+            this._saveRetryTimeouts.delete(uniqueId);
 
             // bail out if project was unlinked while waiting
             if (this._projectId === undefined) {
@@ -336,7 +336,7 @@ class ProjectManager extends Linker<{ projectId: number; branchId: string }> {
             this._log.debug(`retried save for document ${uniqueId} (attempt ${attempt})`);
         }, ProjectManager.SAVE_RETRY_DELAY_MS);
 
-        this._pendingSaveRetries.set(uniqueId, timeout);
+        this._saveRetryTimeouts.set(uniqueId, timeout);
     }
 
     private _watchSharedb() {
@@ -353,10 +353,10 @@ class ProjectManager extends Linker<{ projectId: number; branchId: string }> {
             }
 
             // clear retry state on success
-            const pending = this._pendingSaveRetries.get(uniqueId);
+            const pending = this._saveRetryTimeouts.get(uniqueId);
             if (pending) {
                 clearTimeout(pending);
-                this._pendingSaveRetries.delete(uniqueId);
+                this._saveRetryTimeouts.delete(uniqueId);
             }
             this._saveRetryCounts.delete(uniqueId);
 
@@ -1118,10 +1118,10 @@ class ProjectManager extends Linker<{ projectId: number; branchId: string }> {
         if (this._cleanup.length > 0) {
             await Promise.allSettled(this._cleanup.map((fn) => fn()));
             this._cleanup.length = 0;
-            for (const timeout of this._pendingSaveRetries.values()) {
+            for (const timeout of this._saveRetryTimeouts.values()) {
                 clearTimeout(timeout);
             }
-            this._pendingSaveRetries.clear();
+            this._saveRetryTimeouts.clear();
             this._saveRetryCounts.clear();
             this._files.clear();
             this._assets.clear();
@@ -1299,10 +1299,10 @@ class ProjectManager extends Linker<{ projectId: number; branchId: string }> {
             unwatchMessenger();
 
             // cancel pending save retries
-            for (const timeout of this._pendingSaveRetries.values()) {
+            for (const timeout of this._saveRetryTimeouts.values()) {
                 clearTimeout(timeout);
             }
-            this._pendingSaveRetries.clear();
+            this._saveRetryTimeouts.clear();
             this._saveRetryCounts.clear();
 
             this._files.clear();

--- a/src/project-manager.ts
+++ b/src/project-manager.ts
@@ -52,9 +52,7 @@ class ProjectManager extends Linker<{ projectId: number; branchId: string }> {
 
     private static readonly FLUSH_TIMEOUT_MS = 5 * 1000;
 
-    private _saveRetryTimeouts = new Map<number, NodeJS.Timeout>();
-
-    private _saveRetryCounts = new Map<number, number>();
+    private _saveRetries = new Map<number, { timeout?: NodeJS.Timeout; attempt: number }>();
 
     private _events: EventEmitter<EventMap>;
 
@@ -301,23 +299,38 @@ class ProjectManager extends Linker<{ projectId: number; branchId: string }> {
         return { skip: false, changed: false };
     }
 
-    private _retrySave(uniqueId: number) {
+    private _verifySave(state: string, uniqueId: number) {
+        if (state === 'success') {
+            const entry = this._saveRetries.get(uniqueId);
+            if (entry?.timeout) {
+                clearTimeout(entry.timeout);
+            }
+            this._saveRetries.delete(uniqueId);
+            return true;
+        }
+
+        this._log.warn(`failed to save document ${uniqueId}: ${state}`);
+
         // skip if already retrying this doc
-        if (this._saveRetryTimeouts.has(uniqueId)) {
-            return;
+        const entry = this._saveRetries.get(uniqueId);
+        if (entry?.timeout) {
+            return false;
         }
 
         // enforce retry limit
-        const attempt = (this._saveRetryCounts.get(uniqueId) ?? 0) + 1;
+        const attempt = (entry?.attempt ?? 0) + 1;
         if (attempt > ProjectManager.SAVE_MAX_RETRIES) {
             this._log.error(`giving up saving document ${uniqueId} after ${ProjectManager.SAVE_MAX_RETRIES} retries`);
-            this._saveRetryCounts.delete(uniqueId);
-            return;
+            this._saveRetries.delete(uniqueId);
+            return false;
         }
-        this._saveRetryCounts.set(uniqueId, attempt);
 
+        // schedule retry
         const timeout = setTimeout(async () => {
-            this._saveRetryTimeouts.delete(uniqueId);
+            const e = this._saveRetries.get(uniqueId);
+            if (e) {
+                e.timeout = undefined;
+            }
 
             // bail out if project was unlinked while waiting
             if (this._projectId === undefined) {
@@ -336,34 +349,21 @@ class ProjectManager extends Linker<{ projectId: number; branchId: string }> {
             this._log.debug(`retried save for document ${uniqueId} (attempt ${attempt})`);
         }, ProjectManager.SAVE_RETRY_DELAY_MS);
 
-        this._saveRetryTimeouts.set(uniqueId, timeout);
+        this._saveRetries.set(uniqueId, { timeout, attempt });
+        return false;
     }
 
     private _watchSharedb() {
         const docSaveHandle = this._sharedb.on('doc:save', (state, uniqueId) => {
-            // skip if asset was deleted while save was in-flight
             if (!this._assets.has(uniqueId)) {
                 return;
             }
 
-            if (state !== 'success') {
-                this._log.warn(`failed to save document ${uniqueId}: ${state}`);
-                this._retrySave(uniqueId);
+            if (!this._verifySave(state, uniqueId)) {
                 return;
             }
 
-            // clear retry state on success
-            const pending = this._saveRetryTimeouts.get(uniqueId);
-            if (pending) {
-                clearTimeout(pending);
-                this._saveRetryTimeouts.delete(uniqueId);
-            }
-            this._saveRetryCounts.delete(uniqueId);
-
-            // find file by uniqueId
             const path = this._assetPath(uniqueId);
-
-            // check if file exists
             const file = this._files.get(path);
             if (!file || file.type !== 'file') {
                 return;
@@ -714,21 +714,7 @@ class ProjectManager extends Linker<{ projectId: number; branchId: string }> {
         }
 
         this._log.info(`flushing ${pending.length} pending ops before unlink`);
-        const waits = pending.map(
-            (f) =>
-                new Promise<void>((resolve) => {
-                    if (!f.doc.pending) {
-                        resolve();
-                        return;
-                    }
-                    const done = () => resolve();
-                    f.doc.once('nothing pending', done);
-                    if (!f.doc.pending) {
-                        f.doc.off('nothing pending', done);
-                        resolve();
-                    }
-                })
-        );
+        const waits = pending.map((f) => new Promise<void>((resolve) => f.doc.whenNothingPending(resolve)));
         const [err] = await tryCatch(
             withTimeout(Promise.all(waits), ProjectManager.FLUSH_TIMEOUT_MS, 'flush pending ops timed out')
         );
@@ -1070,25 +1056,10 @@ class ProjectManager extends Linker<{ projectId: number; branchId: string }> {
         // wait for pending ops to be acknowledged before saving,
         // matching the Code Editor's behavior (save.ts:144-150).
         // prevents saving stale content while ops are in-flight.
-        let sent = false;
-        const send = () => {
-            if (sent) {
-                return;
-            }
-            sent = true;
+        file.doc.whenNothingPending(() => {
             this._sharedb.sendRaw(`doc:save:${file.uniqueId}`);
             this._log.debug(`saved file ${path}`);
-        };
-        if (file.doc.pending) {
-            file.doc.once('nothing pending', send);
-            // re-check: event may have fired between pending and once()
-            if (!file.doc.pending) {
-                file.doc.off('nothing pending', send);
-                send();
-            }
-        } else {
-            send();
-        }
+        });
     }
 
     path(assetId: number) {
@@ -1112,21 +1083,6 @@ class ProjectManager extends Linker<{ projectId: number; branchId: string }> {
     async link({ projectId, branchId }: { projectId: number; branchId: string }) {
         if (this._projectId !== undefined) {
             throw this.error.set(() => new Error('project already linked'));
-        }
-
-        // clean up partial state from a previously failed link attempt
-        if (this._cleanup.length > 0) {
-            await Promise.allSettled(this._cleanup.map((fn) => fn()));
-            this._cleanup.length = 0;
-            for (const timeout of this._saveRetryTimeouts.values()) {
-                clearTimeout(timeout);
-            }
-            this._saveRetryTimeouts.clear();
-            this._saveRetryCounts.clear();
-            this._files.clear();
-            this._assets.clear();
-            this._idUniqueId.clear();
-            this.collisions.clear();
         }
 
         // fetch project asset metadata
@@ -1298,16 +1254,13 @@ class ProjectManager extends Linker<{ projectId: number; branchId: string }> {
             unwatchSharedb();
             unwatchMessenger();
 
-            // cancel pending save retries
-            for (const timeout of this._saveRetryTimeouts.values()) {
-                clearTimeout(timeout);
-            }
-            this._saveRetryTimeouts.clear();
-            this._saveRetryCounts.clear();
+            Array.from(this._saveRetries.values()).forEach(({ timeout }) => clearTimeout(timeout));
+            this._saveRetries.clear();
 
             this._files.clear();
             this._assets.clear();
             this._idUniqueId.clear();
+
             this.collisions.clear();
         });
 

--- a/src/providers/collab-provider.ts
+++ b/src/providers/collab-provider.ts
@@ -167,6 +167,9 @@ class CollabProvider
             throw this.error.set(() => new Error('manager already linked'));
         }
 
+        // drain stale cleanup from a previously failed link
+        await super.unlink();
+
         const unwatchDocument = this._watchDocument(folderUri, projectManager);
 
         this._cleanup.push(async () => {

--- a/src/providers/dirty-decoration-provider.ts
+++ b/src/providers/dirty-decoration-provider.ts
@@ -62,6 +62,9 @@ class DirtyDecorationProvider
             throw this.error.set(() => new Error('already linked'));
         }
 
+        // drain stale cleanup from a previously failed link
+        await super.unlink();
+
         // listen for dirty transitions
         const onDirty = this._events.on('asset:file:dirty', (path) => this._fire(path));
         const onUpdate = this._events.on('asset:file:update', (path) => this._fire(path));

--- a/src/test/mocks/sharedb.ts
+++ b/src/test/mocks/sharedb.ts
@@ -80,8 +80,8 @@ class Doc implements sharedb.Doc {
         return undefined;
     }
 
-    whenNothingPending(_callback: () => void): void {
-        return undefined;
+    whenNothingPending(callback: () => void): void {
+        callback();
     }
 
     hasPending(): boolean {

--- a/src/utils/ot-document.ts
+++ b/src/utils/ot-document.ts
@@ -10,7 +10,6 @@ const SOURCE = ShareDb.SOURCE;
 
 type OTDocumentEvents = {
     op: [ShareDbTextOp, string];
-    'nothing pending': [];
 };
 
 class OTDocument extends EventEmitter<OTDocumentEvents> {
@@ -31,8 +30,6 @@ class OTDocument extends EventEmitter<OTDocumentEvents> {
             this._text = ottext.apply(this._text, op) as string;
             this.emit('op', op, prev);
         });
-
-        doc.on('nothing pending', () => this.emit('nothing pending'));
     }
 
     get text() {
@@ -48,6 +45,10 @@ class OTDocument extends EventEmitter<OTDocumentEvents> {
 
     get pending() {
         return this._doc.hasPending();
+    }
+
+    whenNothingPending(fn: () => void) {
+        this._doc.whenNothingPending(fn);
     }
 
     get raw() {


### PR DESCRIPTION
## Summary

- Rename `CollisionTracker` → `CollisionManager`, expose directly instead of through a proxy signal
- Remove `_retrySubscription` / `resubscribe` — failed subscriptions log and skip (retry strategy to be revisited separately)
- Consolidate `_retrySave` + inline cleanup into single `_verifySave` method with merged `_saveRetries` map
- Replace manual `nothing pending` event wiring with `OTDocument.whenNothingPending`
- Add `super.unlink()` drain at start of `link()` in all Linker subclasses to clean up partial state from failed links