### PR TITLE
[CHORE] Update Prettier to 3.8.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7063,9 +7063,9 @@
             }
         },
         "node_modules/prettier": {
-            "version": "3.8.1",
-            "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.1.tgz",
-            "integrity": "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==",
+            "version": "3.8.3",
+            "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.3.tgz",
+            "integrity": "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==",
             "dev": true,
             "license": "MIT",
             "bin": {


### PR DESCRIPTION
### What's Changed

- Update Prettier to 3.8.3
- Refresh root package-lock.json
- Verified with npm ci, npm run pretest, npm run compile, npm run compile:web, and npm run compile:plugin
