### PR TITLE
[FIX] Coalesce rapid doc:save messages

### DIFF
--- a/src/project-manager.ts
+++ b/src/project-manager.ts
@@ -393,6 +393,14 @@ class ProjectManager extends Linker<{ projectId: number; branchId: string }> {
         return false;
     }
 
+    private _drainSaves(uniqueId: number, path: string) {
+        if (!this._savePending.has(uniqueId)) {
+            return;
+        }
+        this._savePending.delete(uniqueId);
+        this.save(path);
+    }
+
     private _watchSharedb() {
         const docSaveHandle = this._sharedb.on('doc:save', (state, uniqueId) => {
             if (!this._assets.has(uniqueId)) {
@@ -417,7 +425,7 @@ class ProjectManager extends Linker<{ projectId: number; branchId: string }> {
             // mark as clean (sharedb content now synced with S3)
             file.dirty = false;
             this._events.emit('asset:file:save', path);
-            this._drainSavePending(uniqueId, path);
+            this._drainSaves(uniqueId, path);
         });
         return () => {
             this._sharedb.off('doc:save', docSaveHandle);
@@ -1142,20 +1150,12 @@ class ProjectManager extends Linker<{ projectId: number; branchId: string }> {
             if (!file.dirty) {
                 this._saveInflight.delete(file.uniqueId);
                 this._events.emit('asset:file:save', path);
-                this._drainSavePending(file.uniqueId, path);
+                this._drainSaves(file.uniqueId, path);
                 return;
             }
             this._sharedb.sendRaw(`doc:save:${file.uniqueId}`);
             this._log.debug(`saved file ${path}`);
         });
-    }
-
-    private _drainSavePending(uniqueId: number, path: string) {
-        if (!this._savePending.has(uniqueId)) {
-            return;
-        }
-        this._savePending.delete(uniqueId);
-        this.save(path);
     }
 
     path(assetId: number) {

--- a/src/project-manager.ts
+++ b/src/project-manager.ts
@@ -59,6 +59,10 @@ class ProjectManager extends Linker<{ projectId: number; branchId: string }> {
 
     private _saveRetries = new Map<number, { timeout?: NodeJS.Timeout; attempt: number }>();
 
+    private _saveInflight = new Set<number>();
+
+    private _savePending = new Set<number>();
+
     private _events: EventEmitter<EventMap>;
 
     private _sharedb: ShareDb;
@@ -395,6 +399,11 @@ class ProjectManager extends Linker<{ projectId: number; branchId: string }> {
                 return;
             }
 
+            // clear in-flight on any ack; retry path (_verifySave) re-sends
+            // sendRaw directly without re-entering save(), so its ack will
+            // arrive with an empty _saveInflight — harmless
+            this._saveInflight.delete(uniqueId);
+
             if (!this._verifySave(state, uniqueId)) {
                 return;
             }
@@ -408,6 +417,7 @@ class ProjectManager extends Linker<{ projectId: number; branchId: string }> {
             // mark as clean (sharedb content now synced with S3)
             file.dirty = false;
             this._events.emit('asset:file:save', path);
+            this._drainSavePending(uniqueId, path);
         });
         return () => {
             this._sharedb.off('doc:save', docSaveHandle);
@@ -1114,13 +1124,38 @@ class ProjectManager extends Linker<{ projectId: number; branchId: string }> {
             return;
         }
 
+        // coalesce: if a save is already in-flight, mark pending and let the
+        // ack drive the follow-up (Code Editor save.ts:159-162)
+        if (this._saveInflight.has(file.uniqueId)) {
+            this._savePending.add(file.uniqueId);
+            return;
+        }
+        this._saveInflight.add(file.uniqueId);
+
         // wait for pending ops to be acknowledged before saving,
         // matching the Code Editor's behavior (save.ts:144-150).
         // prevents saving stale content while ops are in-flight.
         file.doc.whenNothingPending(() => {
+            // re-check after pending drains: a remote op may have brought the
+            // doc back in line with S3 (file.dirty is kept live in the 'op' and
+            // 'reload' handlers), in which case skip the server round-trip
+            if (!file.dirty) {
+                this._saveInflight.delete(file.uniqueId);
+                this._events.emit('asset:file:save', path);
+                this._drainSavePending(file.uniqueId, path);
+                return;
+            }
             this._sharedb.sendRaw(`doc:save:${file.uniqueId}`);
             this._log.debug(`saved file ${path}`);
         });
+    }
+
+    private _drainSavePending(uniqueId: number, path: string) {
+        if (!this._savePending.has(uniqueId)) {
+            return;
+        }
+        this._savePending.delete(uniqueId);
+        this.save(path);
     }
 
     path(assetId: number) {
@@ -1434,6 +1469,8 @@ class ProjectManager extends Linker<{ projectId: number; branchId: string }> {
 
             this._saveRetries.forEach(({ timeout }) => clearTimeout(timeout));
             this._saveRetries.clear();
+            this._saveInflight.clear();
+            this._savePending.clear();
 
             this._files.clear();
             this._assets.clear();


### PR DESCRIPTION
### What's Changed

Follow-up to #241. Rapid `Cmd+S` presses previously funnelled through `projectManager.save()` with no in-flight tracking — N presses queued N `whenNothingPending` callbacks and fired N `doc:save:${uniqueId}` messages. Each triggers a server save-pipeline run (checkpointing, compaction, version bumps), which is exactly the condition that maximises the chance of the `_opAcknowledged` version-mismatch branch in sharedb's client firing — one of the triggers for the ingestSnapshot desync that #241 recovers from.

Port the coalescing pattern the online Code Editor already uses in `editor/src/code-editor/menu-panel/file/save.ts`:

- `_saveInflight: Set<number>` — docs with an in-flight `doc:save:` ack pending.
- `_savePending: Set<number>` — a second save was requested while the first was in-flight.
- `save()` early-returns into `_savePending` when the doc is already saving. After `whenNothingPending` drains, re-checks `file.dirty` (kept live by the `'op'` and `'reload'` handlers from #241) to skip the server round-trip when a remote op brought the doc back in line with S3.
- The `doc:save` ack handler clears `_saveInflight` unconditionally and drains `_savePending` on success. The retry path in `_verifySave` is unchanged — it re-sends directly without re-entering `save()`, so its own ack harmlessly finds an empty `_saveInflight`.
- `unlink` clears both new sets alongside `_saveRetries`.

Net effect: N rapid `Cmd+S` presses produce at most 2 server messages (first save + one deferred) instead of N. Often 1 after the `file.dirty` re-check.

No changes to the server protocol, no new tests (VS Code's own save dedupes when the doc isn't dirty, and the mock's synchronous ack collapses the in-flight window — the coalescing invariant is better covered by manual testing).