### PR TITLE
[Fix] Clear stale ping queue on socket reconnect

### DIFF
--- a/src/connections/messenger.ts
+++ b/src/connections/messenger.ts
@@ -192,6 +192,7 @@ class Messenger extends EventEmitter<EventMap> {
         // reset backoff on successful auth
         this._reconnectAttempt = 0;
         this._lastPong = Date.now();
+        this._pings.length = 0;
 
         // reset keep alive
         if (this._alive) {

--- a/src/connections/relay.ts
+++ b/src/connections/relay.ts
@@ -146,6 +146,7 @@ class Relay extends EventEmitter<EventMap> {
         // reset backoff on successful auth
         this._reconnectAttempt = 0;
         this._lastPong = Date.now();
+        this._pings.length = 0;
 
         // reset keep alive
         if (this._alive) {


### PR DESCRIPTION
### What's Changed

- Clear `_pings` queue in `_onauth()` for both Messenger and Relay
- After a disconnect, stale entries (pings sent but never answered) remained in the queue. On reconnect, this caused a permanent off-by-one: every pong was paired with the previous ping's timestamp, adding exactly `PING_INTERVAL_MS` (1000ms) to the measured RTT