### PR TITLE
[CHORE] Update @rollup/plugin-commonjs to 29.0.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
             },
             "devDependencies": {
                 "@eslint/js": "^9.39.2",
-                "@rollup/plugin-commonjs": "^28.0.6",
+                "@rollup/plugin-commonjs": "^29.0.2",
                 "@rollup/plugin-json": "^6.1.0",
                 "@rollup/plugin-node-resolve": "^16.0.3",
                 "@rollup/plugin-replace": "^6.0.3",
@@ -518,9 +518,9 @@
             }
         },
         "node_modules/@rollup/plugin-commonjs": {
-            "version": "28.0.9",
-            "resolved": "https://registry.npmjs.org/@rollup/plugin-commonjs/-/plugin-commonjs-28.0.9.tgz",
-            "integrity": "sha512-PIR4/OHZ79romx0BVVll/PkwWpJ7e5lsqFa3gFfcrFPWwLXLV39JVUzQV9RKjWerE7B845Hqjj9VYlQeieZ2dA==",
+            "version": "29.0.2",
+            "resolved": "https://registry.npmjs.org/@rollup/plugin-commonjs/-/plugin-commonjs-29.0.2.tgz",
+            "integrity": "sha512-S/ggWH1LU7jTyi9DxZOKyxpVd4hF/OZ0JrEbeLjXk/DFXwRny0tjD2c992zOUYQobLrVkRVMDdmHP16HKP7GRg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {

--- a/package.json
+++ b/package.json
@@ -159,7 +159,7 @@
     },
     "devDependencies": {
         "@eslint/js": "^9.39.2",
-        "@rollup/plugin-commonjs": "^28.0.6",
+        "@rollup/plugin-commonjs": "^29.0.2",
         "@rollup/plugin-json": "^6.1.0",
         "@rollup/plugin-node-resolve": "^16.0.3",
         "@rollup/plugin-replace": "^6.0.3",


### PR DESCRIPTION
Supersedes #212

### What's Changed

- Update @rollup/plugin-commonjs to 29.0.2
- Refresh root manifest and lockfile
- Verified with npm ci, npm run pretest, npm run compile, npm run compile:web, and npm run compile:plugin
