### PR TITLE
[CHORE] Update TypeScript stack to 6.0.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -48,8 +48,8 @@
                 "rollup": "^4.55.1",
                 "rollup-plugin-polyfill-node": "^0.13.0",
                 "sinon": "^21.0.1",
-                "typescript": "^5.9.3",
-                "typescript-eslint": "^8.51.0"
+                "typescript": "^6.0.2",
+                "typescript-eslint": "^8.58.2"
             },
             "engines": {
                 "vscode": "^1.98.0"
@@ -1593,20 +1593,20 @@
             }
         },
         "node_modules/@typescript-eslint/eslint-plugin": {
-            "version": "8.57.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.57.1.tgz",
-            "integrity": "sha512-Gn3aqnvNl4NGc6x3/Bqk1AOn0thyTU9bqDRhiRnUWezgvr2OnhYCWCgC8zXXRVqBsIL1pSDt7T9nJUe0oM0kDQ==",
+            "version": "8.58.2",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.58.2.tgz",
+            "integrity": "sha512-aC2qc5thQahutKjP+cl8cgN9DWe3ZUqVko30CMSZHnFEHyhOYoZSzkGtAI2mcwZ38xeImDucI4dnqsHiOYuuCw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@eslint-community/regexpp": "^4.12.2",
-                "@typescript-eslint/scope-manager": "8.57.1",
-                "@typescript-eslint/type-utils": "8.57.1",
-                "@typescript-eslint/utils": "8.57.1",
-                "@typescript-eslint/visitor-keys": "8.57.1",
+                "@typescript-eslint/scope-manager": "8.58.2",
+                "@typescript-eslint/type-utils": "8.58.2",
+                "@typescript-eslint/utils": "8.58.2",
+                "@typescript-eslint/visitor-keys": "8.58.2",
                 "ignore": "^7.0.5",
                 "natural-compare": "^1.4.0",
-                "ts-api-utils": "^2.4.0"
+                "ts-api-utils": "^2.5.0"
             },
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1616,22 +1616,22 @@
                 "url": "https://opencollective.com/typescript-eslint"
             },
             "peerDependencies": {
-                "@typescript-eslint/parser": "^8.57.1",
+                "@typescript-eslint/parser": "^8.58.2",
                 "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
-                "typescript": ">=4.8.4 <6.0.0"
+                "typescript": ">=4.8.4 <6.1.0"
             }
         },
         "node_modules/@typescript-eslint/parser": {
-            "version": "8.57.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.57.1.tgz",
-            "integrity": "sha512-k4eNDan0EIMTT/dUKc/g+rsJ6wcHYhNPdY19VoX/EOtaAG8DLtKCykhrUnuHPYvinn5jhAPgD2Qw9hXBwrahsw==",
+            "version": "8.58.2",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.58.2.tgz",
+            "integrity": "sha512-/Zb/xaIDfxeJnvishjGdcR4jmr7S+bda8PKNhRGdljDM+elXhlvN0FyPSsMnLmJUrVG9aPO6dof80wjMawsASg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/scope-manager": "8.57.1",
-                "@typescript-eslint/types": "8.57.1",
-                "@typescript-eslint/typescript-estree": "8.57.1",
-                "@typescript-eslint/visitor-keys": "8.57.1",
+                "@typescript-eslint/scope-manager": "8.58.2",
+                "@typescript-eslint/types": "8.58.2",
+                "@typescript-eslint/typescript-estree": "8.58.2",
+                "@typescript-eslint/visitor-keys": "8.58.2",
                 "debug": "^4.4.3"
             },
             "engines": {
@@ -1643,18 +1643,18 @@
             },
             "peerDependencies": {
                 "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
-                "typescript": ">=4.8.4 <6.0.0"
+                "typescript": ">=4.8.4 <6.1.0"
             }
         },
         "node_modules/@typescript-eslint/project-service": {
-            "version": "8.57.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.57.1.tgz",
-            "integrity": "sha512-vx1F37BRO1OftsYlmG9xay1TqnjNVlqALymwWVuYTdo18XuKxtBpCj1QlzNIEHlvlB27osvXFWptYiEWsVdYsg==",
+            "version": "8.58.2",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.58.2.tgz",
+            "integrity": "sha512-Cq6UfpZZk15+r87BkIh5rDpi38W4b+Sjnb8wQCPPDDweS/LRCFjCyViEbzHk5Ck3f2QDfgmlxqSa7S7clDtlfg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/tsconfig-utils": "^8.57.1",
-                "@typescript-eslint/types": "^8.57.1",
+                "@typescript-eslint/tsconfig-utils": "^8.58.2",
+                "@typescript-eslint/types": "^8.58.2",
                 "debug": "^4.4.3"
             },
             "engines": {
@@ -1665,18 +1665,18 @@
                 "url": "https://opencollective.com/typescript-eslint"
             },
             "peerDependencies": {
-                "typescript": ">=4.8.4 <6.0.0"
+                "typescript": ">=4.8.4 <6.1.0"
             }
         },
         "node_modules/@typescript-eslint/scope-manager": {
-            "version": "8.57.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.57.1.tgz",
-            "integrity": "sha512-hs/QcpCwlwT2L5S+3fT6gp0PabyGk4Q0Rv2doJXA0435/OpnSR3VRgvrp8Xdoc3UAYSg9cyUjTeFXZEPg/3OKg==",
+            "version": "8.58.2",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.58.2.tgz",
+            "integrity": "sha512-SgmyvDPexWETQek+qzZnrG6844IaO02UVyOLhI4wpo82dpZJY9+6YZCKAMFzXb7qhx37mFK1QcPQ18tud+vo6Q==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/types": "8.57.1",
-                "@typescript-eslint/visitor-keys": "8.57.1"
+                "@typescript-eslint/types": "8.58.2",
+                "@typescript-eslint/visitor-keys": "8.58.2"
             },
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1687,9 +1687,9 @@
             }
         },
         "node_modules/@typescript-eslint/tsconfig-utils": {
-            "version": "8.57.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.57.1.tgz",
-            "integrity": "sha512-0lgOZB8cl19fHO4eI46YUx2EceQqhgkPSuCGLlGi79L2jwYY1cxeYc1Nae8Aw1xjgW3PKVDLlr3YJ6Bxx8HkWg==",
+            "version": "8.58.2",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.58.2.tgz",
+            "integrity": "sha512-3SR+RukipDvkkKp/d0jP0dyzuls3DbGmwDpVEc5wqk5f38KFThakqAAO0XMirWAE+kT00oTauTbzMFGPoAzB0A==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -1700,21 +1700,21 @@
                 "url": "https://opencollective.com/typescript-eslint"
             },
             "peerDependencies": {
-                "typescript": ">=4.8.4 <6.0.0"
+                "typescript": ">=4.8.4 <6.1.0"
             }
         },
         "node_modules/@typescript-eslint/type-utils": {
-            "version": "8.57.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.57.1.tgz",
-            "integrity": "sha512-+Bwwm0ScukFdyoJsh2u6pp4S9ktegF98pYUU0hkphOOqdMB+1sNQhIz8y5E9+4pOioZijrkfNO/HUJVAFFfPKA==",
+            "version": "8.58.2",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.58.2.tgz",
+            "integrity": "sha512-Z7EloNR/B389FvabdGeTo2XMs4W9TjtPiO9DAsmT0yom0bwlPyRjkJ1uCdW1DvrrrYP50AJZ9Xc3sByZA9+dcg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/types": "8.57.1",
-                "@typescript-eslint/typescript-estree": "8.57.1",
-                "@typescript-eslint/utils": "8.57.1",
+                "@typescript-eslint/types": "8.58.2",
+                "@typescript-eslint/typescript-estree": "8.58.2",
+                "@typescript-eslint/utils": "8.58.2",
                 "debug": "^4.4.3",
-                "ts-api-utils": "^2.4.0"
+                "ts-api-utils": "^2.5.0"
             },
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1725,13 +1725,13 @@
             },
             "peerDependencies": {
                 "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
-                "typescript": ">=4.8.4 <6.0.0"
+                "typescript": ">=4.8.4 <6.1.0"
             }
         },
         "node_modules/@typescript-eslint/types": {
-            "version": "8.57.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.57.1.tgz",
-            "integrity": "sha512-S29BOBPJSFUiblEl6RzPPjJt6w25A6XsBqRVDt53tA/tlL8q7ceQNZHTjPeONt/3S7KRI4quk+yP9jK2WjBiPQ==",
+            "version": "8.58.2",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.58.2.tgz",
+            "integrity": "sha512-9TukXyATBQf/Jq9AMQXfvurk+G5R2MwfqQGDR2GzGz28HvY/lXNKGhkY+6IOubwcquikWk5cjlgPvD2uAA7htQ==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -1743,21 +1743,21 @@
             }
         },
         "node_modules/@typescript-eslint/typescript-estree": {
-            "version": "8.57.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.57.1.tgz",
-            "integrity": "sha512-ybe2hS9G6pXpqGtPli9Gx9quNV0TWLOmh58ADlmZe9DguLq0tiAKVjirSbtM1szG6+QH6rVXyU6GTLQbWnMY+g==",
+            "version": "8.58.2",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.58.2.tgz",
+            "integrity": "sha512-ELGuoofuhhoCvNbQjFFiobFcGgcDCEm0ThWdmO4Z0UzLqPXS3KFvnEZ+SHewwOYHjM09tkzOWXNTv9u6Gqtyuw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/project-service": "8.57.1",
-                "@typescript-eslint/tsconfig-utils": "8.57.1",
-                "@typescript-eslint/types": "8.57.1",
-                "@typescript-eslint/visitor-keys": "8.57.1",
+                "@typescript-eslint/project-service": "8.58.2",
+                "@typescript-eslint/tsconfig-utils": "8.58.2",
+                "@typescript-eslint/types": "8.58.2",
+                "@typescript-eslint/visitor-keys": "8.58.2",
                 "debug": "^4.4.3",
                 "minimatch": "^10.2.2",
                 "semver": "^7.7.3",
                 "tinyglobby": "^0.2.15",
-                "ts-api-utils": "^2.4.0"
+                "ts-api-utils": "^2.5.0"
             },
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1767,7 +1767,7 @@
                 "url": "https://opencollective.com/typescript-eslint"
             },
             "peerDependencies": {
-                "typescript": ">=4.8.4 <6.0.0"
+                "typescript": ">=4.8.4 <6.1.0"
             }
         },
         "node_modules/@typescript-eslint/typescript-estree/node_modules/balanced-match": {
@@ -1781,9 +1781,9 @@
             }
         },
         "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-            "version": "5.0.4",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.4.tgz",
-            "integrity": "sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg==",
+            "version": "5.0.5",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+            "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -1794,13 +1794,13 @@
             }
         },
         "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
-            "version": "10.2.4",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.4.tgz",
-            "integrity": "sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==",
+            "version": "10.2.5",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+            "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
             "dev": true,
             "license": "BlueOak-1.0.0",
             "dependencies": {
-                "brace-expansion": "^5.0.2"
+                "brace-expansion": "^5.0.5"
             },
             "engines": {
                 "node": "18 || 20 || >=22"
@@ -1810,16 +1810,16 @@
             }
         },
         "node_modules/@typescript-eslint/utils": {
-            "version": "8.57.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.57.1.tgz",
-            "integrity": "sha512-XUNSJ/lEVFttPMMoDVA2r2bwrl8/oPx8cURtczkSEswY5T3AeLmCy+EKWQNdL4u0MmAHOjcWrqJp2cdvgjn8dQ==",
+            "version": "8.58.2",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.58.2.tgz",
+            "integrity": "sha512-QZfjHNEzPY8+l0+fIXMvuQ2sJlplB4zgDZvA+NmvZsZv3EQwOcc1DuIU1VJUTWZ/RKouBMhDyNaBMx4sWvrzRA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.9.1",
-                "@typescript-eslint/scope-manager": "8.57.1",
-                "@typescript-eslint/types": "8.57.1",
-                "@typescript-eslint/typescript-estree": "8.57.1"
+                "@typescript-eslint/scope-manager": "8.58.2",
+                "@typescript-eslint/types": "8.58.2",
+                "@typescript-eslint/typescript-estree": "8.58.2"
             },
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1830,17 +1830,17 @@
             },
             "peerDependencies": {
                 "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
-                "typescript": ">=4.8.4 <6.0.0"
+                "typescript": ">=4.8.4 <6.1.0"
             }
         },
         "node_modules/@typescript-eslint/visitor-keys": {
-            "version": "8.57.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.57.1.tgz",
-            "integrity": "sha512-YWnmJkXbofiz9KbnbbwuA2rpGkFPLbAIetcCNO6mJ8gdhdZ/v7WDXsoGFAJuM6ikUFKTlSQnjWnVO4ux+UzS6A==",
+            "version": "8.58.2",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.58.2.tgz",
+            "integrity": "sha512-f1WO2Lx8a9t8DARmcWAUPJbu0G20bJlj8L4z72K00TMeJAoyLr/tHhI/pzYBLrR4dXWkcxO1cWYZEOX8DKHTqA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/types": "8.57.1",
+                "@typescript-eslint/types": "8.58.2",
                 "eslint-visitor-keys": "^5.0.0"
             },
             "engines": {
@@ -8386,9 +8386,9 @@
             }
         },
         "node_modules/ts-api-utils": {
-            "version": "2.4.0",
-            "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.4.0.tgz",
-            "integrity": "sha512-3TaVTaAv2gTiMB35i3FiGJaRfwb3Pyn/j3m/bfAvGe8FB7CF6u+LMYqYlDh7reQf7UNvoTvdfAqHGmPGOSsPmA==",
+            "version": "2.5.0",
+            "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.5.0.tgz",
+            "integrity": "sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -8560,9 +8560,9 @@
             }
         },
         "node_modules/typescript": {
-            "version": "5.9.3",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-            "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+            "version": "6.0.2",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.2.tgz",
+            "integrity": "sha512-bGdAIrZ0wiGDo5l8c++HWtbaNCWTS4UTv7RaTH/ThVIgjkveJt83m74bBHMJkuCbslY8ixgLBVZJIOiQlQTjfQ==",
             "license": "Apache-2.0",
             "bin": {
                 "tsc": "bin/tsc",
@@ -8573,16 +8573,16 @@
             }
         },
         "node_modules/typescript-eslint": {
-            "version": "8.57.1",
-            "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.57.1.tgz",
-            "integrity": "sha512-fLvZWf+cAGw3tqMCYzGIU6yR8K+Y9NT2z23RwOjlNFF2HwSB3KhdEFI5lSBv8tNmFkkBShSjsCjzx1vahZfISA==",
+            "version": "8.58.2",
+            "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.58.2.tgz",
+            "integrity": "sha512-V8iSng9mRbdZjl54VJ9NKr6ZB+dW0J3TzRXRGcSbLIej9jV86ZRtlYeTKDR/QLxXykocJ5icNzbsl2+5TzIvcQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/eslint-plugin": "8.57.1",
-                "@typescript-eslint/parser": "8.57.1",
-                "@typescript-eslint/typescript-estree": "8.57.1",
-                "@typescript-eslint/utils": "8.57.1"
+                "@typescript-eslint/eslint-plugin": "8.58.2",
+                "@typescript-eslint/parser": "8.58.2",
+                "@typescript-eslint/typescript-estree": "8.58.2",
+                "@typescript-eslint/utils": "8.58.2"
             },
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -8593,7 +8593,7 @@
             },
             "peerDependencies": {
                 "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
-                "typescript": ">=4.8.4 <6.0.0"
+                "typescript": ">=4.8.4 <6.1.0"
             }
         },
         "node_modules/unbox-primitive": {

--- a/package.json
+++ b/package.json
@@ -188,8 +188,8 @@
         "rollup": "^4.55.1",
         "rollup-plugin-polyfill-node": "^0.13.0",
         "sinon": "^21.0.1",
-        "typescript": "^5.9.3",
-        "typescript-eslint": "^8.51.0"
+        "typescript": "^6.0.2",
+        "typescript-eslint": "^8.58.2"
     },
     "engines": {
         "vscode": "^1.98.0"

--- a/plugin/package-lock.json
+++ b/plugin/package-lock.json
@@ -7,14 +7,15 @@
         "": {
             "name": "playcanvas-plugin",
             "version": "0.0.0",
+            "license": "MIT",
             "dependencies": {
                 "typescript": "*"
             }
         },
         "node_modules/typescript": {
-            "version": "5.9.3",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-            "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+            "version": "6.0.2",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.2.tgz",
+            "integrity": "sha512-bGdAIrZ0wiGDo5l8c++HWtbaNCWTS4UTv7RaTH/ThVIgjkveJt83m74bBHMJkuCbslY8ixgLBVZJIOiQlQTjfQ==",
             "license": "Apache-2.0",
             "bin": {
                 "tsc": "bin/tsc",


### PR DESCRIPTION
Supersedes #205; partially supersedes #208

### What's Changed

- Update root and plugin TypeScript to 6.0.2
- Align typescript-eslint with the TypeScript 6 peer range
- Verified with npm ci, cd plugin && npm ci && npx tsc -p . && npm pack --dry-run, npm run pretest, npm run compile, npm run compile:web, and npm run compile:plugin
