### PR TITLE
[Fix] Allow deleting stub files from VS Code

### DIFF
--- a/src/project-manager.ts
+++ b/src/project-manager.ts
@@ -899,7 +899,7 @@ class ProjectManager extends Linker<{ projectId: number; branchId: string }> {
     async delete(path: string, type: 'file' | 'folder') {
         // check if file exists
         const file = this._files.get(path);
-        if (!file || file.type !== type) {
+        if (!file || (file.type === 'stub' ? 'file' : file.type) !== type) {
             this._log.warn(`skipping delete of ${path} as it does not exist`);
             return;
         }


### PR DESCRIPTION
## Summary

- Normalize stub type to `'file'` in `ProjectManager.delete()` type check so unopened lazily-subscribed files can be deleted from the extension

## Root Cause

Lazy document subscription (`2a6b16b`) stores unopened files as stubs with `type: 'stub'` in `_files`. When deleting, `disk.ts` correctly converts stub → `'file'` before calling `projectManager.delete(path, 'file')`, but project-manager re-reads from `_files` and checks `file.type !== type` — which is `'stub' !== 'file'` — skipping the delete entirely.

## Test plan

- [x] Open a project with lazy-loaded (unopened) files
- [x] Delete an unopened file from the VS Code explorer
- [x] Confirm the file is removed from the online IDE
- [x] Confirm deleting opened files still works as before