### PR TITLE
[FIX] Parallelize initial disk writes on project link

### DIFF
--- a/src/disk.ts
+++ b/src/disk.ts
@@ -18,6 +18,9 @@ import { signal } from './utils/signal';
 import { delta, diff, norm, stat, sharedb2vscode, vscode2sharedb } from './utils/text';
 import { parsePath, relativePath, uriStartsWith, fileExists, tryCatch, hash } from './utils/utils';
 
+const FETCH_CONCURRENCY = 16;
+const WRITE_CONCURRENCY = 16;
+
 const readDirRecursive = async (uri: vscode.Uri) => {
     const entries = await vscode.workspace.fs.readDirectory(uri);
     const result: vscode.Uri[] = [];
@@ -54,10 +57,6 @@ const fileContent = async (uri: vscode.Uri, type: Promise<'file' | 'folder' | un
     }
     return content;
 };
-
-const FETCH_CONCURRENCY = 16;
-
-const WRITE_CONCURRENCY = 16;
 
 // Helper function for path matching (checks if paths are related - ancestor/descendant)
 const pathsRelated = (path1: string, path2: string): boolean => {

--- a/src/disk.ts
+++ b/src/disk.ts
@@ -3,7 +3,7 @@ import { type as ottext } from 'ot-text';
 import * as vscode from 'vscode';
 
 import { NAME } from './config';
-import { simpleNotification } from './notification';
+import { progressNotification } from './notification';
 import type { ProjectManager } from './project-manager';
 import type { EventMap } from './typings/event-map';
 import type { ShareDbTextOp } from './typings/sharedb';
@@ -1385,9 +1385,6 @@ class Disk extends Linker<{ folderUri: vscode.Uri; projectManager: ProjectManage
         // drain stale cleanup from a previously failed link
         await super.unlink();
 
-        // read files to disk
-        const updatingDiskDone = await simpleNotification('Updating Disk');
-
         // sort into hierarchy
         // TODO: store as tree instead of flat map and sorting
         const ordered = Array.from(projectManager.files.entries()).sort((a, b) => {
@@ -1410,6 +1407,11 @@ class Disk extends Linker<{ folderUri: vscode.Uri; projectManager: ProjectManage
             return 0;
         });
 
+        // show progress notification early so users see feedback during REST prefetch
+        const folders = ordered.filter(([, f]) => f.type === 'folder');
+        const files = ordered.filter(([, f]) => f.type !== 'folder');
+        const updatingDiskNext = await progressNotification('Updating Disk', folders.length + files.length);
+
         // prefetch REST content for stubs (concurrent with limit)
         const stubs = ordered.filter(([, f]) => f.type === 'stub');
         const fetched = new Map<number, Uint8Array>();
@@ -1431,7 +1433,7 @@ class Disk extends Linker<{ folderUri: vscode.Uri; projectManager: ProjectManage
             for (let i = 0; i < entries.length; i += WRITE_CONCURRENCY) {
                 const batch = entries.slice(i, i + WRITE_CONCURRENCY);
                 await Promise.all(
-                    batch.map(([path, file]) => {
+                    batch.map(async ([path, file]) => {
                         const uri = vscode.Uri.joinPath(folderUri, path);
                         let content: Uint8Array;
                         if (file.type === 'file') {
@@ -1441,19 +1443,14 @@ class Disk extends Linker<{ folderUri: vscode.Uri; projectManager: ProjectManage
                         } else {
                             content = new Uint8Array();
                         }
-                        return this._create(uri, type, content);
+                        await this._create(uri, type, content);
+                        updatingDiskNext();
                     })
                 );
             }
         };
-        await writeBatched(
-            ordered.filter(([, f]) => f.type === 'folder'),
-            'folder'
-        );
-        await writeBatched(
-            ordered.filter(([, f]) => f.type !== 'folder'),
-            'file'
-        );
+        await writeBatched(folders, 'folder');
+        await writeBatched(files, 'file');
 
         // parse ignore file (after disk write so stub content is available)
         const ignoreFile = projectManager.files.get(Disk.IGNORE_FILE);
@@ -1507,9 +1504,6 @@ class Disk extends Linker<{ folderUri: vscode.Uri; projectManager: ProjectManage
 
         this._folderUri = folderUri;
         this._projectManager = projectManager;
-
-        // notify completion
-        updatingDiskDone();
 
         this._log.info(`linked to ${folderUri.toString()}`);
     }

--- a/src/disk.ts
+++ b/src/disk.ts
@@ -57,6 +57,8 @@ const fileContent = async (uri: vscode.Uri, type: Promise<'file' | 'folder' | un
 
 const FETCH_CONCURRENCY = 16;
 
+const WRITE_CONCURRENCY = 16;
+
 // Helper function for path matching (checks if paths are related - ancestor/descendant)
 const pathsRelated = (path1: string, path2: string): boolean => {
     if (path1 === path2) {
@@ -1424,19 +1426,34 @@ class Disk extends Linker<{ folderUri: vscode.Uri; projectManager: ProjectManage
             }
         }
 
-        // write files to disk
-        for (const [path, file] of ordered) {
-            const uri = vscode.Uri.joinPath(folderUri, path);
-            let content: Uint8Array;
-            if (file.type === 'file') {
-                content = buffer.from(file.doc.text);
-            } else if (file.type === 'stub') {
-                content = fetched.get(file.uniqueId) ?? new Uint8Array();
-            } else {
-                content = new Uint8Array();
+        // write files to disk — folders first (parents before descendants), then files in parallel batches
+        const writeBatched = async (entries: typeof ordered, type: 'file' | 'folder') => {
+            for (let i = 0; i < entries.length; i += WRITE_CONCURRENCY) {
+                const batch = entries.slice(i, i + WRITE_CONCURRENCY);
+                await Promise.all(
+                    batch.map(([path, file]) => {
+                        const uri = vscode.Uri.joinPath(folderUri, path);
+                        let content: Uint8Array;
+                        if (file.type === 'file') {
+                            content = buffer.from(file.doc.text);
+                        } else if (file.type === 'stub') {
+                            content = fetched.get(file.uniqueId) ?? new Uint8Array();
+                        } else {
+                            content = new Uint8Array();
+                        }
+                        return this._create(uri, type, content);
+                    })
+                );
             }
-            await this._create(uri, file.type === 'folder' ? 'folder' : 'file', content);
-        }
+        };
+        await writeBatched(
+            ordered.filter(([, f]) => f.type === 'folder'),
+            'folder'
+        );
+        await writeBatched(
+            ordered.filter(([, f]) => f.type !== 'folder'),
+            'file'
+        );
 
         // parse ignore file (after disk write so stub content is available)
         const ignoreFile = projectManager.files.get(Disk.IGNORE_FILE);


### PR DESCRIPTION
Fixes #240

### What's Changed

- Replaced the serial `for`/`await` loop in `Disk.link()` with a two-phase batched-parallel driver (`WRITE_CONCURRENCY = 16`): folders first so parents exist, then files.
- Mutex, echo, viewing-skip, and downstream ignore/type/cleanup steps are unchanged.
- Large projects previously hung on "Updating Disk" for 30+ seconds because each `_create()` awaited sequentially; batching writes brings that down dramatically and unblocks queued deep-link opens from the Editor sooner.