### PR TITLE
[Fix] Align plugin compiler options with online editor

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -43,7 +43,7 @@
                 "eslint-plugin-prettier": "^5.5.4",
                 "globals": "^17.0.0",
                 "jsonc-eslint-parser": "^2.4.2",
-                "playcanvas": "2.17.1",
+                "playcanvas": "2.17.2",
                 "prettier": "^3.7.4",
                 "rollup": "^4.55.1",
                 "rollup-plugin-polyfill-node": "^0.13.0",
@@ -6898,9 +6898,9 @@
             }
         },
         "node_modules/playcanvas": {
-            "version": "2.17.1",
-            "resolved": "https://registry.npmjs.org/playcanvas/-/playcanvas-2.17.1.tgz",
-            "integrity": "sha512-OTBUtfYS7JeCdAkhiWgSjyMXqE2VeZDpsLxIJvMvIZ7eFrB9usDxsqCiCPuEzBRibtW7gr/w58aIhzGgHkB2EA==",
+            "version": "2.17.2",
+            "resolved": "https://registry.npmjs.org/playcanvas/-/playcanvas-2.17.2.tgz",
+            "integrity": "sha512-+J3ewI2Zi2C1IZ/tZqubBBYSoruaMyPh9QD1/IQS/0QRmuZPNtx+9SwrYsK2QR91+ImeH0MRchkOFfNYWwEOVQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {

--- a/package.json
+++ b/package.json
@@ -183,7 +183,7 @@
         "eslint-plugin-prettier": "^5.5.4",
         "globals": "^17.0.0",
         "jsonc-eslint-parser": "^2.4.2",
-        "playcanvas": "2.17.1",
+        "playcanvas": "2.17.2",
         "prettier": "^3.7.4",
         "rollup": "^4.55.1",
         "rollup-plugin-polyfill-node": "^0.13.0",

--- a/plugin/src/index.ts
+++ b/plugin/src/index.ts
@@ -11,12 +11,6 @@ const FILES = new Map([
     ['.pc/module.d.ts', 'declare module "playcanvas" { export = pc; }\n']
 ]);
 
-const COMPILER_OPTIONS: ts.CompilerOptions = {
-    allowJs: true,
-    checkJs: true,
-    noEmit: true
-};
-
 const PROJECT_REGEX = /playcanvas\.playcanvas\/\w+\/.+ \(\d+\)/;
 
 const log = (project: ts.server.Project, message: string) => {
@@ -25,6 +19,14 @@ const log = (project: ts.server.Project, message: string) => {
 
 const init = (modules: { typescript: typeof ts }): ts.server.PluginModule => {
     const ts = modules.typescript;
+
+    const compilerOptions: ts.CompilerOptions = {
+        allowJs: true,
+        checkJs: true,
+        noEmit: true,
+        target: ts.ScriptTarget.ES2020,
+        lib: ['lib.es2020.d.ts', 'lib.dom.d.ts', 'lib.dom.iterable.d.ts']
+    };
 
     const create = (info: ts.server.PluginCreateInfo): ts.LanguageService => {
         // check if we are inside a project
@@ -49,7 +51,7 @@ const init = (modules: { typescript: typeof ts }): ts.server.PluginModule => {
         proxy.getCompilationSettings = () => {
             const settings = getCompilationSettings();
             log(info.project, `Merging custom compiler options into project settings.`);
-            return Object.assign(settings, COMPILER_OPTIONS);
+            return Object.assign(settings, compilerOptions);
         };
 
         // intercept getScriptSnapshot to provide a snapshot for the virtual file


### PR DESCRIPTION
### What's Changed

- Add `target: ES2020` and `lib: ['es2020', 'dom', 'dom.iterable']` to the TS plugin compiler options to match the online editor's Monaco configuration
- Move compiler options inside `init()` to use the runtime `ts.ScriptTarget` enum instead of a magic number
- Bump `playcanvas` dependency to 2.17.2