### PR TITLE
[CHORE] Update @types/node to 22.19.17

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1493,9 +1493,9 @@
             "license": "MIT"
         },
         "node_modules/@types/node": {
-            "version": "22.19.15",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.15.tgz",
-            "integrity": "sha512-F0R/h2+dsy5wJAUe3tAU6oqa2qbWY5TpNfL/RGmo1y38hiyO1w3x2jPtt76wmuaJI4DQnOBu21cNXQ2STIUUWg==",
+            "version": "22.19.17",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.17.tgz",
+            "integrity": "sha512-wGdMcf+vPYM6jikpS/qhg6WiqSV/OhG+jeeHT/KlVqxYfD40iYJf9/AE1uQxVWFvU7MipKRkRv8NSHiCGgPr8Q==",
             "dev": true,
             "license": "MIT",
             "dependencies": {


### PR DESCRIPTION
### What's Changed

- Update @types/node within the existing 22.x range
- Refresh root package-lock.json
- Verified with npm ci, npm run pretest, npm run compile, npm run compile:web, and npm run compile:plugin
