### PR TITLE
[Feat] Lazy document subscription for faster project loading

### DIFF
--- a/src/disk.ts
+++ b/src/disk.ts
@@ -518,23 +518,31 @@ class Disk extends Linker<{ folderUri: vscode.Uri; projectManager: ProjectManage
             const uri = vscode.Uri.joinPath(folderUri, path);
 
             if (this._opened.has(uri.path)) {
-                // reconcile open buffer with live OT content
+                // reconcile: submit buffer divergence to OT (preserves user edits made before subscribe)
                 await this._writeMutex.atomic([`${uri}`], async () => {
                     this._locks.add(`${uri}`);
                     await tryCatch(async () => {
-                        const doc = await vscode.workspace.openTextDocument(uri);
-                        const current = doc.getText();
-                        if (norm(current) !== norm(content)) {
-                            const { prefix, suffix } = diff(current, content);
-                            const edit = new vscode.WorkspaceEdit();
-                            edit.replace(
-                                uri,
-                                new vscode.Range(doc.positionAt(prefix), doc.positionAt(current.length - suffix)),
-                                content.substring(prefix, content.length - suffix)
-                            );
-                            await vscode.workspace.applyEdit(edit);
+                        const pm = this._projectManager;
+                        if (!pm) {
+                            return;
                         }
-                        this._bufferState.set(uri.path, norm(content));
+                        const file = pm.files.get(path);
+                        if (!file || file.type !== 'file') {
+                            return;
+                        }
+
+                        const doc = await vscode.workspace.openTextDocument(uri);
+                        const bufferText = norm(doc.getText());
+
+                        const userOp = delta(file.doc.text, bufferText);
+                        if (userOp) {
+                            file.doc.apply(userOp);
+                            file.dirty = true;
+                            this._events.emit('asset:file:dirty', path, true);
+                            this._log.info(`subscribe.recovered ${uri}`);
+                        }
+
+                        this._bufferState.set(uri.path, norm(doc.getText()));
                     });
                     this._locks.delete(`${uri}`);
                 });

--- a/src/disk.ts
+++ b/src/disk.ts
@@ -53,6 +53,8 @@ const fileContent = async (uri: vscode.Uri, type: Promise<'file' | 'folder' | un
     return content;
 };
 
+const FETCH_CONCURRENCY = 16;
+
 // Helper function for path matching (checks if paths are related - ancestor/descendant)
 const pathsRelated = (path1: string, path2: string): boolean => {
     if (path1 === path2) {
@@ -119,7 +121,7 @@ class Disk extends Linker<{ folderUri: vscode.Uri; projectManager: ProjectManage
         }
 
         const file = pm.files.get(Disk.IGNORE_FILE);
-        const text = deleted ? '' : file?.type === 'file' ? (file.doc.text ?? '') : '';
+        const text = deleted ? '' : file?.type === 'file' ? file.doc.text : '';
         const h = hash(text);
         if (h === this._ignoreHash) {
             return;
@@ -512,12 +514,61 @@ class Disk extends Linker<{ folderUri: vscode.Uri; projectManager: ProjectManage
             this._checkIgnoreUpdated(uri);
             await this._save(uri);
         });
+        const assetFileSubscribed = this._events.on('asset:file:subscribed', async (path, content, dirty) => {
+            const uri = vscode.Uri.joinPath(folderUri, path);
+
+            if (this._opened.has(uri.path)) {
+                // reconcile open buffer with live OT content
+                await this._writeMutex.atomic([`${uri}`], async () => {
+                    this._locks.add(`${uri}`);
+                    await tryCatch(async () => {
+                        const doc = await vscode.workspace.openTextDocument(uri);
+                        const current = doc.getText();
+                        if (norm(current) !== norm(content)) {
+                            const { prefix, suffix } = diff(current, content);
+                            const edit = new vscode.WorkspaceEdit();
+                            edit.replace(
+                                uri,
+                                new vscode.Range(doc.positionAt(prefix), doc.positionAt(current.length - suffix)),
+                                content.substring(prefix, content.length - suffix)
+                            );
+                            await vscode.workspace.applyEdit(edit);
+                        }
+                        this._bufferState.set(uri.path, norm(content));
+                    });
+                    this._locks.delete(`${uri}`);
+                });
+            } else {
+                // sync to disk for closed files
+                const buf = buffer.from(norm(content));
+                const key = `${uri}`;
+                this._syncing.add(key);
+                void this._debouncer
+                    .debounce(key, async () => {
+                        this._echo.set(`${uri}:change`, hash(buf));
+                        await vscode.workspace.fs.writeFile(uri, buf);
+                        setTimeout(() => this._syncing.delete(key), 200);
+                    })
+                    .catch((err) => {
+                        if (/debounce/.test(err.message)) {
+                            return;
+                        }
+                        this._syncing.delete(key);
+                        this._log.error(`failed to sync subscribed ${uri}: ${err.message}`);
+                    });
+            }
+
+            if (dirty) {
+                this._events.emit('asset:file:dirty', path, true);
+            }
+        });
         return () => {
             this._events.off('asset:file:create', assetFileCreate);
             this._events.off('asset:file:update', assetFileUpdate);
             this._events.off('asset:file:rename', assetFileRename);
             this._events.off('asset:file:delete', assetFileDelete);
             this._events.off('asset:file:save', assetFileSave);
+            this._events.off('asset:file:subscribed', assetFileSubscribed);
         };
     }
 
@@ -765,12 +816,20 @@ class Disk extends Linker<{ folderUri: vscode.Uri; projectManager: ProjectManage
                                     // atomic write pattern: external tools write temp+rename,
                                     // producing create events for existing files — treat as change
                                     const existing = projectManager.files.get(path);
-                                    if (existing && existing.type === 'file' && type === 'file' && content) {
-                                        if (existing.doc.text === norm(buffer.toString(content))) {
+                                    if (
+                                        existing &&
+                                        (existing.type === 'file' || existing.type === 'stub') &&
+                                        type === 'file' &&
+                                        content
+                                    ) {
+                                        if (
+                                            existing.type === 'file' &&
+                                            existing.doc.text === norm(buffer.toString(content))
+                                        ) {
                                             return;
                                         }
                                         this._log.debug(`change.local (atomic) ${op.uri}`);
-                                        projectManager.write(path, content);
+                                        await projectManager.write(path, content);
                                         if (this._opened.has(op.uri.path)) {
                                             const doc = vscode.workspace.textDocuments.find(
                                                 (d) => d.uri.path === op.uri.path
@@ -841,7 +900,7 @@ class Disk extends Linker<{ folderUri: vscode.Uri; projectManager: ProjectManage
                                     }
 
                                     this._log.debug(`change.local ${op.uri}`);
-                                    projectManager.write(path, content);
+                                    await projectManager.write(path, content);
 
                                     // dirtify if file was opened while change was deferred
                                     if (this._opened.has(op.uri.path)) {
@@ -930,10 +989,10 @@ class Disk extends Linker<{ folderUri: vscode.Uri; projectManager: ProjectManage
                 return;
             }
 
-            // check if file is in memory and of type file
+            // check if file is in memory (stubs allowed — triggers subscribe on write)
             const path = relativePath(uri, folderUri);
             const file = projectManager.files.get(path);
-            if (!file || file.type !== 'file') {
+            if (!file || file.type === 'folder') {
                 return;
             }
 
@@ -974,7 +1033,7 @@ class Disk extends Linker<{ folderUri: vscode.Uri; projectManager: ProjectManage
             defer({
                 action: 'delete',
                 uri,
-                type: Promise.resolve(file.type)
+                type: Promise.resolve(file.type === 'stub' ? 'file' : file.type)
             });
         });
         return () => {
@@ -996,12 +1055,6 @@ class Disk extends Linker<{ folderUri: vscode.Uri; projectManager: ProjectManage
 
         // read files to disk
         const updatingDiskDone = await simpleNotification('Updating Disk');
-
-        // parse ignore file
-        const file = projectManager.files.get(Disk.IGNORE_FILE);
-        if (file?.type === 'file') {
-            this._parseIgnoreText(file.doc.text, folderUri);
-        }
 
         // sort into hierarchy
         // TODO: store as tree instead of flat map and sorting
@@ -1025,11 +1078,46 @@ class Disk extends Linker<{ folderUri: vscode.Uri; projectManager: ProjectManage
             return 0;
         });
 
-        // add files from project (write ShareDB content to disk)
+        // prefetch REST content for stubs (concurrent with limit)
+        const stubs = ordered.filter(([, f]) => f.type === 'stub');
+        const fetched = new Map<number, Uint8Array>();
+        for (let i = 0; i < stubs.length; i += FETCH_CONCURRENCY) {
+            const batch = stubs.slice(i, i + FETCH_CONCURRENCY);
+            const results = await Promise.all(
+                batch.map(async ([, f]) => {
+                    const [err, buf] = await tryCatch(projectManager.fetchContent(f.uniqueId));
+                    return [f.uniqueId, err ? new Uint8Array() : buf] as const;
+                })
+            );
+            for (const [id, buf] of results) {
+                fetched.set(id, buf);
+            }
+        }
+
+        // write files to disk
         for (const [path, file] of ordered) {
             const uri = vscode.Uri.joinPath(folderUri, path);
-            const content = file.type === 'file' ? buffer.from(file.doc.text) : new Uint8Array();
-            await this._create(uri, file.type, content);
+            let content: Uint8Array;
+            if (file.type === 'file') {
+                content = buffer.from(file.doc.text);
+            } else if (file.type === 'stub') {
+                content = fetched.get(file.uniqueId) ?? new Uint8Array();
+            } else {
+                content = new Uint8Array();
+            }
+            await this._create(uri, file.type === 'folder' ? 'folder' : 'file', content);
+        }
+
+        // parse ignore file (after disk write so stub content is available)
+        const ignoreFile = projectManager.files.get(Disk.IGNORE_FILE);
+        if (ignoreFile?.type === 'file') {
+            this._parseIgnoreText(ignoreFile.doc.text, folderUri);
+        } else if (ignoreFile?.type === 'stub') {
+            const ignoreUri = vscode.Uri.joinPath(folderUri, Disk.IGNORE_FILE);
+            const [, raw] = await tryCatch(vscode.workspace.fs.readFile(ignoreUri) as Promise<Uint8Array>);
+            if (raw) {
+                this._parseIgnoreText(buffer.toString(raw), folderUri);
+            }
         }
 
         // remove old files

--- a/src/project-manager.ts
+++ b/src/project-manager.ts
@@ -16,7 +16,7 @@ import { Deferred } from './utils/deferred';
 import type { EventEmitter } from './utils/event-emitter';
 import { Linker } from './utils/linker';
 import { OTDocument } from './utils/ot-document';
-import { signal } from './utils/signal';
+import { effect, signal } from './utils/signal';
 import { delta, norm } from './utils/text';
 import { hash, parsePath, guard, withTimeout, tryCatch, sanitizeName } from './utils/utils';
 
@@ -79,6 +79,8 @@ class ProjectManager extends Linker<{ projectId: number; branchId: string }> {
     private _idUniqueId: Bimap<number, number> = new Bimap<number, number>();
 
     private _subscribing = new Map<string, Promise<(VirtualFile & { type: 'file' }) | undefined>>();
+
+    private _queued = new Set<string>();
 
     collisions: CollisionManager;
 
@@ -584,6 +586,33 @@ class ProjectManager extends Linker<{ projectId: number; branchId: string }> {
         };
     }
 
+    private _watchReconnect(projectId: number) {
+        return effect(() => {
+            if (!this._sharedb.connected.get()) {
+                return;
+            }
+
+            const paths = Array.from(this._queued);
+            this._queued.clear();
+
+            for (const path of paths) {
+                void this.subscribe(path)
+                    .then((f) => {
+                        if (f && f.type === 'file') {
+                            this._relay.join(`document-${f.uniqueId}`, projectId);
+                            this._cleanup.push(async () => {
+                                this._relay.leave(`document-${f.uniqueId}`, projectId);
+                            });
+                        }
+                    })
+                    .catch((err: Error) => {
+                        this._queued.add(path);
+                        this._log.warn(`reconnect subscribe failed for ${path}: ${err.message}`);
+                    });
+            }
+        });
+    }
+
     private _watchEvents(projectId: number) {
         const assetUpdateHandle = this._events.on('asset:update', async (uniqueId, key, before, after) => {
             switch (true) {
@@ -724,7 +753,8 @@ class ProjectManager extends Linker<{ projectId: number; branchId: string }> {
                     }
                 })
                 .catch((err: Error) => {
-                    this._log.warn(`subscribe failed for ${path}: ${err.message}`);
+                    this._queued.add(path);
+                    this._log.warn(`subscribe failed for ${path}, queued: ${err.message}`);
                 });
         });
         const docCloseHandle = this._events.on('asset:doc:close', (path: string) => {
@@ -1213,6 +1243,8 @@ class ProjectManager extends Linker<{ projectId: number; branchId: string }> {
     }
 
     async unsubscribe(path: string) {
+        this._queued.delete(path);
+
         const file = this._files.get(path);
         if (!file || file.type !== 'file') {
             return;
@@ -1396,12 +1428,14 @@ class ProjectManager extends Linker<{ projectId: number; branchId: string }> {
         const unwatchEvents = this._watchEvents(projectId);
         const unwatchSharedb = this._watchSharedb();
         const unwatchMessenger = this._watchMessenger(branchId);
+        const unwatchReconnect = this._watchReconnect(projectId);
 
         // register cleanup
         this._cleanup.push(async () => {
             unwatchEvents();
             unwatchSharedb();
             unwatchMessenger();
+            unwatchReconnect();
 
             this._saveRetries.forEach(({ timeout }) => clearTimeout(timeout));
             this._saveRetries.clear();
@@ -1410,6 +1444,7 @@ class ProjectManager extends Linker<{ projectId: number; branchId: string }> {
             this._assets.clear();
             this._idUniqueId.clear();
             this._subscribing.clear();
+            this._queued.clear();
 
             this.collisions.clear();
         });

--- a/src/project-manager.ts
+++ b/src/project-manager.ts
@@ -43,6 +43,10 @@ type VirtualFile = {
           doc: OTDocument;
           dirty: boolean; // true if hash(doc.data) != asset.file.hash
       }
+    | {
+          type: 'stub';
+          dirty: boolean; // true dirty state discovered on subscribe
+      }
 );
 
 class ProjectManager extends Linker<{ projectId: number; branchId: string }> {
@@ -73,6 +77,8 @@ class ProjectManager extends Linker<{ projectId: number; branchId: string }> {
     private _files: Map<string, VirtualFile> = new Map<string, VirtualFile>();
 
     private _idUniqueId: Bimap<number, number> = new Bimap<number, number>();
+
+    private _subscribing = new Map<string, Promise<(VirtualFile & { type: 'file' }) | undefined>>();
 
     collisions: CollisionManager;
 
@@ -296,6 +302,26 @@ class ProjectManager extends Linker<{ projectId: number; branchId: string }> {
 
         this._log.debug(`added folder ${path}`);
 
+        return { skip: false, changed: false };
+    }
+
+    private _addStub(uniqueId: number) {
+        const path = this._assetPath(uniqueId);
+
+        const check = this.collisions.check(uniqueId);
+        if (check.skip) {
+            return check;
+        }
+
+        const asset = this._assets.get(uniqueId);
+        if (!asset?.file) {
+            throw this.error.set(() => new Error(`missing file data for asset ${uniqueId}`));
+        }
+
+        this._files.set(path, { type: 'stub', uniqueId, dirty: false });
+        this._events.emit('asset:file:create', path, 'file', new Uint8Array());
+
+        this._log.debug(`added stub ${path}`);
         return { skip: false, changed: false };
     }
 
@@ -535,8 +561,8 @@ class ProjectManager extends Linker<{ projectId: number; branchId: string }> {
                 // prepare asset unsubscribe
                 subscriptions.push(['assets', `${uniqueId}`]);
 
-                // prepare document unsubscribe
-                if (asset.type !== 'folder') {
+                // prepare document unsubscribe (only if actively subscribed)
+                if (asset.type !== 'folder' && file?.type === 'file') {
                     subscriptions.push(['documents', `${uniqueId}`]);
                 }
 
@@ -652,14 +678,19 @@ class ProjectManager extends Linker<{ projectId: number; branchId: string }> {
 
                     // check if file exists
                     const file = this._files.get(path);
-                    if (!file || file.type !== 'file') {
+                    if (!file || file.type === 'folder') {
                         return;
                     }
 
-                    // NOTE: only mark clean if local content matches the saved hash,
-                    // NOTE: otherwise local unsaved changes would be silently discarded
-                    const localHash = hash(file.doc.text);
-                    if (fileTo?.hash === localHash) {
+                    if (file.type === 'file') {
+                        // NOTE: only mark clean if local content matches the saved hash,
+                        // NOTE: otherwise local unsaved changes would be silently discarded
+                        const localHash = hash(file.doc.text);
+                        if (fileTo?.hash === localHash) {
+                            file.dirty = false;
+                        }
+                    } else {
+                        // stub: no doc to compare, mark clean on remote save
                         file.dirty = false;
                     }
 
@@ -671,28 +702,41 @@ class ProjectManager extends Linker<{ projectId: number; branchId: string }> {
         });
 
         const docOpenHandle = this._events.on('asset:doc:open', (path: string) => {
-            // wait for file to be available
-            void this.waitForFile(path, 'file')
-                .then((file) => {
-                    // join relay room
-                    this._relay.join(`document-${file.uniqueId}`, projectId);
-                    this._cleanup.push(async () => {
-                        this._relay.leave(`document-${file.uniqueId}`, projectId);
-                    });
+            const file = this._files.get(path);
+            if (!file) {
+                return;
+            }
+
+            const p =
+                file.type === 'stub'
+                    ? this.subscribe(path)
+                    : file.type === 'file'
+                      ? Promise.resolve(file)
+                      : Promise.resolve(undefined);
+
+            void p
+                .then((f) => {
+                    if (f && f.type === 'file') {
+                        this._relay.join(`document-${f.uniqueId}`, projectId);
+                        this._cleanup.push(async () => {
+                            this._relay.leave(`document-${f.uniqueId}`, projectId);
+                        });
+                    }
                 })
                 .catch((err: Error) => {
-                    this._log.warn(`waitForFile failed for ${path}: ${err.message}`);
+                    this._log.warn(`subscribe failed for ${path}: ${err.message}`);
                 });
         });
         const docCloseHandle = this._events.on('asset:doc:close', (path: string) => {
-            // check if in project
             const file = this._files.get(path);
             if (!file || file.type !== 'file') {
                 return;
             }
 
-            // leave relay room
             this._relay.leave(`document-${file.uniqueId}`, projectId);
+            void this.unsubscribe(path).catch((err: Error) => {
+                this._log.warn(`unsubscribe failed for ${path}: ${err.message}`);
+            });
         });
 
         return () => {
@@ -1013,10 +1057,22 @@ class ProjectManager extends Linker<{ projectId: number; branchId: string }> {
         this._log.debug(`moved ${oldPath} to ${newPath}`);
     }
 
-    write(path: string, content: Uint8Array) {
-        // check if file is in memory
-        const file = this._files.get(path);
-        if (!file || file.type !== 'file') {
+    async write(path: string, content: Uint8Array) {
+        let file = this._files.get(path);
+        if (!file || file.type === 'folder') {
+            return;
+        }
+
+        // subscribe stub before writing
+        if (file.type === 'stub') {
+            const promoted = await this.subscribe(path);
+            if (!promoted) {
+                return;
+            }
+            file = promoted;
+        }
+
+        if (file.type !== 'file') {
             return;
         }
 
@@ -1076,6 +1132,115 @@ class ProjectManager extends Linker<{ projectId: number; branchId: string }> {
         const path = this._assetPath(uniqueId);
         const file = this._files.get(path);
         return file?.uniqueId === uniqueId;
+    }
+
+    async subscribe(path: string) {
+        const file = this._files.get(path);
+        if (!file) {
+            return undefined;
+        }
+
+        // already subscribed
+        if (file.type === 'file') {
+            return file;
+        }
+
+        if (file.type !== 'stub') {
+            return undefined;
+        }
+
+        // coalesce concurrent subscribe calls for the same path
+        const inflight = this._subscribing.get(path);
+        if (inflight) {
+            return inflight;
+        }
+
+        const pending = this._doSubscribe(path, file.uniqueId);
+        this._subscribing.set(path, pending);
+        const result = await pending;
+        this._subscribing.delete(path);
+        return result;
+    }
+
+    private async _doSubscribe(path: string, uniqueId: number) {
+        const doc = await this._sharedb.subscribe('documents', `${uniqueId}`);
+        if (!doc) {
+            this._log.error(`failed to subscribe to document ${uniqueId}`);
+            return undefined;
+        }
+
+        // null data after hard reset — clean up and skip until reload
+        if (doc.data === null) {
+            await this._sharedb.unsubscribe('documents', `${uniqueId}`);
+            this._log.debug(`subscribe skipped ${path} (null data, pending reload)`);
+            return undefined;
+        }
+
+        this._cleanup.push(async () => {
+            await this._sharedb.unsubscribe('documents', `${uniqueId}`);
+        });
+
+        const otdoc = new OTDocument(doc);
+        const asset = this._assets.get(uniqueId);
+        if (!asset?.file) {
+            throw this.error.set(() => new Error(`missing file data for asset ${uniqueId}`));
+        }
+        const dirty = hash(otdoc.text) !== asset.file.hash;
+
+        const promoted: VirtualFile & { type: 'file' } = {
+            type: 'file',
+            uniqueId,
+            doc: otdoc,
+            dirty
+        };
+        this._files.set(path, promoted);
+
+        // wire op handler (same as _addFile)
+        otdoc.on('op', (op, prev) => {
+            const p = this._assetPath(uniqueId);
+            const a = this._assets.get(uniqueId);
+            const d = a?.file?.hash !== hash(otdoc.text);
+            promoted.dirty = d;
+            this._events.emit('asset:file:update', p, op as ShareDbTextOp, otdoc.text, prev);
+            if (!d) {
+                this._events.emit('asset:file:save', p);
+            }
+        });
+
+        this._events.emit('asset:file:subscribed', path, otdoc.text, dirty);
+        this._log.debug(`subscribed ${path} (${dirty ? 'dirty' : 'clean'})`);
+        return promoted;
+    }
+
+    async unsubscribe(path: string) {
+        const file = this._files.get(path);
+        if (!file || file.type !== 'file') {
+            return;
+        }
+
+        if (file.doc.pending) {
+            this._log.debug(`skipping unsubscribe of ${path} (pending ops)`);
+            return;
+        }
+
+        const uniqueId = file.uniqueId;
+        await this._sharedb.unsubscribe('documents', `${uniqueId}`);
+        this._sharedb.sendRaw(`close:document:${uniqueId}`);
+        this._files.set(path, { type: 'stub', uniqueId, dirty: file.dirty });
+        this._log.debug(`unsubscribed ${path}`);
+    }
+
+    async fetchContent(uniqueId: number) {
+        const asset = this._assets.get(uniqueId);
+        if (!asset?.file?.filename || !this._branchId) {
+            return new Uint8Array();
+        }
+        const id = this._idUniqueId.getR(uniqueId);
+        if (!id) {
+            return new Uint8Array();
+        }
+        const buf = await this._rest.assetFile(id, this._branchId, asset.file.filename);
+        return new Uint8Array(buf);
     }
 
     async link({ projectId, branchId }: { projectId: number; branchId: string }) {
@@ -1214,29 +1379,12 @@ class ProjectManager extends Linker<{ projectId: number; branchId: string }> {
             loadFileNext();
         }
 
-        // add all files next in batches
-        for (let i = 0; i < files.length; i += BATCH_SIZE) {
-            const batch = files.slice(i, i + BATCH_SIZE);
-            const subscriptions: [string, string][] = batch.map((asset) => ['documents', `${asset.uniqueId}`]);
-            const docs = await this._sharedb.bulkSubscribe(subscriptions);
-            this._cleanup.push(async () => {
-                await this._sharedb.bulkUnsubscribe(subscriptions);
-            });
-            for (let j = 0; j < docs.length; j++) {
-                const doc = docs[j];
-                const { uniqueId } = batch[j];
-                if (!doc) {
-                    this._log.error(`failed to subscribe to document ${uniqueId}`);
-                    loadFileNext();
-                    continue;
-                }
-
-                // add file to file system
-                if (this._addFile(uniqueId, doc).changed) {
-                    skipsDirty = true;
-                }
-                loadFileNext();
+        // add file stubs (lazy — document subscribed on open)
+        for (const asset of files) {
+            if (this._addStub(asset.uniqueId).changed) {
+                skipsDirty = true;
             }
+            loadFileNext();
         }
 
         // show collisions if dirty
@@ -1261,6 +1409,7 @@ class ProjectManager extends Linker<{ projectId: number; branchId: string }> {
             this._files.clear();
             this._assets.clear();
             this._idUniqueId.clear();
+            this._subscribing.clear();
 
             this.collisions.clear();
         });

--- a/src/test/mocks/rest.ts
+++ b/src/test/mocks/rest.ts
@@ -41,6 +41,8 @@ class MockRest extends Rest {
 
     assetRename: sinon.SinonSpy<[number, string, number, string], Promise<Asset>>;
 
+    assetFile: sinon.SinonSpy<[number, string, string], Promise<ArrayBuffer>>;
+
     constructor(sandbox: sinon.SinonSandbox, messenger: MockMessenger, sharedb: MockShareDb) {
         super({
             url: '',
@@ -139,6 +141,10 @@ class MockRest extends Rest {
             }
 
             return asset;
+        });
+        this.assetFile = sandbox.spy(async (assetId: number, _branchId: string, _filename: string) => {
+            const content = documents.get(assetId) ?? '';
+            return new TextEncoder().encode(content).buffer;
         });
     }
 }

--- a/src/typings/event-map.d.ts
+++ b/src/typings/event-map.d.ts
@@ -11,6 +11,7 @@ export type EventMap = {
     'asset:file:rename': [string, string];
     'asset:file:save': [string];
     'asset:file:dirty': [string, boolean];
+    'asset:file:subscribed': [string, string, boolean];
 
     'asset:doc:open': [string];
     'asset:doc:close': [string];


### PR DESCRIPTION
Fixes #177
Fixes #181

### What's Changed

- Subscribe to ShareDB documents on demand (file open or external edit) instead of eagerly on project load
- Asset metadata subscriptions remain eager for file tree, collision detection, path resolution
- Stub entries in the virtual file system represent unsubscribed files; REST/S3 content fetched for disk sync on load
- Failed subscribes queued and retried on reconnect
- User edits made before subscribe completes are preserved and submitted to OT (not overwritten)

### Alignment with online IDE

| Feature | Online Editor | VS Code Extension | Match |
|---------|--------------|-------------------|-------|
| Subscribe trigger | `select:asset` → `loadDocument()` | `asset:doc:open` → `subscribe()` | ✅ |
| Unsubscribe trigger | `documents:close` → `unsubscribe` + `destroy` | `asset:doc:close` → `unsubscribe()` | ✅ |
| `close:document` message | `connection.socket.send(...)` | `sharedb.sendRaw(...)` | ✅ |
| Queued loads (disconnected) | `queuedLoad` map | `_queued` set | ✅ |
| Retry on reconnect | `realtime:authenticated` handler | `effect()` on `connected` signal | ✅ |
| Re-queue on retry failure | Implicit (entry stays) | Explicit (`.catch` re-adds) | ✅ |
| Remove from queue on close | `delete queuedLoad[id]` | `_queued.delete(path)` | ✅ |
| Dirty check after load | Compare `doc.data` with REST content | Compare `hash(otdoc.text)` vs `asset.file.hash` | ✅ |
| Pause on disconnect | `doc.pause()` all open docs | `doc.pause()` all subscribed docs | ✅ |
| Resume on reconnect | `doc.subscribe()` + `doc.resume()` | `doc.subscribe()` + `doc.resume()` | ✅ |
| Per-document error tracking | `entry.error` + read-only mode | Not implemented (UX enhancement) | ❌ |
| ESM dependency auto-load | Parse `.mjs` imports → load deps | Not implemented (Monaco-specific) | ❌ |