### PR TITLE
[FIX] Prevent open-file sync desyncs

### DIFF
--- a/src/disk.ts
+++ b/src/disk.ts
@@ -846,12 +846,13 @@ class Disk extends Linker<{ folderUri: vscode.Uri; projectManager: ProjectManage
 
         const onchange = vscode.workspace.onDidChangeTextDocument((e) => {
             const { document, contentChanges, reason } = e;
-            if (contentChanges.length === 0) {
+            // check if in folder
+            if (!uriStartsWith(document.uri, folderUri)) {
                 return;
             }
 
-            // check if in folder
-            if (!uriStartsWith(document.uri, folderUri)) {
+            // check if there are changes
+            if (contentChanges.length === 0) {
                 return;
             }
 
@@ -917,11 +918,6 @@ class Disk extends Linker<{ folderUri: vscode.Uri; projectManager: ProjectManage
             file.dirty ||= !!ops.length;
             if (!prev && file.dirty) {
                 this._events.emit('asset:file:dirty', path, true);
-            }
-
-            // external disk change — force dirty indicator
-            if (!document.isDirty && ops.length) {
-                this._dirtify(document);
             }
 
             this._log.debug(`document.change ${document.uri.path} ${ops.map((o) => stat(o)).join(' ')}`);

--- a/src/disk.ts
+++ b/src/disk.ts
@@ -232,6 +232,14 @@ class Disk extends Linker<{ folderUri: vscode.Uri; projectManager: ProjectManage
                     return;
                 }
 
+                const viewing =
+                    this._opened.has(uri.path) ||
+                    vscode.workspace.textDocuments.some((d) => d.uri.toString() === uri.toString());
+                if (viewing) {
+                    this._log.debug(`create.remote.open ${uri}`);
+                    return;
+                }
+
                 // for files, check content
                 const existingContent = await vscode.workspace.fs.readFile(uri);
                 if (buffer.cmp(existingContent, content)) {
@@ -616,6 +624,16 @@ class Disk extends Linker<{ folderUri: vscode.Uri; projectManager: ProjectManage
             const uri = vscode.Uri.joinPath(folderUri, path);
             this._checkIgnoreUpdated(uri);
             await this._create(uri, type, content);
+            if (type !== 'file' || !this._opened.has(uri.path)) {
+                return;
+            }
+
+            const file = this._projectManager?.files.get(path);
+            if (!file || file.type !== 'file') {
+                return;
+            }
+
+            await this._subscribed(uri, path, file.doc.text, file.dirty);
         });
         const assetFileUpdate = this._events.on('asset:file:update', async (path, op, content, prev) => {
             const uri = vscode.Uri.joinPath(folderUri, path);

--- a/src/disk.ts
+++ b/src/disk.ts
@@ -572,6 +572,19 @@ class Disk extends Linker<{ folderUri: vscode.Uri; projectManager: ProjectManage
         }
     }
 
+    private async _reconcile(uri: vscode.Uri, path: string, type: 'file' | 'folder') {
+        if (type !== 'file' || !this._opened.has(uri.path)) {
+            return;
+        }
+
+        const file = this._projectManager?.files.get(path);
+        if (!file || file.type !== 'file') {
+            return;
+        }
+
+        await this._subscribed(uri, path, file.doc.text, file.dirty);
+    }
+
     private _dirtify(doc: vscode.TextDocument) {
         const folderUri = this._folderUri;
         const pm = this._projectManager;
@@ -624,16 +637,7 @@ class Disk extends Linker<{ folderUri: vscode.Uri; projectManager: ProjectManage
             const uri = vscode.Uri.joinPath(folderUri, path);
             this._checkIgnoreUpdated(uri);
             await this._create(uri, type, content);
-            if (type !== 'file' || !this._opened.has(uri.path)) {
-                return;
-            }
-
-            const file = this._projectManager?.files.get(path);
-            if (!file || file.type !== 'file') {
-                return;
-            }
-
-            await this._subscribed(uri, path, file.doc.text, file.dirty);
+            await this._reconcile(uri, path, type);
         });
         const assetFileUpdate = this._events.on('asset:file:update', async (path, op, content, prev) => {
             const uri = vscode.Uri.joinPath(folderUri, path);

--- a/src/test/suite/extension.test.ts
+++ b/src/test/suite/extension.test.ts
@@ -1153,54 +1153,6 @@ suite('extension', () => {
         assert.strictEqual(saveCalls.length, 0, 'should not send doc:save for external closed file change');
     });
 
-    test('file change - external write dirtifies', async () => {
-        // get folder uri
-        const folderUri = vscode.workspace.workspaceFolders?.[0]?.uri;
-        assert.ok(folderUri, 'workspace folder should exist');
-
-        // create asset
-        const asset = await assetCreate({ name: 'dirtify_external.js', content: '// SAMPLE CONTENT' });
-        assert.ok(asset, 'asset should be created');
-        const document = documents.get(asset.uniqueId);
-        assert.ok(document, 'document should exist');
-
-        // get file uri
-        const uri = vscode.Uri.joinPath(folderUri, asset.name);
-
-        // open document
-        const tdoc = await vscode.workspace.openTextDocument(uri);
-
-        // reset sendRaw history
-        sharedb.sendRaw.resetHistory();
-
-        // create change promise (onDidChangeTextDocument fires for external edits)
-        const changed = new Promise<void>((resolve) => {
-            const disposable = vscode.workspace.onDidChangeTextDocument((e) => {
-                if (e.document.uri.toString() === uri.toString() && e.document.getText() !== document) {
-                    disposable.dispose();
-                    resolve();
-                }
-            });
-        });
-
-        // make external change by writing to file directly
-        const newContent = `// EXTERNAL EDIT\n${document}`;
-        await vscode.workspace.fs.writeFile(uri, buffer.from(newContent));
-
-        // wait for VS Code to reload buffer and fire onDidChangeTextDocument
-        await assertResolves(changed, 'vscode.onDidChangeTextDocument');
-
-        // wait for dirtify and any deferred handlers
-        await wait(200);
-
-        // verify document is dirty (dirtify worked)
-        assert.strictEqual(tdoc.isDirty, true, 'document should be dirty after external edit');
-
-        // verify no doc:save was sent (no auto-save)
-        const saveCalls = sharedb.sendRaw.getCalls().filter((c) => `${c.args[0]}`.startsWith('doc:save:'));
-        assert.strictEqual(saveCalls.length, 0, 'should not send doc:save for external open file change');
-    });
-
     test('file save - local to remote', async () => {
         // get folder uri
         const folderUri = vscode.workspace.workspaceFolders?.[0]?.uri;


### PR DESCRIPTION
Fixes #201
Fixes #227

### What's Changed

- avoid rewriting an already-open file during remote create
- reconcile open buffers after create so the first edit is preserved
- stop synthetic dirtify from running on local document edits

### Known Regression

- open files changed by external tools will no longer be synthetic-dirtied by this code path; that follow-up fix is intentionally deferred to a separate PR

### Validation

- npm run compile
- npm run lint