### PR TITLE
[CHORE] Update @types/sinon to 21.0.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1552,9 +1552,9 @@
             "license": "MIT"
         },
         "node_modules/@types/sinon": {
-            "version": "21.0.0",
-            "resolved": "https://registry.npmjs.org/@types/sinon/-/sinon-21.0.0.tgz",
-            "integrity": "sha512-+oHKZ0lTI+WVLxx1IbJDNmReQaIsQJjN2e7UUrJHEeByG7bFeKJYsv1E75JxTQ9QKJDp21bAa/0W2Xo4srsDnw==",
+            "version": "21.0.1",
+            "resolved": "https://registry.npmjs.org/@types/sinon/-/sinon-21.0.1.tgz",
+            "integrity": "sha512-5yoJSqLbjH8T9V2bksgRayuhpZy+723/z6wBOR+Soe4ZlXC0eW8Na71TeaZPUWDQvM7LYKa9UGFc6LRqxiR5fQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {


### PR DESCRIPTION
Partially supersedes #210

### What's Changed

- Update @types/sinon to 21.0.1
- Refresh root package-lock.json
- Verified with npm ci, npm run pretest, npm run compile, npm run compile:web, and npm run compile:plugin
