### PR TITLE
[Feat] Write type definition files to .pc/ directory on disk

### DIFF
--- a/package.json
+++ b/package.json
@@ -114,6 +114,16 @@
         ],
         "colors": [
             {
+                "id": "playcanvas.managedForeground",
+                "description": "Color for extension-managed files in the explorer",
+                "defaults": {
+                    "dark": "#8a8a8a",
+                    "light": "#6b6b6b",
+                    "highContrast": "#8a8a8a",
+                    "highContrastLight": "#6b6b6b"
+                }
+            },
+            {
                 "id": "playcanvas.dirtyForeground",
                 "description": "Color for unsaved files in the explorer",
                 "defaults": {

--- a/plugin/src/index.ts
+++ b/plugin/src/index.ts
@@ -6,10 +6,10 @@ import type * as ts from 'typescript/lib/tsserverlibrary';
 const DEBUG = true;
 const FILES = new Map([
     // global pc namespace
-    ['globals.d.ts', fs.readFileSync(path.join(__dirname, 'playcanvas.d.ts'), 'utf8')],
+    ['.pc/globals.d.ts', fs.readFileSync(path.join(__dirname, 'playcanvas.d.ts'), 'utf8')],
 
     // 'playcanvas' module declaration
-    ['module.d.ts', 'declare module "playcanvas" { export = pc; }']
+    ['.pc/module.d.ts', 'declare module "playcanvas" { export = pc; }\n']
 ]);
 
 const COMPILER_OPTIONS: ts.CompilerOptions = {
@@ -60,7 +60,8 @@ const init = (modules: { typescript: typeof ts }): ts.server.PluginModule => {
         proxy.getScriptSnapshot = (fileName) => {
             if (paths.includes(fileName)) {
                 log(info.project, `Providing snapshot for virtual file: ${fileName}`);
-                return ts.ScriptSnapshot.fromString(FILES.get(path.basename(fileName))!);
+                const rel = path.relative(projectDir, fileName).replace(/\\/g, '/');
+                return ts.ScriptSnapshot.fromString(FILES.get(rel)!);
             }
             return getScriptSnapshot(fileName);
         };
@@ -69,7 +70,8 @@ const init = (modules: { typescript: typeof ts }): ts.server.PluginModule => {
         proxy.readFile = (fileName, encoding) => {
             if (paths.includes(fileName)) {
                 log(info.project, `Reading content for virtual file: ${fileName}`);
-                return FILES.get(path.basename(fileName))!;
+                const rel = path.relative(projectDir, fileName).replace(/\\/g, '/');
+                return FILES.get(rel)!;
             }
             return readFile(fileName, encoding);
         };

--- a/src/disk.ts
+++ b/src/disk.ts
@@ -112,6 +112,8 @@ class Disk extends Linker<{ folderUri: vscode.Uri; projectManager: ProjectManage
 
     private _extensionUri: vscode.Uri;
 
+    private _dts?: { globals: Uint8Array; module: Uint8Array };
+
     constructor({ events, extensionUri }: { events: EventEmitter<EventMap>; extensionUri: vscode.Uri }) {
         super();
 
@@ -178,17 +180,23 @@ class Disk extends Linker<{ folderUri: vscode.Uri; projectManager: ProjectManage
     }
 
     private async _writeTypeFiles(folderUri: vscode.Uri) {
-        const dtsUri = vscode.Uri.joinPath(
-            this._extensionUri,
-            'node_modules',
-            'playcanvas-plugin',
-            'out',
-            'playcanvas.d.ts'
-        );
-        const [err, content] = await tryCatch(vscode.workspace.fs.readFile(dtsUri) as Promise<Uint8Array>);
-        if (err) {
-            this._log.warn('failed to read playcanvas.d.ts', err);
-            return;
+        if (!this._dts) {
+            const dtsUri = vscode.Uri.joinPath(
+                this._extensionUri,
+                'node_modules',
+                'playcanvas-plugin',
+                'out',
+                'playcanvas.d.ts'
+            );
+            const [err, content] = await tryCatch(vscode.workspace.fs.readFile(dtsUri) as Promise<Uint8Array>);
+            if (err) {
+                this._log.warn('failed to read playcanvas.d.ts', err);
+                return;
+            }
+            this._dts = {
+                globals: content,
+                module: buffer.from('declare module "playcanvas" { export = pc; }\n')
+            };
         }
 
         const dirUri = vscode.Uri.joinPath(folderUri, Disk.TYPE_DIR);
@@ -198,15 +206,14 @@ class Disk extends Linker<{ folderUri: vscode.Uri; projectManager: ProjectManage
         // global pc namespace types
         const globalsUri = vscode.Uri.joinPath(dirUri, 'globals.d.ts');
         this._echo.set(`${globalsUri}:create`, '');
-        this._echo.set(`${globalsUri}:change`, hash(content));
-        await vscode.workspace.fs.writeFile(globalsUri, content);
+        this._echo.set(`${globalsUri}:change`, hash(this._dts.globals));
+        await vscode.workspace.fs.writeFile(globalsUri, this._dts.globals);
 
         // 'playcanvas' module declaration (must be separate — script file referencing global pc)
-        const moduleContent = buffer.from('declare module "playcanvas" { export = pc; }\n');
         const moduleUri = vscode.Uri.joinPath(dirUri, 'module.d.ts');
         this._echo.set(`${moduleUri}:create`, '');
-        this._echo.set(`${moduleUri}:change`, hash(moduleContent));
-        await vscode.workspace.fs.writeFile(moduleUri, moduleContent);
+        this._echo.set(`${moduleUri}:change`, hash(this._dts.module));
+        await vscode.workspace.fs.writeFile(moduleUri, this._dts.module);
 
         this._log.debug('wrote type files to .pc/');
     }
@@ -1199,9 +1206,15 @@ class Disk extends Linker<{ folderUri: vscode.Uri; projectManager: ProjectManage
                 return;
             }
 
-            // skip .pc/ type files
+            // restore .pc/ type files if modified by user (skip if echo matches our own write)
             const changeRel = relativePath(uri, folderUri);
             if (changeRel === Disk.TYPE_DIR || changeRel.startsWith(`${Disk.TYPE_DIR}/`)) {
+                const echoHash = this._echo.get(`${uri}:change`);
+                if (echoHash) {
+                    this._echo.delete(`${uri}:change`);
+                } else {
+                    void this._writeTypeFiles(folderUri);
+                }
                 return;
             }
 

--- a/src/disk.ts
+++ b/src/disk.ts
@@ -74,6 +74,8 @@ const pathsRelated = (path1: string, path2: string): boolean => {
 class Disk extends Linker<{ folderUri: vscode.Uri; projectManager: ProjectManager }> {
     static IGNORE_FILE = '.pcignore';
 
+    static TYPE_DIR = '.pc';
+
     private _events: EventEmitter<EventMap>;
 
     private _folderUri?: vscode.Uri;
@@ -108,10 +110,13 @@ class Disk extends Linker<{ folderUri: vscode.Uri; projectManager: ProjectManage
 
     error = signal<Error | undefined>(undefined);
 
-    constructor({ events }: { events: EventEmitter<EventMap> }) {
+    private _extensionUri: vscode.Uri;
+
+    constructor({ events, extensionUri }: { events: EventEmitter<EventMap>; extensionUri: vscode.Uri }) {
         super();
 
         this._events = events;
+        this._extensionUri = extensionUri;
     }
 
     private _checkIgnoreUpdated(uri: vscode.Uri, deleted = false) {
@@ -170,6 +175,40 @@ class Disk extends Linker<{ folderUri: vscode.Uri; projectManager: ProjectManage
             return ig.ignores(path);
         };
         this._log.debug(`parsed ignore file ${vscode.Uri.joinPath(folderUri, Disk.IGNORE_FILE)}`);
+    }
+
+    private async _writeTypeFiles(folderUri: vscode.Uri) {
+        const dtsUri = vscode.Uri.joinPath(
+            this._extensionUri,
+            'node_modules',
+            'playcanvas-plugin',
+            'out',
+            'playcanvas.d.ts'
+        );
+        const [err, content] = await tryCatch(vscode.workspace.fs.readFile(dtsUri) as Promise<Uint8Array>);
+        if (err) {
+            this._log.warn('failed to read playcanvas.d.ts', err);
+            return;
+        }
+
+        const dirUri = vscode.Uri.joinPath(folderUri, Disk.TYPE_DIR);
+        this._echo.set(`${dirUri}:create`, '');
+        await vscode.workspace.fs.createDirectory(dirUri);
+
+        // global pc namespace types
+        const globalsUri = vscode.Uri.joinPath(dirUri, 'globals.d.ts');
+        this._echo.set(`${globalsUri}:create`, '');
+        this._echo.set(`${globalsUri}:change`, hash(content));
+        await vscode.workspace.fs.writeFile(globalsUri, content);
+
+        // 'playcanvas' module declaration (must be separate — script file referencing global pc)
+        const moduleContent = buffer.from('declare module "playcanvas" { export = pc; }\n');
+        const moduleUri = vscode.Uri.joinPath(dirUri, 'module.d.ts');
+        this._echo.set(`${moduleUri}:create`, '');
+        this._echo.set(`${moduleUri}:change`, hash(moduleContent));
+        await vscode.workspace.fs.writeFile(moduleUri, moduleContent);
+
+        this._log.debug('wrote type files to .pc/');
     }
 
     private _create(uri: vscode.Uri, type: 'file' | 'folder', content: Uint8Array) {
@@ -1136,6 +1175,12 @@ class Disk extends Linker<{ folderUri: vscode.Uri; projectManager: ProjectManage
                 return;
             }
 
+            // skip .pc/ type files
+            const createRel = relativePath(uri, folderUri);
+            if (createRel === Disk.TYPE_DIR || createRel.startsWith(`${Disk.TYPE_DIR}/`)) {
+                return;
+            }
+
             const type = fileType(uri);
             defer({
                 action: 'create',
@@ -1151,6 +1196,12 @@ class Disk extends Linker<{ folderUri: vscode.Uri; projectManager: ProjectManage
 
             // ignore check
             if (this._ignoring(uri)) {
+                return;
+            }
+
+            // skip .pc/ type files
+            const changeRel = relativePath(uri, folderUri);
+            if (changeRel === Disk.TYPE_DIR || changeRel.startsWith(`${Disk.TYPE_DIR}/`)) {
                 return;
             }
 
@@ -1195,6 +1246,13 @@ class Disk extends Linker<{ folderUri: vscode.Uri; projectManager: ProjectManage
 
             // ignore check
             if (this._ignoring(uri)) {
+                return;
+            }
+
+            // re-create .pc/ type files if deleted
+            const deleteRel = relativePath(uri, folderUri);
+            if (deleteRel === Disk.TYPE_DIR || deleteRel.startsWith(`${Disk.TYPE_DIR}/`)) {
+                void this._writeTypeFiles(folderUri);
                 return;
             }
 
@@ -1296,11 +1354,14 @@ class Disk extends Linker<{ folderUri: vscode.Uri; projectManager: ProjectManage
             }
         }
 
+        // write type definition files to .pc/
+        await this._writeTypeFiles(folderUri);
+
         // remove old files
         const existing = await readDirRecursive(folderUri);
         for (const uri of existing) {
             const path = relativePath(uri, folderUri);
-            if (!projectManager.files.has(path)) {
+            if (!projectManager.files.has(path) && path !== Disk.TYPE_DIR && !path.startsWith(`${Disk.TYPE_DIR}/`)) {
                 await this._delete(uri);
             }
         }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -13,7 +13,7 @@ import { Metrics } from './metrics';
 import { simpleNotification } from './notification';
 import { ProjectManager } from './project-manager';
 import { CollabProvider } from './providers/collab-provider';
-import { DirtyDecorationProvider } from './providers/dirty-decoration-provider';
+import { DecorationProvider } from './providers/decoration-provider';
 import { closeSentry, setSentryCollaborators, setSentryProject, setSentryUser } from './sentry';
 import type { EventMap } from './typings/event-map';
 import type { Project } from './typings/models';
@@ -168,7 +168,8 @@ export const activate = async (context: vscode.ExtensionContext) => {
 
     // disk
     const disk = new Disk({
-        events
+        events,
+        extensionUri: context.extensionUri
     });
     effect(() => {
         const err = disk.error.get();
@@ -189,7 +190,7 @@ export const activate = async (context: vscode.ExtensionContext) => {
             // unlink everything
             const uriState = await uriHandler.unlink();
             const collabState = await collabProvider.unlink();
-            const dirtyState = await dirtyProvider.unlink();
+            const dirtyState = await decorationProvider.unlink();
             const diskState = await disk.unlink();
             const projectState = await projectManager.unlink();
 
@@ -202,7 +203,7 @@ export const activate = async (context: vscode.ExtensionContext) => {
             // relink everything
             await projectManager.link(projectState);
             await disk.link(diskState);
-            await dirtyProvider.link(dirtyState);
+            await decorationProvider.link(dirtyState);
             await collabProvider.link(collabState);
             await uriHandler.link(uriState);
         });
@@ -248,14 +249,14 @@ export const activate = async (context: vscode.ExtensionContext) => {
     relay.on('room:leave', updateCollabTags);
 
     // dirty decoration provider
-    const dirtyProvider = new DirtyDecorationProvider({ events });
+    const decorationProvider = new DecorationProvider({ events });
     effect(() => {
-        const err = dirtyProvider.error.get();
+        const err = decorationProvider.error.get();
         if (err) {
             void handleError(err, 'dirty-decoration-provider').catch((e) => log.error(e.message));
         }
     });
-    context.subscriptions.push(vscode.window.registerFileDecorationProvider(dirtyProvider));
+    context.subscriptions.push(vscode.window.registerFileDecorationProvider(decorationProvider));
 
     // connection status bar item
     const connectionStatusColors = {
@@ -747,10 +748,10 @@ export const activate = async (context: vscode.ExtensionContext) => {
         );
 
         // link dirty decoration provider
-        await dirtyProvider.link({ folderUri, projectManager });
+        await decorationProvider.link({ folderUri, projectManager });
         context.subscriptions.push(
             new vscode.Disposable(() => {
-                void dirtyProvider.unlink();
+                void decorationProvider.unlink();
             })
         );
 

--- a/src/providers/decoration-provider.ts
+++ b/src/providers/decoration-provider.ts
@@ -1,5 +1,6 @@
 import * as vscode from 'vscode';
 
+import { Disk } from '../disk';
 import type { ProjectManager } from '../project-manager';
 import type { EventMap } from '../typings/event-map';
 import { fail } from '../utils/error';
@@ -7,9 +8,15 @@ import type { EventEmitter } from '../utils/event-emitter';
 import { Linker } from '../utils/linker';
 import { signal } from '../utils/signal';
 
+const MANAGED_COLOR = new vscode.ThemeColor('playcanvas.managedForeground');
+const MANAGED_DECORATION: vscode.FileDecoration = {
+    badge: 'PC',
+    color: MANAGED_COLOR,
+    tooltip: 'Managed by PlayCanvas'
+};
 const DIRTY_COLOR = new vscode.ThemeColor('playcanvas.dirtyForeground');
 
-class DirtyDecorationProvider
+class DecorationProvider
     extends Linker<{ folderUri: vscode.Uri; projectManager: ProjectManager }>
     implements vscode.FileDecorationProvider
 {
@@ -30,6 +37,12 @@ class DirtyDecorationProvider
     }
 
     provideFileDecoration(uri: vscode.Uri) {
+        // badge for .pc/ directory and its managed files
+        const segments = uri.path.split('/');
+        if (segments.includes(Disk.TYPE_DIR)) {
+            return MANAGED_DECORATION;
+        }
+
         const folderUri = this._folderUri;
         const pm = this._projectManager;
         if (!folderUri || !pm) {
@@ -120,4 +133,4 @@ class DirtyDecorationProvider
     }
 }
 
-export { DirtyDecorationProvider };
+export { DecorationProvider };


### PR DESCRIPTION
Fixes #163

### What's Changed

- Write `globals.d.ts` and `module.d.ts` to a `.pc/` directory on disk during project load so they back the plugin's virtual type files with real files
- Update the TS server plugin to use `.pc/` subpaths for virtual files, aligning with the disk paths to avoid duplicate type declarations
- Guard file watchers and cleanup logic to prevent `.pc/` files from syncing to PlayCanvas or being deleted during project reload
- Re-create `.pc/` type files automatically if a user deletes them
- Add "PC" badge with muted gray color on `.pc/` directory and its files via `FileDecorationProvider`
- Rename `DirtyDecorationProvider` → `DecorationProvider` to reflect broader scope
- Add `playcanvas.managedForeground` theme color for extension-managed file decorations

**This enables:**
- Ctrl+click on PlayCanvas types (e.g. `pc.Entity`) navigates to the real `.pc/globals.d.ts` file instead of a non-existent virtual path
- Users can create their own `jsconfig.json` with `"include": [".pc/*.d.ts", "./**/*.js"]` to get full cross-file autocomplete without breaking PlayCanvas type completions

### Preview

<img width="602" height="354" alt="image" src="https://github.com/user-attachments/assets/766bfa95-9152-4706-86aa-feb97e31b3f9" />
