### PR TITLE
[Chore] Add assignees to Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,8 @@ updates:
       open-pull-requests-limit: 10
       reviewers:
           - kpal81xd
+      assignees:
+          - kpal81xd
       labels:
           - dependencies
       commit-message:
@@ -21,6 +23,10 @@ updates:
       directory: /plugin
       schedule:
           interval: weekly
+      reviewers:
+          - kpal81xd
+      assignees:
+          - kpal81xd
       labels:
           - dependencies
       commit-message:


### PR DESCRIPTION
### What's Changed

- Add `assignees: kpal81xd` to both ecosystem entries in dependabot.yml
- Add `reviewers` + `assignees` to the plugin directory entry (was missing)