### PR TITLE
[CHORE] Update @sentry/browser to 10.48.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1039,75 +1039,75 @@
             "license": "MIT"
         },
         "node_modules/@sentry-internal/browser-utils": {
-            "version": "10.43.0",
-            "resolved": "https://registry.npmjs.org/@sentry-internal/browser-utils/-/browser-utils-10.43.0.tgz",
-            "integrity": "sha512-8zYTnzhAPvNkVH1Irs62wl0J/c+0QcJ62TonKnzpSFUUD3V5qz8YDZbjIDGfxy+1EB9fO0sxtddKCzwTHF/MbQ==",
+            "version": "10.48.0",
+            "resolved": "https://registry.npmjs.org/@sentry-internal/browser-utils/-/browser-utils-10.48.0.tgz",
+            "integrity": "sha512-SCiTLBXzugFKxev6NoKYBIhQoDk0gUh0AVVVepCBqfCJiWBG01Zvv0R5tCVohr4cWRllkQ8mlBdNQd/I7s9tdA==",
             "license": "MIT",
             "dependencies": {
-                "@sentry/core": "10.43.0"
+                "@sentry/core": "10.48.0"
             },
             "engines": {
                 "node": ">=18"
             }
         },
         "node_modules/@sentry-internal/feedback": {
-            "version": "10.43.0",
-            "resolved": "https://registry.npmjs.org/@sentry-internal/feedback/-/feedback-10.43.0.tgz",
-            "integrity": "sha512-YoXuwluP6eOcQxTeTtaWb090++MrLyWOVsUTejzUQQ6LFL13Jwt+bDPF1kvBugMq4a7OHw/UNKQfd6//rZMn2g==",
+            "version": "10.48.0",
+            "resolved": "https://registry.npmjs.org/@sentry-internal/feedback/-/feedback-10.48.0.tgz",
+            "integrity": "sha512-tGkEyOM1HDS9qebDphUMEnyk3qq/50AnuTBiFmMJyjNzowylVGmRRk0sr3xkmbVHCDXQCiYnDmSVlJ2x4SDMrQ==",
             "license": "MIT",
             "dependencies": {
-                "@sentry/core": "10.43.0"
+                "@sentry/core": "10.48.0"
             },
             "engines": {
                 "node": ">=18"
             }
         },
         "node_modules/@sentry-internal/replay": {
-            "version": "10.43.0",
-            "resolved": "https://registry.npmjs.org/@sentry-internal/replay/-/replay-10.43.0.tgz",
-            "integrity": "sha512-khCXlGrlH1IU7P5zCEAJFestMeH97zDVCekj8OsNNDtN/1BmCJ46k6Xi0EqAUzdJgrOLJeLdoYdgtiIjovZ8Sg==",
+            "version": "10.48.0",
+            "resolved": "https://registry.npmjs.org/@sentry-internal/replay/-/replay-10.48.0.tgz",
+            "integrity": "sha512-sevRTePfuk4PNuz9KAKpmTZEomAU0aLXyIhOwA0OnUDdxPhkY8kq5lwDbuxTHv6DQUjUX3YgFbY45VH1JEqHKA==",
             "license": "MIT",
             "dependencies": {
-                "@sentry-internal/browser-utils": "10.43.0",
-                "@sentry/core": "10.43.0"
+                "@sentry-internal/browser-utils": "10.48.0",
+                "@sentry/core": "10.48.0"
             },
             "engines": {
                 "node": ">=18"
             }
         },
         "node_modules/@sentry-internal/replay-canvas": {
-            "version": "10.43.0",
-            "resolved": "https://registry.npmjs.org/@sentry-internal/replay-canvas/-/replay-canvas-10.43.0.tgz",
-            "integrity": "sha512-ZIw1UNKOFXo1LbPCJPMAx9xv7D8TMZQusLDUgb6BsPQJj0igAuwd7KRGTkjjgnrwBp2O/sxcQFRhQhknWk7QPg==",
+            "version": "10.48.0",
+            "resolved": "https://registry.npmjs.org/@sentry-internal/replay-canvas/-/replay-canvas-10.48.0.tgz",
+            "integrity": "sha512-9nWuN2z4O+iwbTfuYV5ZmngBgJU/ZxfOo47A5RJP3Nu/kl59aJ1lUhILYOKyeNOIC/JyeERmpIcTxnlPXQzZ3Q==",
             "license": "MIT",
             "dependencies": {
-                "@sentry-internal/replay": "10.43.0",
-                "@sentry/core": "10.43.0"
+                "@sentry-internal/replay": "10.48.0",
+                "@sentry/core": "10.48.0"
             },
             "engines": {
                 "node": ">=18"
             }
         },
         "node_modules/@sentry/browser": {
-            "version": "10.43.0",
-            "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-10.43.0.tgz",
-            "integrity": "sha512-2V3I3sXi3SMeiZpKixd9ztokSgK27cmvsD9J5oyOyjhGLTW/6QKCwHbKnluMgQMXq20nixQk5zN4wRjRUma3sg==",
+            "version": "10.48.0",
+            "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-10.48.0.tgz",
+            "integrity": "sha512-4jt2zX2ExgFcNe2x+W+/k81fmDUsOrquGtt028CiGuDuma6kEsWBI4JbooT1jhj2T+eeUxe3YGbM23Zhh7Ghhw==",
             "license": "MIT",
             "dependencies": {
-                "@sentry-internal/browser-utils": "10.43.0",
-                "@sentry-internal/feedback": "10.43.0",
-                "@sentry-internal/replay": "10.43.0",
-                "@sentry-internal/replay-canvas": "10.43.0",
-                "@sentry/core": "10.43.0"
+                "@sentry-internal/browser-utils": "10.48.0",
+                "@sentry-internal/feedback": "10.48.0",
+                "@sentry-internal/replay": "10.48.0",
+                "@sentry-internal/replay-canvas": "10.48.0",
+                "@sentry/core": "10.48.0"
             },
             "engines": {
                 "node": ">=18"
             }
         },
         "node_modules/@sentry/core": {
-            "version": "10.43.0",
-            "resolved": "https://registry.npmjs.org/@sentry/core/-/core-10.43.0.tgz",
-            "integrity": "sha512-l0SszQAPiQGWl/ferw8GP3ALyHXiGiRKJaOvNmhGO+PrTQyZTZ6OYyPnGijAFRg58dE1V3RCH/zw5d2xSUIiNg==",
+            "version": "10.48.0",
+            "resolved": "https://registry.npmjs.org/@sentry/core/-/core-10.48.0.tgz",
+            "integrity": "sha512-h8F+fXVwYC9ro5ZaO8V+v3vqc0awlXHGblEAuVxSGgh4IV/oFX+QVzXeDTTrFOFS6v/Vn5vAyu240eJrJAS6/g==",
             "license": "MIT",
             "engines": {
                 "node": ">=18"


### PR DESCRIPTION
Supersedes #213

### What's Changed

- Update @sentry/browser to 10.48.0
- Refresh root package-lock.json
- Verified with npm ci, npm run pretest, npm run compile, npm run compile:web, and npm run compile:plugin
