### PR TITLE
[Fix] Undo-to-saved-state test uses playcanvas.undo on separate line

### DIFF
--- a/src/test/suite/extension.test.ts
+++ b/src/test/suite/extension.test.ts
@@ -1300,22 +1300,22 @@ suite('extension', () => {
         const saved = tdoc.getText();
         assert.strictEqual(saved, '// SAVED\n// ORIGINAL', 'saved content should match');
 
-        // edit after save
+        // edit after save (line 1 to prevent UndoManager composing with SAVED)
         const edit2 = new vscode.WorkspaceEdit();
-        edit2.insert(uri, new vscode.Position(0, 0), '// TEMP\n');
+        edit2.insert(uri, new vscode.Position(1, 0), '// TEMP\n');
         await vscode.workspace.applyEdit(edit2);
         assert.strictEqual(tdoc.isDirty, true, 'should be dirty after edit');
 
         // undo back to saved state
         const undone = new Promise<void>((resolve) => {
             const disposable = vscode.workspace.onDidChangeTextDocument((e) => {
-                if (e.document.uri.toString() === uri.toString() && e.reason === vscode.TextDocumentChangeReason.Undo) {
+                if (e.document.uri.toString() === uri.toString() && tdoc.getText() === saved) {
                     disposable.dispose();
                     resolve();
                 }
             });
         });
-        await vscode.commands.executeCommand('undo');
+        await vscode.commands.executeCommand('playcanvas.undo');
         await assertResolves(undone, 'undo change event');
 
         assert.strictEqual(tdoc.getText(), saved, 'buffer should match saved content after undo');


### PR DESCRIPTION
### What's Changed

- Switch undo-to-saved-state test from native `undo` to `playcanvas.undo` to avoid dirtify timing race introduced by #196
- Insert `// TEMP\n` at line 1 instead of line 0 so `UndoManager._canConcat` rejects composition with the SAVED edit (different-line non-whitespace edits are never merged)
- Wait for buffer content match instead of `e.reason === Undo`, matching the pattern used by the other undo tests