### PR TITLE
[Fix] Collaborative undo/redo only reverts local edits

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,6 +77,33 @@
             {
                 "command": "playcanvas.showPathCollisions",
                 "title": "PlayCanvas: Show Path Collisions"
+            },
+            {
+                "command": "playcanvas.undo",
+                "title": "PlayCanvas: Undo"
+            },
+            {
+                "command": "playcanvas.redo",
+                "title": "PlayCanvas: Redo"
+            }
+        ],
+        "keybindings": [
+            {
+                "command": "playcanvas.undo",
+                "key": "ctrl+z",
+                "mac": "cmd+z",
+                "when": "playcanvas.isCollabFile && textInputFocus && !editorReadonly"
+            },
+            {
+                "command": "playcanvas.redo",
+                "key": "ctrl+shift+z",
+                "mac": "cmd+shift+z",
+                "when": "playcanvas.isCollabFile && textInputFocus && !editorReadonly"
+            },
+            {
+                "command": "playcanvas.redo",
+                "key": "ctrl+y",
+                "when": "playcanvas.isCollabFile && textInputFocus && !editorReadonly && !isMac"
             }
         ],
         "typescriptServerPlugins": [

--- a/package.json
+++ b/package.json
@@ -92,18 +92,18 @@
                 "command": "playcanvas.undo",
                 "key": "ctrl+z",
                 "mac": "cmd+z",
-                "when": "playcanvas.isCollabFile && textInputFocus && !editorReadonly"
+                "when": "playcanvas.active && textInputFocus && !editorReadonly"
             },
             {
                 "command": "playcanvas.redo",
                 "key": "ctrl+shift+z",
                 "mac": "cmd+shift+z",
-                "when": "playcanvas.isCollabFile && textInputFocus && !editorReadonly"
+                "when": "playcanvas.active && textInputFocus && !editorReadonly"
             },
             {
                 "command": "playcanvas.redo",
                 "key": "ctrl+y",
-                "when": "playcanvas.isCollabFile && textInputFocus && !editorReadonly && !isMac"
+                "when": "playcanvas.active && textInputFocus && !editorReadonly && !isMac"
             }
         ],
         "typescriptServerPlugins": [

--- a/src/disk.ts
+++ b/src/disk.ts
@@ -593,7 +593,7 @@ class Disk extends Linker<{ folderUri: vscode.Uri; projectManager: ProjectManage
         // track active editor to gate keybindings
         const updateCtx = (e?: vscode.TextEditor) => {
             const collab = e && uriStartsWith(e.document.uri, folderUri);
-            vscode.commands.executeCommand('setContext', 'playcanvas.isCollabFile', !!collab);
+            vscode.commands.executeCommand('setContext', 'playcanvas.active', !!collab);
         };
         updateCtx(vscode.window.activeTextEditor);
         const onEditor = vscode.window.onDidChangeActiveTextEditor(updateCtx);
@@ -713,7 +713,7 @@ class Disk extends Linker<{ folderUri: vscode.Uri; projectManager: ProjectManage
             onEditor.dispose();
             undoCmd.dispose();
             redoCmd.dispose();
-            vscode.commands.executeCommand('setContext', 'playcanvas.isCollabFile', false);
+            vscode.commands.executeCommand('setContext', 'playcanvas.active', false);
         };
     }
 
@@ -1351,7 +1351,7 @@ class Disk extends Linker<{ folderUri: vscode.Uri; projectManager: ProjectManage
         this._bufferState.clear();
         this._undos.forEach((m) => m.clear());
         this._undos.clear();
-        vscode.commands.executeCommand('setContext', 'playcanvas.isCollabFile', false);
+        vscode.commands.executeCommand('setContext', 'playcanvas.active', false);
         this._log.info(`unlinked from ${folderUri.toString()}`);
         return { folderUri, projectManager };
     }

--- a/src/disk.ts
+++ b/src/disk.ts
@@ -7,6 +7,7 @@ import { simpleNotification } from './notification';
 import type { ProjectManager } from './project-manager';
 import type { EventMap } from './typings/event-map';
 import type { ShareDbTextOp } from './typings/sharedb';
+import { UndoManager } from './undo-manager';
 import * as buffer from './utils/buffer';
 import { Debouncer } from './utils/debouncer';
 import type { EventEmitter } from './utils/event-emitter';
@@ -91,6 +92,8 @@ class Disk extends Linker<{ folderUri: vscode.Uri; projectManager: ProjectManage
     private _saving = new Set<string>();
 
     private _bufferState = new Map<string, string>();
+
+    private _undos = new Map<string, UndoManager>();
 
     private _readMutex = new Mutex<void>(pathsRelated, (err) => this._log.warn('readMutex error', err));
 
@@ -275,6 +278,12 @@ class Disk extends Linker<{ folderUri: vscode.Uri; projectManager: ProjectManage
 
                 this._log.debug(`change.remote.closed ${uri} ${stat(op)}`);
                 return;
+            }
+
+            // transform undo/redo stacks against the remote op (OT-space)
+            const mgr = this._undos.get(uri.path);
+            if (mgr) {
+                mgr.xform(op);
             }
 
             // update editor if file is open
@@ -580,6 +589,134 @@ class Disk extends Linker<{ folderUri: vscode.Uri; projectManager: ProjectManage
         };
     }
 
+    private _watchUndoRedo(folderUri: vscode.Uri, projectManager: ProjectManager) {
+        // track active editor to gate keybindings
+        const updateCtx = (e?: vscode.TextEditor) => {
+            const collab = e && uriStartsWith(e.document.uri, folderUri);
+            vscode.commands.executeCommand('setContext', 'playcanvas.isCollabFile', !!collab);
+        };
+        updateCtx(vscode.window.activeTextEditor);
+        const onEditor = vscode.window.onDidChangeActiveTextEditor(updateCtx);
+
+        // shared apply logic for undo/redo — op pop + apply are atomic inside mutex
+        const applyOp = async (
+            op: ShareDbTextOp,
+            uri: vscode.Uri,
+            path: string,
+            file: { doc: { text: string; apply: (op: ShareDbTextOp) => void }; dirty: boolean }
+        ) => {
+            this._locks.add(`${uri}`);
+            await tryCatch(async () => {
+                // capture pre-apply canonical text for correct buffer-space delta
+                const pre = file.doc.text;
+
+                // apply to OT canonical state (submits to ShareDB)
+                file.doc.apply(op);
+
+                // apply visual edit to buffer
+                const doc = await vscode.workspace.openTextDocument(uri);
+                const raw = doc.getText();
+                const buf = norm(raw);
+                // delta from pre-apply canonical to buffer gives true user divergence
+                const userOp = delta(pre, buf);
+                const bufOp = userOp ? (ottext.transform(op, userOp, 'right') as ShareDbTextOp) : op;
+                const edit = sharedb2vscode(doc, uri, [bufOp], buf);
+                await vscode.workspace.applyEdit(edit);
+
+                // reconcile: recover keystrokes typed during applyEdit await
+                const postText = norm(doc.getText());
+                const expected = ottext.apply(buf, bufOp) as string;
+                this._bufferState.set(uri.path, postText);
+
+                const late = delta(expected, postText);
+                if (late) {
+                    const adv = delta(expected, file.doc.text);
+                    const adjusted = adv ? (ottext.transform(late, adv, 'left') as ShareDbTextOp) : late;
+                    file.doc.apply(adjusted);
+                }
+
+                // cursor: position after the buffer-space op's primary edit
+                const active = vscode.window.activeTextEditor;
+                if (active && active.document.uri.toString() === uri.toString()) {
+                    let cursor = 0;
+                    if (bufOp.length === 1) {
+                        if (typeof bufOp[0] === 'string') {
+                            cursor = bufOp[0].length;
+                        }
+                    } else if (bufOp.length > 1 && typeof bufOp[0] === 'number') {
+                        cursor = bufOp[0];
+                        if (typeof bufOp[1] === 'string') {
+                            cursor += bufOp[1].length;
+                        }
+                    }
+                    const pos = doc.positionAt(cursor);
+                    active.selection = new vscode.Selection(pos, pos);
+                }
+
+                // mark dirty
+                const wasDirty = file.dirty;
+                file.dirty = true;
+                if (!wasDirty) {
+                    this._events.emit('asset:file:dirty', path, true);
+                }
+            });
+            this._locks.delete(`${uri}`);
+        };
+
+        const undoCmd = vscode.commands.registerCommand(`${NAME}.undo`, async () => {
+            const editor = vscode.window.activeTextEditor;
+            if (!editor) {
+                return;
+            }
+            const uri = editor.document.uri;
+            const path = relativePath(uri, folderUri);
+            const mgr = this._undos.get(uri.path);
+            const file = projectManager.files.get(path);
+            if (!mgr?.canUndo || !file || file.type !== 'file') {
+                return;
+            }
+
+            // pop + apply inside mutex to prevent race with concurrent _update
+            await this._writeMutex.atomic([`${uri}`], async () => {
+                const op = mgr.undo(file.doc.text);
+                if (!op) {
+                    return;
+                }
+                await applyOp(op, uri, path, file);
+            });
+        });
+
+        const redoCmd = vscode.commands.registerCommand(`${NAME}.redo`, async () => {
+            const editor = vscode.window.activeTextEditor;
+            if (!editor) {
+                return;
+            }
+            const uri = editor.document.uri;
+            const path = relativePath(uri, folderUri);
+            const mgr = this._undos.get(uri.path);
+            const file = projectManager.files.get(path);
+            if (!mgr?.canRedo || !file || file.type !== 'file') {
+                return;
+            }
+
+            // pop + apply inside mutex to prevent race with concurrent _update
+            await this._writeMutex.atomic([`${uri}`], async () => {
+                const op = mgr.redo(file.doc.text);
+                if (!op) {
+                    return;
+                }
+                await applyOp(op, uri, path, file);
+            });
+        });
+
+        return () => {
+            onEditor.dispose();
+            undoCmd.dispose();
+            redoCmd.dispose();
+            vscode.commands.executeCommand('setContext', 'playcanvas.isCollabFile', false);
+        };
+    }
+
     private _watchDocument(folderUri: vscode.Uri, projectManager: ProjectManager) {
         for (const open of vscode.workspace.textDocuments) {
             if (!uriStartsWith(open.uri, folderUri)) {
@@ -587,6 +724,7 @@ class Disk extends Linker<{ folderUri: vscode.Uri; projectManager: ProjectManage
             }
             const path = relativePath(open.uri, folderUri);
             this._opened.add(open.uri.path);
+            this._undos.set(open.uri.path, new UndoManager());
             this._events.emit('asset:doc:open', path);
             this._dirtify(open);
         }
@@ -596,6 +734,7 @@ class Disk extends Linker<{ folderUri: vscode.Uri; projectManager: ProjectManage
             }
             const path = relativePath(document.uri, folderUri);
             this._opened.add(document.uri.path);
+            this._undos.set(document.uri.path, new UndoManager());
             this._diskHash.set(document.uri.path, hash(norm(document.getText())));
             this._events.emit('asset:doc:open', path);
             this._dirtify(document);
@@ -606,6 +745,8 @@ class Disk extends Linker<{ folderUri: vscode.Uri; projectManager: ProjectManage
             }
             const path = relativePath(document.uri, folderUri);
             this._opened.delete(document.uri.path);
+            this._undos.get(document.uri.path)?.clear();
+            this._undos.delete(document.uri.path);
             this._diskHash.delete(document.uri.path);
             this._saving.delete(document.uri.path);
             this._bufferState.delete(document.uri.path);
@@ -650,7 +791,33 @@ class Disk extends Linker<{ folderUri: vscode.Uri; projectManager: ProjectManage
 
             // submit ops via OTDocument (applies locally + submits to ShareDB)
             const ops = vscode2sharedb(document, contentChanges, file.doc.text);
+            const mgr = this._undos.get(document.uri.path);
             for (const op of ops) {
+                // push inverse to undo stack for local edits
+                // (undo/redo apply under _locks, so they never reach here)
+                if (mgr) {
+                    const snap = file.doc.text;
+                    const inv = ottext.semanticInvert(snap, op) as ShareDbTextOp;
+                    // detect whitespace/newline from inserted text in the forward op
+                    let ins = '';
+                    for (const c of op) {
+                        if (typeof c === 'string') {
+                            ins += c;
+                        }
+                    }
+                    const hasDel = op.some((c) => typeof c === 'object');
+                    const ws = !hasDel && /^ +$/.test(ins);
+                    const nl = !hasDel && /^\n+$/.test(ins);
+                    // line number from op offset
+                    const off = typeof op[0] === 'number' ? op[0] : 0;
+                    let line = 0;
+                    for (let i = 0; i < off && i < snap.length; i++) {
+                        if (snap[i] === '\n') {
+                            line++;
+                        }
+                    }
+                    mgr.push(inv, ws, nl, line);
+                }
                 file.doc.apply(op);
             }
 
@@ -1141,16 +1308,20 @@ class Disk extends Linker<{ folderUri: vscode.Uri; projectManager: ProjectManage
         const unwatchEvents = this._watchEvents(folderUri);
         const unwatchDocument = this._watchDocument(folderUri, projectManager);
         const unwatchDisk = this._watchDisk(folderUri, projectManager);
+        const unwatchUndoRedo = this._watchUndoRedo(folderUri, projectManager);
 
         // register cleanup
         this._cleanup.push(async () => {
             unwatchEvents();
             unwatchDocument();
             unwatchDisk();
+            unwatchUndoRedo();
 
             this._echo.clear();
             this._syncing.clear();
             this._saving.clear();
+            this._undos.forEach((m) => m.clear());
+            this._undos.clear();
             await this._readMutex.clear();
             await this._writeMutex.clear();
             this._debouncer.clear();
@@ -1178,6 +1349,9 @@ class Disk extends Linker<{ folderUri: vscode.Uri; projectManager: ProjectManage
         this._folderUri = undefined;
         this._projectManager = undefined;
         this._bufferState.clear();
+        this._undos.forEach((m) => m.clear());
+        this._undos.clear();
+        vscode.commands.executeCommand('setContext', 'playcanvas.isCollabFile', false);
         this._log.info(`unlinked from ${folderUri.toString()}`);
         return { folderUri, projectManager };
     }

--- a/src/disk.ts
+++ b/src/disk.ts
@@ -283,7 +283,7 @@ class Disk extends Linker<{ folderUri: vscode.Uri; projectManager: ProjectManage
             // transform undo/redo stacks against the remote op (OT-space)
             const mgr = this._undos.get(uri.path);
             if (mgr) {
-                mgr.xform(op);
+                mgr.transform(op);
             }
 
             // update editor if file is open

--- a/src/test/suite/extension.test.ts
+++ b/src/test/suite/extension.test.ts
@@ -2262,4 +2262,169 @@ suite('extension', () => {
 
         assert.ok(sharedb.sendRaw.called, 'local redelete should propagate to remote');
     });
+
+    test('undo reverts local edit', async () => {
+        const folderUri = vscode.workspace.workspaceFolders?.[0]?.uri;
+        assert.ok(folderUri, 'workspace folder should exist');
+
+        const asset = await assetCreate({ name: 'undo_local.js', content: '// ORIGINAL' });
+        assert.ok(asset, 'asset should be created');
+
+        const uri = vscode.Uri.joinPath(folderUri, asset.name);
+        const tdoc = await vscode.workspace.openTextDocument(uri);
+        await vscode.window.showTextDocument(tdoc);
+        await assertResolves(
+            new Promise<void>((resolve) => {
+                if (!tdoc.isDirty && tdoc.getText() === '// ORIGINAL') {
+                    resolve();
+                    return;
+                }
+                const disposable = vscode.workspace.onDidChangeTextDocument((e) => {
+                    if (e.document.uri.toString() !== uri.toString()) {
+                        return;
+                    }
+                    if (!tdoc.isDirty && tdoc.getText() === '// ORIGINAL') {
+                        disposable.dispose();
+                        resolve();
+                    }
+                });
+            }),
+            'initial document settle'
+        );
+
+        // local edit: insert at start
+        const localOp = assertOpsPromise(`documents:${asset.uniqueId}`, [['// LOCAL\n']]);
+        const edit = new vscode.WorkspaceEdit();
+        edit.insert(uri, new vscode.Position(0, 0), '// LOCAL\n');
+        await vscode.workspace.applyEdit(edit);
+        await assertResolves(localOp, 'local op');
+        assert.strictEqual(tdoc.getText(), '// LOCAL\n// ORIGINAL');
+
+        // undo
+        const undoOp = assertOpsPromise(`documents:${asset.uniqueId}`, [[{ d: 10 }]]);
+        await vscode.commands.executeCommand('playcanvas.undo');
+        await assertResolves(undoOp, 'undo op');
+
+        assert.strictEqual(tdoc.getText(), '// ORIGINAL', 'buffer should revert to original');
+        assert.strictEqual(documents.get(asset.uniqueId), '// ORIGINAL', 'OT doc should match');
+    });
+
+    test('redo re-applies undone edit', async () => {
+        const folderUri = vscode.workspace.workspaceFolders?.[0]?.uri;
+        assert.ok(folderUri, 'workspace folder should exist');
+
+        const asset = await assetCreate({ name: 'redo_local.js', content: '// ORIGINAL' });
+        assert.ok(asset, 'asset should be created');
+
+        const uri = vscode.Uri.joinPath(folderUri, asset.name);
+        const tdoc = await vscode.workspace.openTextDocument(uri);
+        await vscode.window.showTextDocument(tdoc);
+        await assertResolves(
+            new Promise<void>((resolve) => {
+                if (!tdoc.isDirty && tdoc.getText() === '// ORIGINAL') {
+                    resolve();
+                    return;
+                }
+                const disposable = vscode.workspace.onDidChangeTextDocument((e) => {
+                    if (e.document.uri.toString() !== uri.toString()) {
+                        return;
+                    }
+                    if (!tdoc.isDirty && tdoc.getText() === '// ORIGINAL') {
+                        disposable.dispose();
+                        resolve();
+                    }
+                });
+            }),
+            'initial document settle'
+        );
+
+        // local edit
+        const localOp = assertOpsPromise(`documents:${asset.uniqueId}`, [['// LOCAL\n']]);
+        const edit = new vscode.WorkspaceEdit();
+        edit.insert(uri, new vscode.Position(0, 0), '// LOCAL\n');
+        await vscode.workspace.applyEdit(edit);
+        await assertResolves(localOp, 'local op');
+
+        // undo
+        const undoOp = assertOpsPromise(`documents:${asset.uniqueId}`, [[{ d: 10 }]]);
+        await vscode.commands.executeCommand('playcanvas.undo');
+        await assertResolves(undoOp, 'undo op');
+        assert.strictEqual(tdoc.getText(), '// ORIGINAL');
+
+        // redo
+        const redoOp = assertOpsPromise(`documents:${asset.uniqueId}`, [['// LOCAL\n']]);
+        await vscode.commands.executeCommand('playcanvas.redo');
+        await assertResolves(redoOp, 'redo op');
+
+        assert.strictEqual(tdoc.getText(), '// LOCAL\n// ORIGINAL', 'buffer should have local edit again');
+        assert.strictEqual(documents.get(asset.uniqueId), '// LOCAL\n// ORIGINAL', 'OT doc should match');
+    });
+
+    test('undo skips remote edits - only reverts local', async () => {
+        const folderUri = vscode.workspace.workspaceFolders?.[0]?.uri;
+        assert.ok(folderUri, 'workspace folder should exist');
+
+        const asset = await assetCreate({ name: 'undo_skip_remote.js', content: '// ORIGINAL' });
+        assert.ok(asset, 'asset should be created');
+
+        const uri = vscode.Uri.joinPath(folderUri, asset.name);
+        const tdoc = await vscode.workspace.openTextDocument(uri);
+        await vscode.window.showTextDocument(tdoc);
+        await assertResolves(
+            new Promise<void>((resolve) => {
+                if (!tdoc.isDirty && tdoc.getText() === '// ORIGINAL') {
+                    resolve();
+                    return;
+                }
+                const disposable = vscode.workspace.onDidChangeTextDocument((e) => {
+                    if (e.document.uri.toString() !== uri.toString()) {
+                        return;
+                    }
+                    if (!tdoc.isDirty && tdoc.getText() === '// ORIGINAL') {
+                        disposable.dispose();
+                        resolve();
+                    }
+                });
+            }),
+            'initial document settle'
+        );
+
+        // local edit: insert "// LOCAL\n" at start
+        const localOp = assertOpsPromise(`documents:${asset.uniqueId}`, [['// LOCAL\n']]);
+        const edit = new vscode.WorkspaceEdit();
+        edit.insert(uri, new vscode.Position(0, 0), '// LOCAL\n');
+        await vscode.workspace.applyEdit(edit);
+        await assertResolves(localOp, 'local op');
+        assert.strictEqual(tdoc.getText(), '// LOCAL\n// ORIGINAL');
+
+        // remote edit: insert "// REMOTE\n" at start
+        const remoteChanged = new Promise<void>((resolve) => {
+            const disposable = vscode.workspace.onDidChangeTextDocument((e) => {
+                if (e.document.uri.toString() === uri.toString() && tdoc.getText().startsWith('// REMOTE\n')) {
+                    disposable.dispose();
+                    resolve();
+                }
+            });
+        });
+        const doc = sharedb.subscriptions.get(`documents:${asset.uniqueId}`);
+        assert.ok(doc, 'sharedb document should exist');
+        doc.submitOp(['// REMOTE\n'], { source: 'remote' });
+        await assertResolves(remoteChanged, 'remote change applied to buffer');
+        assert.strictEqual(tdoc.getText(), '// REMOTE\n// LOCAL\n// ORIGINAL');
+
+        // undo: should only revert local "// LOCAL\n", preserving remote "// REMOTE\n"
+        const undoChanged = new Promise<void>((resolve) => {
+            const disposable = vscode.workspace.onDidChangeTextDocument((e) => {
+                if (e.document.uri.toString() === uri.toString() && !tdoc.getText().includes('// LOCAL')) {
+                    disposable.dispose();
+                    resolve();
+                }
+            });
+        });
+        await vscode.commands.executeCommand('playcanvas.undo');
+        await assertResolves(undoChanged, 'undo change applied');
+
+        assert.strictEqual(tdoc.getText(), '// REMOTE\n// ORIGINAL', 'remote edit preserved, local reverted');
+        assert.strictEqual(documents.get(asset.uniqueId), '// REMOTE\n// ORIGINAL', 'OT doc should match buffer');
+    });
 });

--- a/src/test/suite/extension.test.ts
+++ b/src/test/suite/extension.test.ts
@@ -2301,9 +2301,16 @@ suite('extension', () => {
         assert.strictEqual(tdoc.getText(), '// LOCAL\n// ORIGINAL');
 
         // undo
-        const undoOp = assertOpsPromise(`documents:${asset.uniqueId}`, [[{ d: 10 }]]);
+        const undoChanged = new Promise<void>((resolve) => {
+            const disposable = vscode.workspace.onDidChangeTextDocument((e) => {
+                if (e.document.uri.toString() === uri.toString() && tdoc.getText() === '// ORIGINAL') {
+                    disposable.dispose();
+                    resolve();
+                }
+            });
+        });
         await vscode.commands.executeCommand('playcanvas.undo');
-        await assertResolves(undoOp, 'undo op');
+        await assertResolves(undoChanged, 'undo change applied');
 
         assert.strictEqual(tdoc.getText(), '// ORIGINAL', 'buffer should revert to original');
         assert.strictEqual(documents.get(asset.uniqueId), '// ORIGINAL', 'OT doc should match');
@@ -2346,15 +2353,29 @@ suite('extension', () => {
         await assertResolves(localOp, 'local op');
 
         // undo
-        const undoOp = assertOpsPromise(`documents:${asset.uniqueId}`, [[{ d: 10 }]]);
+        const undoChanged = new Promise<void>((resolve) => {
+            const disposable = vscode.workspace.onDidChangeTextDocument((e) => {
+                if (e.document.uri.toString() === uri.toString() && tdoc.getText() === '// ORIGINAL') {
+                    disposable.dispose();
+                    resolve();
+                }
+            });
+        });
         await vscode.commands.executeCommand('playcanvas.undo');
-        await assertResolves(undoOp, 'undo op');
+        await assertResolves(undoChanged, 'undo change applied');
         assert.strictEqual(tdoc.getText(), '// ORIGINAL');
 
         // redo
-        const redoOp = assertOpsPromise(`documents:${asset.uniqueId}`, [['// LOCAL\n']]);
+        const redoChanged = new Promise<void>((resolve) => {
+            const disposable = vscode.workspace.onDidChangeTextDocument((e) => {
+                if (e.document.uri.toString() === uri.toString() && tdoc.getText() === '// LOCAL\n// ORIGINAL') {
+                    disposable.dispose();
+                    resolve();
+                }
+            });
+        });
         await vscode.commands.executeCommand('playcanvas.redo');
-        await assertResolves(redoOp, 'redo op');
+        await assertResolves(redoChanged, 'redo change applied');
 
         assert.strictEqual(tdoc.getText(), '// LOCAL\n// ORIGINAL', 'buffer should have local edit again');
         assert.strictEqual(documents.get(asset.uniqueId), '// LOCAL\n// ORIGINAL', 'OT doc should match');

--- a/src/typings/ot-text.d.ts
+++ b/src/typings/ot-text.d.ts
@@ -1,4 +1,6 @@
 declare module 'ot-text' {
     // eslint-disable-next-line @typescript-eslint/consistent-type-imports
-    export const type: import('sharedb/lib/sharedb.js').Type;
+    export const type: import('sharedb/lib/sharedb.js').Type & {
+        semanticInvert(str: string, op: unknown[]): unknown[];
+    };
 }

--- a/src/undo-manager.ts
+++ b/src/undo-manager.ts
@@ -1,0 +1,170 @@
+import { type as ottext } from 'ot-text';
+
+import type { ShareDbTextOp } from './typings/sharedb';
+
+const MAX_SIZE = 200;
+const MERGE_DELAY = 2000;
+
+type Entry = { op: ShareDbTextOp; time: number; ws: boolean; nl: boolean };
+
+// check if op is a no-op (empty or zero-delete)
+const noop = (op: ShareDbTextOp) =>
+    op.length === 0 || (op.length === 1 && typeof op[0] === 'object' && (op[0] as { d: number }).d === 0);
+
+class UndoManager {
+    private _undo: Entry[] = [];
+
+    private _redo: Entry[] = [];
+
+    private _prevLine: number | null = null;
+
+    private _line: number | null = null;
+
+    private _force = false;
+
+    private _timer: ReturnType<typeof setTimeout> | null = null;
+
+    // push inverse op to undo stack (mirrors editor addToHistory)
+    push(inv: ShareDbTextOp, ws: boolean, nl: boolean, line: number) {
+        this._prevLine = this._line;
+        this._line = line;
+
+        const entry: Entry = { op: inv, time: Date.now(), ws, nl };
+        const prev = this._undo[this._undo.length - 1];
+        const elapsed = prev ? entry.time - prev.time : Infinity;
+
+        if ((elapsed <= MERGE_DELAY || this._force) && prev && this._canConcat(prev, entry)) {
+            // compose(newer, older): apply newer inverse first, then older
+            prev.op = ottext.compose(entry.op, prev.op) as ShareDbTextOp;
+            if (!ws) {
+                prev.ws = false;
+                prev.nl = false;
+            } else if (nl) {
+                prev.nl = true;
+            }
+        } else {
+            this._undo.push(entry);
+            if (this._undo.length > MAX_SIZE) {
+                this._undo.shift();
+            }
+        }
+
+        this._redo.length = 0;
+        this._setForce();
+    }
+
+    // transform all stack entries against remote op (mirrors editor transformStacks)
+    xform(remote: ShareDbTextOp) {
+        const initial = remote;
+        let r = remote;
+
+        let i = this._undo.length;
+        while (i--) {
+            const e = this._undo[i];
+            const old = e.op;
+            e.op = ottext.transform(e.op, r, 'left') as ShareDbTextOp;
+            if (noop(e.op)) {
+                this._undo.splice(i, 1);
+            } else {
+                r = ottext.transform(r, old, 'right') as ShareDbTextOp;
+            }
+        }
+
+        r = initial;
+        i = this._redo.length;
+        while (i--) {
+            const e = this._redo[i];
+            const old = e.op;
+            e.op = ottext.transform(e.op, r, 'left') as ShareDbTextOp;
+            if (noop(e.op)) {
+                this._redo.splice(i, 1);
+            } else {
+                r = ottext.transform(r, old, 'right') as ShareDbTextOp;
+            }
+        }
+    }
+
+    // pop undo, compute redo counterpart, return op to apply
+    undo(snapshot: string) {
+        const e = this._undo.pop();
+        if (!e) {
+            return null;
+        }
+        const inv = ottext.semanticInvert(snapshot, e.op) as ShareDbTextOp;
+        this._redo.push({ op: inv, time: e.time, ws: e.ws, nl: e.nl });
+        return e.op;
+    }
+
+    // pop redo, compute undo counterpart, return op to apply
+    redo(snapshot: string) {
+        const e = this._redo.pop();
+        if (!e) {
+            return null;
+        }
+        const inv = ottext.semanticInvert(snapshot, e.op) as ShareDbTextOp;
+        this._undo.push({ op: inv, time: e.time, ws: e.ws, nl: e.nl });
+        return e.op;
+    }
+
+    get canUndo() {
+        return this._undo.length > 0;
+    }
+
+    get canRedo() {
+        return this._redo.length > 0;
+    }
+
+    clear() {
+        this._undo.length = 0;
+        this._redo.length = 0;
+        this._prevLine = null;
+        this._line = null;
+        if (this._timer !== null) {
+            clearTimeout(this._timer);
+            this._timer = null;
+        }
+        this._force = false;
+    }
+
+    private _canConcat(prev: Entry, next: Entry) {
+        if (this._force) {
+            return true;
+        }
+        if (prev.op.length === 0 || next.op.length === 0) {
+            return true;
+        }
+
+        const pd = prev.op.some((c) => typeof c === 'object');
+        const nd = next.op.some((c) => typeof c === 'object');
+        if (pd !== nd) {
+            return false;
+        }
+        if (next.ws && !prev.ws) {
+            return false;
+        }
+
+        if (this._line !== this._prevLine) {
+            if (prev.ws && !prev.nl) {
+                return false;
+            }
+            if (!next.ws && !prev.ws) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private _setForce() {
+        this._force = true;
+        if (this._timer !== null) {
+            clearTimeout(this._timer);
+        }
+        this._timer = setTimeout(() => {
+            this._force = false;
+            this._timer = null;
+        });
+    }
+}
+
+export { UndoManager };

--- a/src/undo-manager.ts
+++ b/src/undo-manager.ts
@@ -24,6 +24,54 @@ class UndoManager {
 
     private _timer: ReturnType<typeof setTimeout> | null = null;
 
+    get canUndo() {
+        return this._undo.length > 0;
+    }
+
+    get canRedo() {
+        return this._redo.length > 0;
+    }
+
+    private _canConcat(prev: Entry, next: Entry) {
+        if (this._force) {
+            return true;
+        }
+        if (prev.op.length === 0 || next.op.length === 0) {
+            return true;
+        }
+
+        const pd = prev.op.some((c) => typeof c === 'object');
+        const nd = next.op.some((c) => typeof c === 'object');
+        if (pd !== nd) {
+            return false;
+        }
+        if (next.ws && !prev.ws) {
+            return false;
+        }
+
+        if (this._line !== this._prevLine) {
+            if (prev.ws && !prev.nl) {
+                return false;
+            }
+            if (!next.ws && !prev.ws) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private _setForce() {
+        this._force = true;
+        if (this._timer !== null) {
+            clearTimeout(this._timer);
+        }
+        this._timer = setTimeout(() => {
+            this._force = false;
+            this._timer = null;
+        });
+    }
+
     // push inverse op to undo stack (mirrors editor addToHistory)
     push(inv: ShareDbTextOp, ws: boolean, nl: boolean, line: number) {
         this._prevLine = this._line;
@@ -54,7 +102,7 @@ class UndoManager {
     }
 
     // transform all stack entries against remote op (mirrors editor transformStacks)
-    xform(remote: ShareDbTextOp) {
+    transform(remote: ShareDbTextOp) {
         const initial = remote;
         let r = remote;
 
@@ -106,14 +154,6 @@ class UndoManager {
         return e.op;
     }
 
-    get canUndo() {
-        return this._undo.length > 0;
-    }
-
-    get canRedo() {
-        return this._redo.length > 0;
-    }
-
     clear() {
         this._undo.length = 0;
         this._redo.length = 0;
@@ -124,46 +164,6 @@ class UndoManager {
             this._timer = null;
         }
         this._force = false;
-    }
-
-    private _canConcat(prev: Entry, next: Entry) {
-        if (this._force) {
-            return true;
-        }
-        if (prev.op.length === 0 || next.op.length === 0) {
-            return true;
-        }
-
-        const pd = prev.op.some((c) => typeof c === 'object');
-        const nd = next.op.some((c) => typeof c === 'object');
-        if (pd !== nd) {
-            return false;
-        }
-        if (next.ws && !prev.ws) {
-            return false;
-        }
-
-        if (this._line !== this._prevLine) {
-            if (prev.ws && !prev.nl) {
-                return false;
-            }
-            if (!next.ws && !prev.ws) {
-                return false;
-            }
-        }
-
-        return true;
-    }
-
-    private _setForce() {
-        this._force = true;
-        if (this._timer !== null) {
-            clearTimeout(this._timer);
-        }
-        this._timer = setTimeout(() => {
-            this._force = false;
-            this._timer = null;
-        });
     }
 }
 


### PR DESCRIPTION
Fixes #154
Fixes #158

### What's Changed

- Custom undo/redo system that tracks only the user's own edits, mirroring the online editor's approach (`editor/src/code-editor/monaco/sharedb.ts`)
- Per-document undo/redo stacks store inverse ops; `transformStacks` adjusts positions against incoming remote ops via OT
- Context-gated keybindings (`playcanvas.active`) override Ctrl+Z / Ctrl+Shift+Z for collaborative files only
- Integration tests verify undo reverts local edits, redo re-applies them, and remote edits survive the undo/redo cycle