### PR TITLE
[FIX] Mark external reloads dirty

### DIFF
--- a/src/disk.ts
+++ b/src/disk.ts
@@ -585,7 +585,7 @@ class Disk extends Linker<{ folderUri: vscode.Uri; projectManager: ProjectManage
         await this._subscribed(uri, path, file.doc.text, file.dirty);
     }
 
-    private _dirtify(doc: vscode.TextDocument) {
+    private _dirty(doc: vscode.TextDocument) {
         const folderUri = this._folderUri;
         const pm = this._projectManager;
         if (!folderUri || !pm) {
@@ -617,7 +617,7 @@ class Disk extends Linker<{ folderUri: vscode.Uri; projectManager: ProjectManage
                         expected.substring(prefix, expected.length - suffix)
                     );
                     if (!(await vscode.workspace.applyEdit(edit))) {
-                        this._log.warn(`dirtify applyEdit failed for ${doc.uri}`);
+                        this._log.warn(`dirty applyEdit failed for ${doc.uri}`);
                     }
                 } else {
                     // content matches -- replace first char with itself to mark dirty without visible change
@@ -628,8 +628,36 @@ class Disk extends Linker<{ folderUri: vscode.Uri; projectManager: ProjectManage
             });
             this._locks.delete(`${doc.uri}`);
 
-            this._log.debug(`dirtify ${doc.uri}`);
+            this._log.debug(`dirty ${doc.uri}`);
         });
+    }
+
+    private _dirtyReload(document: vscode.TextDocument, text: string) {
+        this._diskHash.set(document.uri.path, hash(text));
+
+        // avoid touching eol chars
+        const raw = document.getText();
+        const i = raw.search(/[^\r\n]/);
+        if (i === -1) {
+            return;
+        }
+
+        const key = `${document.uri}`;
+        const ch = raw.charAt(i);
+        const edit = new vscode.WorkspaceEdit();
+        edit.replace(document.uri, new vscode.Range(document.positionAt(i), document.positionAt(i + 1)), ch);
+
+        // set lock to prevent echo and discard from _update
+        this._locks.add(key);
+        void Promise.resolve(vscode.workspace.applyEdit(edit))
+            .then((applied) => {
+                if (!applied) {
+                    this._log.warn(`dirty reload applyEdit failed for ${document.uri}`);
+                }
+            })
+            .finally(() => {
+                this._locks.delete(key);
+            });
     }
 
     private _watchEvents(folderUri: vscode.Uri) {
@@ -817,7 +845,7 @@ class Disk extends Linker<{ folderUri: vscode.Uri; projectManager: ProjectManage
             this._opened.add(open.uri.path);
             this._undos.set(open.uri.path, new UndoManager());
             this._events.emit('asset:doc:open', path);
-            this._dirtify(open);
+            this._dirty(open);
         }
         const onopen = vscode.workspace.onDidOpenTextDocument((document) => {
             if (!uriStartsWith(document.uri, folderUri)) {
@@ -828,7 +856,7 @@ class Disk extends Linker<{ folderUri: vscode.Uri; projectManager: ProjectManage
             this._undos.set(document.uri.path, new UndoManager());
             this._diskHash.set(document.uri.path, hash(norm(document.getText())));
             this._events.emit('asset:doc:open', path);
-            this._dirtify(document);
+            this._dirty(document);
         });
         const onclose = vscode.workspace.onDidCloseTextDocument((document) => {
             if (!uriStartsWith(document.uri, folderUri)) {
@@ -920,7 +948,15 @@ class Disk extends Linker<{ folderUri: vscode.Uri; projectManager: ProjectManage
                 this._events.emit('asset:file:dirty', path, true);
             }
 
-            this._log.debug(`document.change ${document.uri.path} ${ops.map((o) => stat(o)).join(' ')}`);
+            // trigger VSCode dirty indicator if externally changed
+            const external = !reason && ops.length > 0 && !document.isDirty;
+            if (external) {
+                this._dirtyReload(document, text);
+            }
+
+            this._log.debug(
+                `document.change ${document.uri.path} ${ops.map((o) => stat(o)).join(' ')} external=${external}`
+            );
         });
         const onsave = vscode.workspace.onWillSaveTextDocument((e) => {
             const { document } = e;
@@ -1097,7 +1133,7 @@ class Disk extends Linker<{ folderUri: vscode.Uri; projectManager: ProjectManage
                                                 (d) => d.uri.path === op.uri.path
                                             );
                                             if (doc) {
-                                                this._dirtify(doc);
+                                                this._dirty(doc);
                                             }
                                         }
                                         return;
@@ -1170,7 +1206,7 @@ class Disk extends Linker<{ folderUri: vscode.Uri; projectManager: ProjectManage
                                             (d) => d.uri.path === op.uri.path
                                         );
                                         if (doc) {
-                                            this._dirtify(doc);
+                                            this._dirty(doc);
                                         }
                                     }
 

--- a/src/test/suite/extension.test.ts
+++ b/src/test/suite/extension.test.ts
@@ -1153,6 +1153,46 @@ suite('extension', () => {
         assert.strictEqual(saveCalls.length, 0, 'should not send doc:save for external closed file change');
     });
 
+    test('file change - open external dirties document', async () => {
+        const folderUri = vscode.workspace.workspaceFolders?.[0]?.uri;
+        assert.ok(folderUri, 'workspace folder should exist');
+
+        const asset = await assetCreate({ name: 'external_open_dirty.js', content: '// SAMPLE CONTENT' });
+        assert.ok(asset, 'asset should be created');
+        const document = documents.get(asset.uniqueId);
+        assert.ok(document, 'document should exist');
+
+        const uri = vscode.Uri.joinPath(folderUri, asset.name);
+        const tdoc = await vscode.workspace.openTextDocument(uri);
+        await vscode.window.showTextDocument(tdoc);
+
+        const doc = sharedb.subscriptions.get(`documents:${asset.uniqueId}`);
+        assert.ok(doc, 'sharedb document should exist');
+        doc.submitOp.resetHistory();
+
+        const newContent = `// OPEN EXTERNAL\n${document}`;
+        const updated = assertOpsPromise(`documents:${asset.uniqueId}`, [[3, 'OPEN EXTERNAL\n// ']]);
+        const dirtied = new Promise<void>((resolve) => {
+            const disposable = vscode.workspace.onDidChangeTextDocument((e) => {
+                if (e.document.uri.toString() !== uri.toString()) {
+                    return;
+                }
+                if (tdoc.isDirty && tdoc.getText() === newContent) {
+                    disposable.dispose();
+                    resolve();
+                }
+            });
+        });
+
+        await vscode.workspace.fs.writeFile(uri, buffer.from(newContent));
+
+        await assertResolves(updated, 'sharedb.op');
+        await assertResolves(dirtied, 'document dirty after external open change');
+
+        assert.strictEqual(doc.submitOp.callCount, 1, 'should submit one op for external open file change');
+        assert.strictEqual(tdoc.isDirty, true, 'document should be dirty after external open file change');
+    });
+
     test('file save - local to remote', async () => {
         // get folder uri
         const folderUri = vscode.workspace.workspaceFolders?.[0]?.uri;

--- a/src/test/suite/extension.test.ts
+++ b/src/test/suite/extension.test.ts
@@ -1153,46 +1153,6 @@ suite('extension', () => {
         assert.strictEqual(saveCalls.length, 0, 'should not send doc:save for external closed file change');
     });
 
-    test('file change - open external dirties document', async () => {
-        const folderUri = vscode.workspace.workspaceFolders?.[0]?.uri;
-        assert.ok(folderUri, 'workspace folder should exist');
-
-        const asset = await assetCreate({ name: 'external_open_dirty.js', content: '// SAMPLE CONTENT' });
-        assert.ok(asset, 'asset should be created');
-        const document = documents.get(asset.uniqueId);
-        assert.ok(document, 'document should exist');
-
-        const uri = vscode.Uri.joinPath(folderUri, asset.name);
-        const tdoc = await vscode.workspace.openTextDocument(uri);
-        await vscode.window.showTextDocument(tdoc);
-
-        const doc = sharedb.subscriptions.get(`documents:${asset.uniqueId}`);
-        assert.ok(doc, 'sharedb document should exist');
-        doc.submitOp.resetHistory();
-
-        const newContent = `// OPEN EXTERNAL\n${document}`;
-        const updated = assertOpsPromise(`documents:${asset.uniqueId}`, [[3, 'OPEN EXTERNAL\n// ']]);
-        const dirtied = new Promise<void>((resolve) => {
-            const disposable = vscode.workspace.onDidChangeTextDocument((e) => {
-                if (e.document.uri.toString() !== uri.toString()) {
-                    return;
-                }
-                if (tdoc.isDirty && tdoc.getText() === newContent) {
-                    disposable.dispose();
-                    resolve();
-                }
-            });
-        });
-
-        await vscode.workspace.fs.writeFile(uri, buffer.from(newContent));
-
-        await assertResolves(updated, 'sharedb.op');
-        await assertResolves(dirtied, 'document dirty after external open change');
-
-        assert.strictEqual(doc.submitOp.callCount, 1, 'should submit one op for external open file change');
-        assert.strictEqual(tdoc.isDirty, true, 'document should be dirty after external open file change');
-    });
-
     test('file save - local to remote', async () => {
         // get folder uri
         const folderUri = vscode.workspace.workspaceFolders?.[0]?.uri;


### PR DESCRIPTION
### What's Changed

- mark open files dirty when an external reload updates the buffer without setting `document.isDirty`
- isolate the native dirty-dot workaround in `_dirtyReload` and rename the general helper to `_dirty`
- add a regression test covering open external edits

### Validation

- `npm run compile`
- `npm run pretest`