### PR TITLE
[Fix] Hardening fixes from v1.5.10 audit

### DIFF
--- a/src/collision-manager.ts
+++ b/src/collision-manager.ts
@@ -43,6 +43,16 @@ class CollisionManager {
     }
 
     private _add(uniqueId: number, filePath: string) {
+        const old = this._collided.get(uniqueId);
+        if (old && old !== filePath) {
+            const set = this._collidedByPath.get(old);
+            if (set) {
+                set.delete(uniqueId);
+                if (set.size === 0) {
+                    this._collidedByPath.delete(old);
+                }
+            }
+        }
         this._collided.set(uniqueId, filePath);
         const set = this._collidedByPath.get(filePath) ?? new Set<number>();
         set.add(uniqueId);

--- a/src/connections/constants.ts
+++ b/src/connections/constants.ts
@@ -7,4 +7,4 @@ export const SUBSCRIBE_TIMEOUT_MS = 10 * 1000;
 export const AUTH_TIMEOUT_MS = 2 * 60 * 1000;
 export const EVENT_TIMEOUT_MS = 30 * 1000;
 export const FETCH_TIMEOUT_MS = 10 * 1000;
-export const AUTH_CLOSE_CODE = 3 * 1000;
+export const AUTH_CLOSE_CODE = 3000;

--- a/src/disk.ts
+++ b/src/disk.ts
@@ -668,7 +668,12 @@ class Disk extends Linker<{ folderUri: vscode.Uri; projectManager: ProjectManage
                 const userOp = delta(pre, buf);
                 const bufOp = userOp ? (ottext.transform(op, userOp, 'right') as ShareDbTextOp) : op;
                 const edit = sharedb2vscode(doc, uri, [bufOp], buf);
-                await vscode.workspace.applyEdit(edit);
+                const applied = await vscode.workspace.applyEdit(edit);
+
+                if (!applied) {
+                    this._log.warn(`sync.undo.apply failed ${uri}`);
+                    return;
+                }
 
                 // reconcile: recover keystrokes typed during applyEdit await
                 const postText = norm(doc.getText());

--- a/src/project-manager.ts
+++ b/src/project-manager.ts
@@ -79,7 +79,7 @@ class ProjectManager extends Linker<{ projectId: number; branchId: string }> {
 
     private _idUniqueId: Bimap<number, number> = new Bimap<number, number>();
 
-    private _subscribing = new Map<string, Promise<(VirtualFile & { type: 'file' }) | undefined>>();
+    private _subscribing = new Map<number, Promise<(VirtualFile & { type: 'file' }) | undefined>>();
 
     private _queued = new Set<string>();
 
@@ -1145,16 +1145,16 @@ class ProjectManager extends Linker<{ projectId: number; branchId: string }> {
             return undefined;
         }
 
-        // coalesce concurrent subscribe calls for the same path
-        const inflight = this._subscribing.get(path);
+        // coalesce concurrent subscribe calls for the same asset
+        const inflight = this._subscribing.get(file.uniqueId);
         if (inflight) {
             return inflight;
         }
 
         const pending = this._doSubscribe(path, file.uniqueId);
-        this._subscribing.set(path, pending);
+        this._subscribing.set(file.uniqueId, pending);
         const result = await pending;
-        this._subscribing.delete(path);
+        this._subscribing.delete(file.uniqueId);
         return result;
     }
 
@@ -1162,6 +1162,13 @@ class ProjectManager extends Linker<{ projectId: number; branchId: string }> {
         const doc = await this._sharedb.subscribe('documents', `${uniqueId}`);
         if (!doc) {
             this._log.error(`failed to subscribe to document ${uniqueId}`);
+            return undefined;
+        }
+
+        // asset deleted during subscribe — clean up and bail
+        if (!this._assets.has(uniqueId)) {
+            await this._sharedb.unsubscribe('documents', `${uniqueId}`);
+            this._log.debug(`asset ${uniqueId} deleted during subscribe`);
             return undefined;
         }
 
@@ -1189,7 +1196,9 @@ class ProjectManager extends Linker<{ projectId: number; branchId: string }> {
             doc: otdoc,
             dirty
         };
-        this._files.set(path, promoted);
+        // resolve current path after await (may have changed due to rename)
+        const current = this._assetPath(uniqueId);
+        this._files.set(current, promoted);
 
         // wire op handler (same as _addFile)
         otdoc.on('op', (op, prev) => {
@@ -1203,8 +1212,8 @@ class ProjectManager extends Linker<{ projectId: number; branchId: string }> {
             }
         });
 
-        this._events.emit('asset:file:subscribed', path, otdoc.text, dirty);
-        this._log.debug(`subscribed ${path} (${dirty ? 'dirty' : 'clean'})`);
+        this._events.emit('asset:file:subscribed', current, otdoc.text, dirty);
+        this._log.debug(`subscribed ${current} (${dirty ? 'dirty' : 'clean'})`);
         return promoted;
     }
 


### PR DESCRIPTION
### What's Changed

Audit of all changes between v1.5.10 and v1.7.0-beta.0 identified 4 issues, verified against the online IDE and validated for OT consistency:

- **Log warning on failed undo/redo applyEdit** — the `applyOp` path silently swallowed `applyEdit` failures. A force-reset is intentionally not used (unlike `_update`) because canonical state can advance via queued remote ops, which would cause phantom edits.
- **Clean up stale collision path on re-add** — `_add` overwrote `_collided` mapping without cleaning the old path's `_collidedByPath` Set, leaving ghost entries that inflated collision counts permanently after renames.
- **Key `_subscribing` by uniqueId** — was keyed by path, so a rename during an in-flight `_doSubscribe` would write the promoted file to `_files` at the stale path. Also adds a guard against asset deletion during the subscribe await.
- **Use literal 3000 for `AUTH_CLOSE_CODE`** — every other constant in the file uses `N * 1000` for millisecond durations; this is a WebSocket close code, not a duration.