### PR TITLE
[CHORE] Update globals to 17.5.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4626,9 +4626,9 @@
             }
         },
         "node_modules/globals": {
-            "version": "17.4.0",
-            "resolved": "https://registry.npmjs.org/globals/-/globals-17.4.0.tgz",
-            "integrity": "sha512-hjrNztw/VajQwOLsMNT1cbJiH2muO3OROCHnbehc8eY5JyD2gqz4AcMHPqgaOR59DjgUjYAYLeH699g/eWi2jw==",
+            "version": "17.5.0",
+            "resolved": "https://registry.npmjs.org/globals/-/globals-17.5.0.tgz",
+            "integrity": "sha512-qoV+HK2yFl/366t2/Cb3+xxPUo5BuMynomoDmiaZBIdbs+0pYbjfZU+twLhGKp4uCZ/+NbtpVepH5bGCxRyy2g==",
             "dev": true,
             "license": "MIT",
             "engines": {


### PR DESCRIPTION
Supersedes #207

### What's Changed

- Update globals to 17.5.0
- Refresh root package-lock.json
- Verified with npm ci, npm run pretest, npm run compile, npm run compile:web, and npm run compile:plugin
