### PR TITLE
Replace regex-based Sentry grouping with tagged template fingerprinting

### DIFF
--- a/src/connections/relay.ts
+++ b/src/connections/relay.ts
@@ -3,6 +3,7 @@ import WebSocket, { type Data } from 'isomorphic-ws';
 import { WEB } from '../config';
 import { Log } from '../log';
 import { Deferred } from '../utils/deferred';
+import { fail } from '../utils/error';
 import { EventEmitter } from '../utils/event-emitter';
 import { signal } from '../utils/signal';
 import { withTimeout } from '../utils/utils';
@@ -86,7 +87,7 @@ class Relay extends EventEmitter<EventMap> {
             const reason = `[${this.constructor.name}] invalid access token`;
             // TODO: figure out why this triggers 1006 not 3000
             socket.close(3000, reason);
-            this.error.set(() => new Error(reason));
+            this.error.set(() => fail`${reason}`);
         }, 5000);
         socket.addEventListener('open', () => {
             this._log.debug('socket.open');
@@ -114,7 +115,7 @@ class Relay extends EventEmitter<EventMap> {
             }
 
             // reject pending callers then reset
-            this._active.reject(new Error('connection reset'));
+            this._active.reject(fail`connection reset`);
             this._active = new Deferred();
             this.connected.set(() => false);
 
@@ -318,7 +319,7 @@ class Relay extends EventEmitter<EventMap> {
         this._cancelReconnect();
 
         // reject pending callers
-        this._active.reject(new Error('disconnected'));
+        this._active.reject(fail`disconnected`);
         this._active = new Deferred();
 
         // clear auth timeout

--- a/src/connections/rest.ts
+++ b/src/connections/rest.ts
@@ -1,3 +1,4 @@
+import { fail } from '../utils/error';
 import { Log } from '../log';
 import type { Asset, Branch, Project, User } from '../typings/models';
 import { summarize, tryCatch } from '../utils/utils';
@@ -82,7 +83,7 @@ class Rest {
             }
 
             if (this._disposed) {
-                throw new Error('REST client disposed');
+                throw fail`REST client disposed`;
             }
 
             const ctrl = new AbortController();
@@ -114,7 +115,7 @@ class Rest {
             // http error
             if (!res.ok) {
                 const errorBody = await res.text();
-                const error = new Error(`HTTP ${res.status} ${res.statusText}: ${errorBody}`);
+                const error = fail`HTTP ${res.status} ${res.statusText}: ${errorBody}`;
                 if (RETRYABLE_STATUS.has(res.status) && attempt < MAX_RETRIES) {
                     lastError = error;
                     const delay = this._backoff(attempt, this._retryAfter(res));
@@ -133,7 +134,7 @@ class Rest {
             return result;
         }
 
-        throw lastError || new Error(`Request failed after ${MAX_RETRIES} retries`);
+        throw lastError || fail`Request failed after ${MAX_RETRIES} retries`;
     }
 
     async assetCreate(

--- a/src/connections/sharedb.ts
+++ b/src/connections/sharedb.ts
@@ -6,6 +6,7 @@ import type { Socket } from 'sharedb/lib/sharedb.js';
 import { WEB } from '../config';
 import { Log } from '../log';
 import { Deferred } from '../utils/deferred';
+import { fail } from '../utils/error';
 import { EventEmitter } from '../utils/event-emitter';
 import { signal } from '../utils/signal';
 import { tryCatch, withTimeout } from '../utils/utils';
@@ -103,7 +104,7 @@ class ShareDb extends EventEmitter<EventMap> {
                 if (!json.id) {
                     const reason = `[${this.constructor.name}] invalid access token`;
                     socket.close(3000, reason);
-                    this.error.set(() => new Error(reason));
+                    this.error.set(() => fail`${reason}`);
                     return;
                 }
                 this._log.debug('socket.auth', json);
@@ -125,7 +126,7 @@ class ShareDb extends EventEmitter<EventMap> {
             this._log.debug('socket.close', code, reason.toString());
 
             // reject pending callers then reset
-            this._active.reject(new Error('connection reset'));
+            this._active.reject(fail`connection reset`);
             this._active = new Deferred();
             this.connected.set(() => false);
 
@@ -359,7 +360,7 @@ class ShareDb extends EventEmitter<EventMap> {
         this._cancelReconnect();
 
         // reject pending callers
-        this._active.reject(new Error('disconnected'));
+        this._active.reject(fail`disconnected`);
         this._active = new Deferred();
 
         // clear keep alive

--- a/src/disk.ts
+++ b/src/disk.ts
@@ -10,6 +10,7 @@ import type { ShareDbTextOp } from './typings/sharedb';
 import { UndoManager } from './undo-manager';
 import * as buffer from './utils/buffer';
 import { Debouncer } from './utils/debouncer';
+import { fail } from './utils/error';
 import type { EventEmitter } from './utils/event-emitter';
 import { Linker } from './utils/linker';
 import { Mutex } from './utils/mutex';
@@ -199,7 +200,7 @@ class Disk extends Linker<{ folderUri: vscode.Uri; projectManager: ProjectManage
                 if (!(await fileExists(parentUri))) {
                     const folderUri = this._folderUri;
                     if (!folderUri) {
-                        throw this.error.set(() => new Error(`parent folder does not exist: ${parentUri.path}`));
+                        throw this.error.set(() => fail`parent folder does not exist: ${parentUri.path}`);
                     }
                     // set echo for all missing ancestors to prevent disk watcher from re-processing
                     let ancestor = parentUri;
@@ -1222,7 +1223,7 @@ class Disk extends Linker<{ folderUri: vscode.Uri; projectManager: ProjectManage
 
     async link({ folderUri, projectManager }: { folderUri: vscode.Uri; projectManager: ProjectManager }) {
         if (this._folderUri !== undefined) {
-            throw this.error.set(() => new Error('manager already linked'));
+            throw this.error.set(() => fail`manager already linked`);
         }
 
         // drain stale cleanup from a previously failed link
@@ -1343,7 +1344,7 @@ class Disk extends Linker<{ folderUri: vscode.Uri; projectManager: ProjectManage
         const folderUri = this._folderUri;
         const projectManager = this._projectManager;
         if (!folderUri || !projectManager) {
-            throw this.error.set(() => new Error('unlink called before link'));
+            throw this.error.set(() => fail`unlink called before link`);
         }
         await super.unlink();
         this._folderUri = undefined;

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -9,6 +9,7 @@ import { ShareDb } from './connections/sharedb';
 import { Disk } from './disk';
 import { UriHandler } from './handlers/uri-handler';
 import { Log } from './log';
+import { fail } from './utils/error';
 import { Metrics } from './metrics';
 import { simpleNotification } from './notification';
 import { ProjectManager } from './project-manager';
@@ -391,7 +392,7 @@ export const activate = async (context: vscode.ExtensionContext) => {
             const branches = await rest.projectBranches(project_id);
             const main = branches.find((b) => b.permanent);
             if (!main) {
-                throw new Error(`Failed to find main branch to switch to`);
+                throw fail`Failed to find main branch to switch to`;
             }
 
             // checkout main branch
@@ -413,7 +414,7 @@ export const activate = async (context: vscode.ExtensionContext) => {
 
             // check status
             if (status !== 'success') {
-                throw new Error(`Failed to restore to checkpoint ${checkpoint_id}`);
+                throw fail`Failed to restore to checkpoint ${checkpoint_id}`;
             }
 
             // fetch project and disk from cache
@@ -666,7 +667,7 @@ export const activate = async (context: vscode.ExtensionContext) => {
         // load branch info
         const doc = await sharedb.subscribe('settings', `project_${project.id}_${userId}`);
         if (!doc) {
-            void handleError(new Error(`Failed to load project settings for project ${project.id}`));
+            void handleError(fail`Failed to load project settings for project ${project.id}`);
             return;
         }
         context.subscriptions.push(

--- a/src/handlers/uri-handler.ts
+++ b/src/handlers/uri-handler.ts
@@ -3,6 +3,7 @@ import * as vscode from 'vscode';
 import { NAME, PUBLISHER } from '../config';
 import type { Rest } from '../connections/rest';
 import type { ProjectManager } from '../project-manager';
+import { fail } from '../utils/error';
 import { Linker } from '../utils/linker';
 import { signal } from '../utils/signal';
 import { fileExists, projectToName, guard } from '../utils/utils';
@@ -77,7 +78,7 @@ class UriHandler
         // get file path
         const filePath = projectManager.path(assetId);
         if (!filePath) {
-            throw this.error.set(() => new Error(`asset ${assetId} not found in project`));
+            throw this.error.set(() => fail`asset ${assetId} not found in project`);
         }
 
         // check if file is loaded
@@ -212,7 +213,7 @@ class UriHandler
         // find matching project
         const project = projects.find((p) => p.id === projectId);
         if (!project) {
-            this.error.set(() => new Error(`project ${projectId} not found`));
+            this.error.set(() => fail`project ${projectId} not found`);
             return;
         }
 
@@ -244,7 +245,7 @@ class UriHandler
 
     async link({ folderUri, projectManager }: { folderUri: vscode.Uri; projectManager: ProjectManager }) {
         if (this._folderUri !== undefined) {
-            throw this.error.set(() => new Error('manager already linked'));
+            throw this.error.set(() => fail`manager already linked`);
         }
 
         // drain stale cleanup from a previously failed link
@@ -264,7 +265,7 @@ class UriHandler
         const folderUri = this._folderUri;
         const projectManager = this._projectManager;
         if (!folderUri || !projectManager) {
-            throw this.error.set(() => new Error('unlink called before link'));
+            throw this.error.set(() => fail`unlink called before link`);
         }
         await super.unlink();
         this._folderUri = undefined;

--- a/src/project-manager.ts
+++ b/src/project-manager.ts
@@ -13,6 +13,7 @@ import type { ShareDbOp, ShareDbTextOp } from './typings/sharedb';
 import { Bimap } from './utils/bimap';
 import * as buffer from './utils/buffer';
 import { Deferred } from './utils/deferred';
+import { fail } from './utils/error';
 import type { EventEmitter } from './utils/event-emitter';
 import { Linker } from './utils/linker';
 import { OTDocument } from './utils/ot-document';
@@ -122,7 +123,7 @@ class ProjectManager extends Linker<{ projectId: number; branchId: string }> {
     private _assetPath(uniqueId: number, override: { path?: number[]; name?: string } = {}) {
         const asset = this._assets.get(uniqueId);
         if (!asset) {
-            throw this.error.set(() => new Error(`missing child asset ${uniqueId}`));
+            throw this.error.set(() => fail`missing child asset ${uniqueId}`);
         }
 
         const path = override.path ?? asset.path;
@@ -134,11 +135,11 @@ class ProjectManager extends Linker<{ projectId: number; branchId: string }> {
         while (parent) {
             const parentUniqueId = this._idUniqueId.getL(parent);
             if (!parentUniqueId) {
-                throw this.error.set(() => new Error(`missing id mapping for parent asset ${parent}`));
+                throw this.error.set(() => fail`missing id mapping for parent asset ${parent}`);
             }
             const parentAsset = this._assets.get(parentUniqueId);
             if (!parentAsset) {
-                throw this.error.set(() => new Error(`missing parent asset ${parentUniqueId}`));
+                throw this.error.set(() => fail`missing parent asset ${parentUniqueId}`);
             }
             segments.unshift(sanitizeName(parentAsset.name));
 
@@ -237,7 +238,7 @@ class ProjectManager extends Linker<{ projectId: number; branchId: string }> {
 
         const asset = this._assets.get(uniqueId);
         if (!asset?.file) {
-            throw this.error.set(() => new Error(`missing file data for asset ${uniqueId}`));
+            throw this.error.set(() => fail`missing file data for asset ${uniqueId}`);
         }
         const docHash = hash(otdoc.text);
         const s3Hash = asset.file.hash;
@@ -317,7 +318,7 @@ class ProjectManager extends Linker<{ projectId: number; branchId: string }> {
 
         const asset = this._assets.get(uniqueId);
         if (!asset?.file) {
-            throw this.error.set(() => new Error(`missing file data for asset ${uniqueId}`));
+            throw this.error.set(() => fail`missing file data for asset ${uniqueId}`);
         }
 
         this._files.set(path, { type: 'stub', uniqueId, dirty: false });
@@ -427,7 +428,7 @@ class ProjectManager extends Linker<{ projectId: number; branchId: string }> {
             // subscribe to asset document
             const doc1 = await this._sharedb.subscribe('assets', `${uniqueId}`);
             if (!doc1) {
-                this.error.set(() => new Error(`failed to subscribe to new asset ${uniqueId}`));
+                this.error.set(() => fail`failed to subscribe to new asset ${uniqueId}`);
                 return;
             }
 
@@ -797,14 +798,14 @@ class ProjectManager extends Linker<{ projectId: number; branchId: string }> {
 
     async create(path: string, type: 'folder' | 'file', content?: Uint8Array) {
         if (!this._projectId || !this._branchId) {
-            throw this.error.set(() => new Error('project not loaded'));
+            throw this.error.set(() => fail`project not loaded`);
         }
 
         const [parentPath, name] = parsePath(path);
 
         // validate name
         if (!name) {
-            throw this.error.set(() => new Error(`missing name for ${path}`));
+            throw this.error.set(() => fail`missing name for ${path}`);
         }
 
         // check if file already exists
@@ -818,7 +819,7 @@ class ProjectManager extends Linker<{ projectId: number; branchId: string }> {
         if (parentPath !== '') {
             const file = this._files.get(parentPath);
             if (!file || file.type !== 'folder') {
-                throw this.error.set(() => new Error(`missing parent folder ${parentPath} of ${path}`));
+                throw this.error.set(() => fail`missing parent folder ${parentPath} of ${path}`);
             }
             parent = file.uniqueId;
         }
@@ -939,7 +940,7 @@ class ProjectManager extends Linker<{ projectId: number; branchId: string }> {
 
     async rename(oldPath: string, newPath: string) {
         if (!this._projectId || !this._branchId) {
-            throw this.error.set(() => new Error('project not loaded'));
+            throw this.error.set(() => fail`project not loaded`);
         }
 
         // skip if paths are identical
@@ -949,17 +950,17 @@ class ProjectManager extends Linker<{ projectId: number; branchId: string }> {
 
         // check if moving root
         if (oldPath === '') {
-            throw this.error.set(() => new Error('cannot move root folder'));
+            throw this.error.set(() => fail`cannot move root folder`);
         }
 
         // check if src file exists
         if (!this._files.has(oldPath)) {
-            throw this.error.set(() => new Error(`file not found ${oldPath}`));
+            throw this.error.set(() => fail`file not found ${oldPath}`);
         }
 
         // check if dest file already exists
         if (this._files.has(newPath)) {
-            throw this.error.set(() => new Error(`file already exists ${newPath}`));
+            throw this.error.set(() => fail`file already exists ${newPath}`);
         }
 
         // parse old file path
@@ -971,7 +972,7 @@ class ProjectManager extends Linker<{ projectId: number; branchId: string }> {
             // find file to rename
             const file = this._files.get(oldPath);
             if (!file) {
-                throw this.error.set(() => new Error(`file not found ${oldPath}`));
+                throw this.error.set(() => fail`file not found ${oldPath}`);
             }
 
             // file update
@@ -1010,13 +1011,13 @@ class ProjectManager extends Linker<{ projectId: number; branchId: string }> {
         // find src file
         const srcFile = this._files.get(oldPath);
         if (!srcFile) {
-            throw this.error.set(() => new Error(`file not found ${oldPath}`));
+            throw this.error.set(() => fail`file not found ${oldPath}`);
         }
 
         // find dest folder
         const destFile = this._files.get(newParent);
         if (!destFile || destFile.type !== 'folder') {
-            throw this.error.set(() => new Error(`destination folder not found ${newParent}`));
+            throw this.error.set(() => fail`destination folder not found ${newParent}`);
         }
 
         // file updated
@@ -1178,7 +1179,7 @@ class ProjectManager extends Linker<{ projectId: number; branchId: string }> {
         const otdoc = new OTDocument(doc);
         const asset = this._assets.get(uniqueId);
         if (!asset?.file) {
-            throw this.error.set(() => new Error(`missing file data for asset ${uniqueId}`));
+            throw this.error.set(() => fail`missing file data for asset ${uniqueId}`);
         }
         const dirty = hash(otdoc.text) !== asset.file.hash;
 
@@ -1242,7 +1243,7 @@ class ProjectManager extends Linker<{ projectId: number; branchId: string }> {
 
     async link({ projectId, branchId }: { projectId: number; branchId: string }) {
         if (this._projectId !== undefined) {
-            throw this.error.set(() => new Error('project already linked'));
+            throw this.error.set(() => fail`project already linked`);
         }
 
         // drain stale cleanup from a previously failed link
@@ -1253,7 +1254,7 @@ class ProjectManager extends Linker<{ projectId: number; branchId: string }> {
 
         // validate token scope by checking for uniqueId presence
         if (!Array.isArray(assets) || (assets.length > 0 && !('uniqueId' in assets[0]))) {
-            throw this.error.set(() => new Error('invalid access token scope'));
+            throw this.error.set(() => fail`invalid access token scope`);
         }
 
         // add root folder
@@ -1424,7 +1425,7 @@ class ProjectManager extends Linker<{ projectId: number; branchId: string }> {
         const projectId = this._projectId;
         const branchId = this._branchId;
         if (projectId === undefined || branchId === undefined) {
-            throw this.error.set(() => new Error('unlink called before link'));
+            throw this.error.set(() => fail`unlink called before link`);
         }
         await this._flush();
         await super.unlink();

--- a/src/providers/collab-provider.ts
+++ b/src/providers/collab-provider.ts
@@ -4,6 +4,7 @@ import type { Relay } from '../connections/relay';
 import type { Rest } from '../connections/rest';
 import type { ProjectManager } from '../project-manager';
 import * as buffer from '../utils/buffer';
+import { fail } from '../utils/error';
 import { Linker } from '../utils/linker';
 import { signal } from '../utils/signal';
 import { relativePath, uriStartsWith, tryCatch } from '../utils/utils';
@@ -157,7 +158,7 @@ class CollabProvider
 
     async link({ folderUri, projectManager }: { folderUri: vscode.Uri; projectManager: ProjectManager }) {
         if (this._folderUri !== undefined) {
-            throw this.error.set(() => new Error('manager already linked'));
+            throw this.error.set(() => fail`manager already linked`);
         }
 
         // drain stale cleanup from a previously failed link
@@ -181,7 +182,7 @@ class CollabProvider
         const folderUri = this._folderUri;
         const projectManager = this._projectManager;
         if (!folderUri || !projectManager) {
-            throw this.error.set(() => new Error('unlink called before link'));
+            throw this.error.set(() => fail`unlink called before link`);
         }
         await super.unlink();
         this._folderUri = undefined;

--- a/src/providers/dirty-decoration-provider.ts
+++ b/src/providers/dirty-decoration-provider.ts
@@ -3,6 +3,7 @@ import * as vscode from 'vscode';
 import type { ProjectManager } from '../project-manager';
 import type { EventMap } from '../typings/event-map';
 import type { EventEmitter } from '../utils/event-emitter';
+import { fail } from '../utils/error';
 import { Linker } from '../utils/linker';
 import { signal } from '../utils/signal';
 
@@ -59,7 +60,7 @@ class DirtyDecorationProvider
 
     async link({ folderUri, projectManager }: { folderUri: vscode.Uri; projectManager: ProjectManager }) {
         if (this._folderUri !== undefined) {
-            throw this.error.set(() => new Error('already linked'));
+            throw this.error.set(() => fail`already linked`);
         }
 
         // drain stale cleanup from a previously failed link
@@ -109,7 +110,7 @@ class DirtyDecorationProvider
         const folderUri = this._folderUri;
         const projectManager = this._projectManager;
         if (!folderUri || !projectManager) {
-            throw this.error.set(() => new Error('unlink called before link'));
+            throw this.error.set(() => fail`unlink called before link`);
         }
         await super.unlink();
         this._folderUri = undefined;

--- a/src/sentry.ts
+++ b/src/sentry.ts
@@ -3,35 +3,17 @@ import { BrowserClient, defaultStackParser, makeFetchTransport, Scope } from '@s
 import packageJson from '../package.json';
 
 import { DEBUG, ENV, SENTRY_DSN } from './config';
+import type { FingerprintedError } from './utils/error';
+
+const isFingerprintedError = (e: unknown): e is FingerprintedError =>
+    e instanceof Error && 'fingerprint' in e && typeof (e as FingerprintedError).fingerprint === 'string';
 
 // NOTE: sensitive keys to scrub from event data (matches monorepo sentry-utils.js)
 const SANITIZE_KEYS = /password|token|secret|passwd|authorization|api_key|apikey|sentry_dsn|access_token|credentials/i;
 
-const URI_TOKEN = /\b[a-z][a-z0-9+.-]*:(?:\/\/)?[^\s'"`]+/gi;
-const PATH_TOKEN =
-    /(?:[A-Za-z]:\\[^\s'"`]+|\/(?=[^\s'"`]*[A-Za-z])[^\s'"`]+|(?:\.\.?\/)?(?=[^\s'"`]*[A-Za-z])[^\s'"`]*\/[^\s'"`]+|\b(?=[^\s'"`]*[A-Za-z])[A-Za-z0-9.-]*_[A-Za-z0-9._-]*\b)/g;
-const UUID_TOKEN = /\b[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\b/gi;
-const CONTEXT_ID_TOKEN = /\b(asset|document|project|branch|user|checkpoint)\s+\d+\b/gi;
-const DOCUMENT_ROOM_ID_TOKEN = /\bdocument-(\d+)\b/gi;
-const ASSET_ID_TOKEN = /\basset\s+(\d+)\b/gi;
-const ASSET_URI_ID_TOKEN = /\bassets\/(\d+)\b/gi;
-const TIMESTAMP_TOKEN = /\b\d+(?:\.\d+)?(?:ms|s|m|h)\b/gi;
-
-type SentryMetadata = {
-    message: string;
-    paths: string[];
-    assetIds: string[];
-    documentIds: string[];
-    timestamps: string[];
-};
-
-type GroupingExtra = Record<string, unknown> & {
-    metadata?: SentryMetadata;
-};
-
 type GroupingEvent = {
     message?: string;
-    extra?: GroupingExtra;
+    extra?: Record<string, unknown>;
     fingerprint?: string[];
 };
 
@@ -41,9 +23,7 @@ const sanitize = (obj: unknown, memo = new WeakSet()): unknown => {
             return obj;
         }
         memo.add(obj);
-        const result = obj.map((v) => {
-            return sanitize(v, memo);
-        });
+        const result = obj.map((v) => sanitize(v, memo));
         memo.delete(obj);
         return result;
     }
@@ -63,91 +43,6 @@ const sanitize = (obj: unknown, memo = new WeakSet()): unknown => {
     return obj;
 };
 
-const normalizeMessage = (message: string) => {
-    const trimToken = (value: string) => {
-        return value.replace(/^[('"`]+/, '').replace(/[)"'`,.;!?]+$/, '');
-    };
-    const collectMatches = (pattern: RegExp, pick: (match: RegExpMatchArray) => string | undefined) => {
-        const values = new Set<string>();
-        const regex = new RegExp(pattern.source, pattern.flags);
-        for (const match of message.matchAll(regex)) {
-            const value = pick(match);
-            if (value) {
-                values.add(value);
-            }
-        }
-        return values;
-    };
-
-    // collect path-like values before normalizing so we can keep raw context in event.extra.metadata
-    const uriTokens = collectMatches(URI_TOKEN, (match) => {
-        return trimToken(match[0]);
-    });
-    const pathTokens = collectMatches(PATH_TOKEN, (match) => {
-        return trimToken(match[0]);
-    });
-    const paths = new Set<string>();
-    for (const token of [...uriTokens, ...pathTokens]) {
-        const path = trimToken(token).split(/[?#]/, 1)[0];
-        if (path) {
-            paths.add(path);
-        }
-    }
-
-    // only parse asset id formats that our current logs actually emit
-    const assetIds = new Set<string>();
-    for (const pattern of [ASSET_ID_TOKEN, ASSET_URI_ID_TOKEN]) {
-        const ids = collectMatches(pattern, (match) => {
-            return match[1];
-        });
-        for (const id of ids) {
-            assetIds.add(id);
-        }
-    }
-
-    const documentRoomTokens = collectMatches(DOCUMENT_ROOM_ID_TOKEN, (match) => {
-        return trimToken(match[0]);
-    });
-    const documentIds = collectMatches(DOCUMENT_ROOM_ID_TOKEN, (match) => {
-        return match[1];
-    });
-
-    // collect timing values to reduce retry/backoff cardinality while preserving raw values in metadata
-    const timestamps = collectMatches(TIMESTAMP_TOKEN, (match) => {
-        return trimToken(match[0]);
-    });
-
-    // replace longest tokens first so nested segments don't partially replace
-    const replaceTokens = (input: string, tokens: Set<string>, placeholder: string) => {
-        let output = input;
-        const sorted = Array.from(tokens).sort((a, b) => {
-            return b.length - a.length;
-        });
-        for (const token of sorted) {
-            const escaped = token.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-            output = output.replace(new RegExp(escaped, 'g'), placeholder);
-        }
-        return output;
-    };
-
-    // replace tokens in message
-    let normalized = message;
-    normalized = replaceTokens(normalized, uriTokens, '{path}');
-    normalized = replaceTokens(normalized, pathTokens, '{path}');
-    normalized = replaceTokens(normalized, documentRoomTokens, 'document-{id}');
-    normalized = replaceTokens(normalized, timestamps, '{timestamp}');
-    normalized = normalized.replace(UUID_TOKEN, '{uuid}');
-    normalized = normalized.replace(CONTEXT_ID_TOKEN, '$1 {id}');
-
-    return {
-        normalized,
-        paths: Array.from(paths),
-        assetIds: Array.from(assetIds),
-        documentIds: Array.from(documentIds),
-        timestamps: Array.from(timestamps)
-    };
-};
-
 const client = new BrowserClient({
     dsn: DEBUG ? '' : SENTRY_DSN,
     transport: makeFetchTransport,
@@ -155,36 +50,19 @@ const client = new BrowserClient({
     environment: `extension_${ENV === 'prod' ? 'live' : ENV}`,
     release: packageJson.version,
     integrations: [],
-    beforeSend: (event) => {
-        // type guard to ensure event has message and extra properties
+    beforeSend: (event, hint) => {
         const typedEvent = event as typeof event & GroupingEvent;
-        // extract raw message from either message events or exception events
-        const exceptionValue = typedEvent.exception?.values?.[0];
-        const raw = typedEvent.message || exceptionValue?.value;
-        if (raw) {
-            // NOTE: group by normalized message template while retaining raw debug context
-            const { normalized, paths, assetIds, documentIds, timestamps } = normalizeMessage(raw);
-            typedEvent.extra = {
-                // previous extra data is preserved
-                ...(typedEvent.extra || {}),
+        const original = hint?.originalException;
 
-                // new metadata is added
-                metadata: {
-                    message: raw,
-                    paths,
-                    assetIds,
-                    documentIds,
-                    timestamps
-                }
+        // first-party errors carry their own grouping key via fail tagged template
+        if (isFingerprintedError(original)) {
+            typedEvent.fingerprint = [original.fingerprint];
+            typedEvent.extra = {
+                ...(typedEvent.extra || {}),
+                metadata: { message: original.message, context: original.context }
             };
-            if (typedEvent.message) {
-                typedEvent.message = normalized;
-            }
-            if (exceptionValue) {
-                exceptionValue.value = normalized;
-            }
-            typedEvent.fingerprint = [normalized];
         }
+
         return sanitize(typedEvent) as typeof event;
     }
 });

--- a/src/utils/error.ts
+++ b/src/utils/error.ts
@@ -1,0 +1,8 @@
+export type FingerprintedError = Error & { fingerprint: string; context: unknown[] };
+
+export const fail = (strings: TemplateStringsArray, ...values: unknown[]): FingerprintedError => {
+    const e = new Error(String.raw(strings, ...values)) as FingerprintedError;
+    e.fingerprint = strings.join('{}');
+    e.context = values;
+    return e;
+};


### PR DESCRIPTION
## Summary
- Add `fail` tagged template (`src/utils/error.ts`) that embeds a structural fingerprint at error creation time, so Sentry can group errors without post-hoc regex normalization
- Remove all 8 grouping regex patterns and the `normalizeMessage` function from `sentry.ts` (235 → 106 lines)
- Migrate ~39 error sites across 9 files from `new Error(...)` to `fail`...``

## How it works
`fail` is a tagged template that splits template strings from interpolated values:
```ts
throw fail`file not found ${path}`;
// message: "file not found /assets/script.js"
// fingerprint: "file not found {}"  ← used for Sentry grouping
// context: ["/assets/script.js"]    ← preserved for debugging
```

Errors that don't use `fail` (auth static strings, third-party errors) fall through to Sentry's default stack-based grouping.

## Test plan
- [ ] `npm run compile` passes
- [ ] `npm run lint` passes
- [ ] Verify Sentry events group by fingerprint template, not raw message
- [ ] Verify `extra.metadata.context` contains interpolated values for debugging