### PR TITLE
[Chore] Add Dependabot and pin Node 22

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,27 @@
+version: 2
+updates:
+    - package-ecosystem: npm
+      directory: /
+      schedule:
+          interval: weekly
+      open-pull-requests-limit: 10
+      reviewers:
+          - kpal81xd
+      labels:
+          - dependencies
+      commit-message:
+          prefix: 'chore(deps):'
+      ignore:
+          - dependency-name: sharedb
+          - dependency-name: '@types/sharedb'
+          - dependency-name: playcanvas
+          - dependency-name: ot-text
+
+    - package-ecosystem: npm
+      directory: /plugin
+      schedule:
+          interval: weekly
+      labels:
+          - dependencies
+      commit-message:
+          prefix: 'chore(deps):'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
             - name: Set up Node.js
               uses: actions/setup-node@v6
               with:
-                  node-version: 24.x
+                  node-version: 22.x
                   cache: 'npm'
                   registry-url: 'https://registry.npmjs.org/'
 
@@ -40,7 +40,7 @@ jobs:
             - name: Set up Node.js
               uses: actions/setup-node@v6
               with:
-                  node-version: 24.x
+                  node-version: 22.x
                   cache: 'npm'
                   registry-url: 'https://registry.npmjs.org/'
 
@@ -60,7 +60,7 @@ jobs:
             - name: Set up Node.js
               uses: actions/setup-node@v6
               with:
-                  node-version: 24.x
+                  node-version: 22.x
                   cache: 'npm'
                   registry-url: 'https://registry.npmjs.org/'
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -21,7 +21,7 @@ jobs:
             - name: Set up Node.js
               uses: actions/setup-node@v6
               with:
-                  node-version: 24.x
+                  node-version: 22.x
                   cache: 'npm'
                   registry-url: 'https://registry.npmjs.org/'
 


### PR DESCRIPTION
### What's Changed

- Add `.github/dependabot.yml` with weekly npm update checks for `/` and `/plugin` directories
- Ignore `sharedb`, `@types/sharedb`, `playcanvas`, and `ot-text` — these must remain static
- Pin CI/CD workflows (ci.yml, publish.yml) to Node 22.x (down from 24.x)