### PR TITLE
[Fix] Resolve collaborators not loading on initial script open

### DIFF
--- a/src/project-manager.ts
+++ b/src/project-manager.ts
@@ -795,41 +795,6 @@ class ProjectManager extends Linker<{ projectId: number; branchId: string }> {
         }
     }
 
-    async waitForFile(path: string, type: 'file' | 'folder') {
-        // check if file already exists
-        const file = this._files.get(path);
-        if (file && file.type === type) {
-            return file;
-        }
-
-        // creation promise
-        let oncreate: ((uniqueId: number) => void) | undefined;
-        const pending = new Promise<VirtualFile>((resolve) => {
-            oncreate = (uniqueId: number) => {
-                const assetPath = this._assetPath(uniqueId);
-                if (assetPath === path) {
-                    const file = this._files.get(path);
-                    if (!file || file.type !== type) {
-                        return;
-                    }
-                    this._events.off('asset:create', oncreate!);
-                    resolve(file);
-                }
-            };
-            this._events.on('asset:create', oncreate);
-        });
-        const [err, value] = await tryCatch(
-            withTimeout(pending, EVENT_TIMEOUT_MS, `waitForFile timed out for ${path}`)
-        );
-        if (err) {
-            if (oncreate) {
-                this._events.off('asset:create', oncreate);
-            }
-            throw err;
-        }
-        return value!;
-    }
-
     async create(path: string, type: 'folder' | 'file', content?: Uint8Array) {
         if (!this._projectId || !this._branchId) {
             throw this.error.set(() => new Error('project not loaded'));

--- a/src/providers/collab-provider.ts
+++ b/src/providers/collab-provider.ts
@@ -75,22 +75,15 @@ class CollabProvider
 
     private _watchDocument(folderUri: vscode.Uri, projectManager: ProjectManager) {
         const switchRoom = (uri: vscode.Uri) => {
-            // check if in folder
             if (!uriStartsWith(uri, folderUri)) {
                 return;
             }
-
-            // wait for file to be available
             const path = relativePath(uri, folderUri);
-            void projectManager
-                .waitForFile(path, 'file')
-                .then((file) => {
-                    // set room
-                    this._room = `document-${file.uniqueId}`;
-                    this.refresh();
-                })
-                // eslint-disable-next-line @typescript-eslint/no-empty-function
-                .catch(() => {});
+            const file = projectManager.files.get(path);
+            if (file && file.type !== 'folder') {
+                this._room = `document-${file.uniqueId}`;
+                this.refresh();
+            }
         };
         const disposable = vscode.window.onDidChangeActiveTextEditor((editor) => {
             if (!editor) {


### PR DESCRIPTION
### What's Changed

- `switchRoom()` in `CollabProvider` used `waitForFile(path, 'file')` which waits for an `asset:create` event. With lazy subscription, stubs are promoted via `subscribe()` which emits `asset:file:subscribed` — not `asset:create`. This caused a silent 30s timeout, leaving `_room` unset and the collaborators panel empty until the user switched tabs.
- Replaced the async `waitForFile` call with a synchronous `projectManager.files.get()` lookup. All `VirtualFile` types (file, stub, folder) carry `uniqueId`, which is all `switchRoom` needs to build the relay room name.
- Removed the now-unused `waitForFile` method from `ProjectManager`.