### PR TITLE
[FEAT] Surface project desync via toast and status bar

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -755,6 +755,21 @@ export const activate = async (context: vscode.ExtensionContext) => {
             })
         );
 
+        // desync toast — fires once per false→true transition of the signal.
+        // signal resets to false on project unlink.
+        effect(() => {
+            if (!projectManager.desync.get()) {
+                return;
+            }
+            void vscode.window
+                .showWarningMessage('PlayCanvas project is out of sync. Reload to recover.', 'Reload project')
+                .then((choice) => {
+                    if (choice === 'Reload project') {
+                        void vscode.commands.executeCommand(`${NAME}.reloadProject`);
+                    }
+                });
+        });
+
         // disable autosave for playcanvas workspace — autosave interferes
         // with realtime collaborative editing
         const disableAutosave = () => {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -24,6 +24,11 @@ import { projectToName, tryCatch, uriStartsWith, wait } from './utils/utils';
 
 const HEARTBEAT_MS = 5 * 60 * 1000;
 const PING_SAMPLE_MS = 60 * 1000;
+const COLORS = {
+    success: '#2ecc71',
+    warning: '#e67e22',
+    error: '#e74c3c'
+};
 
 export const activate = async (context: vscode.ExtensionContext) => {
     // ! defer by 1 tick to allow for tests to stub modules before extension loads
@@ -259,13 +264,9 @@ export const activate = async (context: vscode.ExtensionContext) => {
     context.subscriptions.push(vscode.window.registerFileDecorationProvider(decorationProvider));
 
     // connection status bar item
-    const connectionStatusColors = {
-        connected: '#2ecc71',
-        disconnected: '#e74c3c'
-    };
     const connectionStatusItem = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Right, -10001);
     context.subscriptions.push(connectionStatusItem);
-    connectionStatusItem.color = connectionStatusColors.disconnected;
+    connectionStatusItem.color = COLORS.error;
     connectionStatusItem.text = `$(primitive-dot) Disconnected`;
     connectionStatusItem.tooltip = 'PlayCanvas Connection';
     connectionStatusItem.show();
@@ -298,7 +299,7 @@ export const activate = async (context: vscode.ExtensionContext) => {
     }
     effect(() => {
         const enabled = connected.get();
-        connectionStatusItem.color = enabled ? connectionStatusColors.connected : connectionStatusColors.disconnected;
+        connectionStatusItem.color = enabled ? COLORS.success : COLORS.error;
         if (enabled) {
             const m = messenger.ping.get();
             const r = relay.ping.get();
@@ -322,13 +323,9 @@ export const activate = async (context: vscode.ExtensionContext) => {
     context.subscriptions.push(new vscode.Disposable(() => clearInterval(pingSampler)));
 
     // collision status bar item
-    const collisionStatusColors = {
-        none: '',
-        found: '#e67e22'
-    };
     const collisionStatusItem = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Right, -9999);
     context.subscriptions.push(collisionStatusItem);
-    collisionStatusItem.color = collisionStatusColors.none;
+    collisionStatusItem.color = '';
     collisionStatusItem.command = `${NAME}.showPathCollisions`;
     collisionStatusItem.text = `$(check) Path Collisions: 0`;
     collisionStatusItem.tooltip = 'PlayCanvas Asset Path Collisions';
@@ -337,7 +334,7 @@ export const activate = async (context: vscode.ExtensionContext) => {
     // desync status bar item — hidden until project.desync flips true
     const desyncStatusItem = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Right, -10000);
     context.subscriptions.push(desyncStatusItem);
-    desyncStatusItem.color = '#e67e22';
+    desyncStatusItem.color = COLORS.warning;
     desyncStatusItem.command = `${NAME}.reloadProject`;
     desyncStatusItem.text = '$(warning) Out of Sync';
     desyncStatusItem.tooltip = 'PlayCanvas project is out of sync — click to reload';
@@ -718,7 +715,7 @@ export const activate = async (context: vscode.ExtensionContext) => {
         });
         effect(() => {
             const count = projectManager.collisions.count.get();
-            collisionStatusItem.color = count > 0 ? collisionStatusColors.found : collisionStatusColors.none;
+            collisionStatusItem.color = count > 0 ? COLORS.warning : '';
             collisionStatusItem.text = `$(${count > 0 ? 'warning' : 'check'}) Path Collisions: ${count}`;
         });
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -334,6 +334,14 @@ export const activate = async (context: vscode.ExtensionContext) => {
     collisionStatusItem.tooltip = 'PlayCanvas Asset Path Collisions';
     collisionStatusItem.show();
 
+    // desync status bar item — hidden until project.desync flips true
+    const desyncStatusItem = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Right, -10000);
+    context.subscriptions.push(desyncStatusItem);
+    desyncStatusItem.color = '#e67e22';
+    desyncStatusItem.command = `${NAME}.reloadProject`;
+    desyncStatusItem.text = '$(warning) Out of Sync';
+    desyncStatusItem.tooltip = 'PlayCanvas project is out of sync — click to reload';
+
     // branch status bar item
     const branchStatusBarItem = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Left, 10001);
     context.subscriptions.push(branchStatusBarItem);
@@ -755,10 +763,14 @@ export const activate = async (context: vscode.ExtensionContext) => {
             })
         );
 
-        // desync toast — fires once per false→true transition of the signal.
-        // signal resets to false on project unlink.
+        // desync surfaces — sticky status-bar item + one-shot toast per
+        // false→true transition. signal resets to false on project unlink.
         effect(() => {
-            if (!projectManager.desync.get()) {
+            const desynced = projectManager.desync.get();
+            if (desynced) {
+                desyncStatusItem.show();
+            } else {
+                desyncStatusItem.hide();
                 return;
             }
             void vscode.window

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -322,14 +322,12 @@ export const activate = async (context: vscode.ExtensionContext) => {
     }, PING_SAMPLE_MS);
     context.subscriptions.push(new vscode.Disposable(() => clearInterval(pingSampler)));
 
-    // collision status bar item
+    // collision status bar item — hidden until collisions.count > 0
     const collisionStatusItem = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Right, -9999);
     context.subscriptions.push(collisionStatusItem);
-    collisionStatusItem.color = '';
+    collisionStatusItem.color = COLORS.warning;
     collisionStatusItem.command = `${NAME}.showPathCollisions`;
-    collisionStatusItem.text = `$(check) Path Collisions: 0`;
     collisionStatusItem.tooltip = 'PlayCanvas Asset Path Collisions';
-    collisionStatusItem.show();
 
     // desync status bar item — hidden until project.desync flips true
     const desyncStatusItem = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Right, -10000);
@@ -715,8 +713,12 @@ export const activate = async (context: vscode.ExtensionContext) => {
         });
         effect(() => {
             const count = projectManager.collisions.count.get();
-            collisionStatusItem.color = count > 0 ? COLORS.warning : '';
-            collisionStatusItem.text = `$(${count > 0 ? 'warning' : 'check'}) Path Collisions: ${count}`;
+            if (count > 0) {
+                collisionStatusItem.text = `$(warning) Path Collisions: ${count}`;
+                collisionStatusItem.show();
+            } else {
+                collisionStatusItem.hide();
+            }
         });
 
         // store in cache early so messenger events during loading can find it

--- a/src/project-manager.ts
+++ b/src/project-manager.ts
@@ -91,6 +91,8 @@ class ProjectManager extends Linker<{ projectId: number; branchId: string }> {
 
     error = signal<Error | undefined>(undefined);
 
+    desync = signal<boolean>(false);
+
     constructor({
         events,
         sharedb,
@@ -280,6 +282,15 @@ class ProjectManager extends Linker<{ projectId: number; branchId: string }> {
             const dirty = asset?.file?.hash !== hash(otdoc.text);
             file.dirty = dirty;
             this._events.emit('asset:file:subscribed', path, otdoc.text, dirty);
+        });
+
+        // local ops unacked past the stuck threshold — flip project-level
+        // desync only if sharedb is connected (offline queueing is expected).
+        otdoc.on('stuck', () => {
+            if (!this._sharedb.connected.get()) {
+                return;
+            }
+            this.desync.set(() => true);
         });
 
         // emit file created event with OTDocument content for disk
@@ -1267,6 +1278,15 @@ class ProjectManager extends Linker<{ projectId: number; branchId: string }> {
             this._events.emit('asset:file:subscribed', p, otdoc.text, d);
         });
 
+        // local ops unacked past the stuck threshold — flip project-level
+        // desync only if sharedb is connected (offline queueing is expected).
+        otdoc.on('stuck', () => {
+            if (!this._sharedb.connected.get()) {
+                return;
+            }
+            this.desync.set(() => true);
+        });
+
         this._events.emit('asset:file:subscribed', current, otdoc.text, dirty);
         this._log.debug(`subscribed ${current} (${dirty ? 'dirty' : 'clean'})`);
         return promoted;
@@ -1497,6 +1517,7 @@ class ProjectManager extends Linker<{ projectId: number; branchId: string }> {
         await super.unlink();
         this._projectId = undefined;
         this._branchId = undefined;
+        this.desync.set(() => false);
         this._log.info(`project ${projectId} (branch ${branchId}) unloaded`);
         return { projectId, branchId };
     }

--- a/src/utils/ot-document.ts
+++ b/src/utils/ot-document.ts
@@ -7,7 +7,7 @@ import type { ShareDbTextOp } from '../typings/sharedb';
 import { EventEmitter } from './event-emitter';
 
 const SOURCE = ShareDb.SOURCE;
-const PENDING_TIMEOUT_MS = 5000;
+const PENDING_TIMEOUT_MS = 30 * 1000; // max potential timeout
 
 type OTDocumentEvents = {
     op: [ShareDbTextOp, string];
@@ -20,7 +20,7 @@ class OTDocument extends EventEmitter<OTDocumentEvents> {
 
     private _doc: Doc;
 
-    private _watchdog: NodeJS.Timeout | null = null;
+    private _timers = new Set<NodeJS.Timeout>();
 
     private _stuck = false;
 
@@ -51,19 +51,18 @@ class OTDocument extends EventEmitter<OTDocumentEvents> {
             this.emit('reload');
         });
 
-        // submitted ops acknowledged — cancel any armed stuck timer.
+        // ops drained — allow future stalls to be re-detected. project-level
+        // desync stays sticky until unlink, so this only re-arms the doc-local
+        // one-shot guard.
         doc.on('no write pending', () => {
-            if (this._watchdog) {
-                clearTimeout(this._watchdog);
-                this._watchdog = null;
-            }
+            this._stuck = false;
         });
 
         doc.on('destroy', () => {
-            if (this._watchdog) {
-                clearTimeout(this._watchdog);
-                this._watchdog = null;
+            for (const t of this._timers) {
+                clearTimeout(t);
             }
+            this._timers.clear();
         });
     }
 
@@ -75,21 +74,32 @@ class OTDocument extends EventEmitter<OTDocumentEvents> {
         // ot-text checkOp rejects skip=0, so strip leading zero
         const clean = (typeof op[0] === 'number' && op[0] === 0 ? op.slice(1) : op) as ShareDbTextOp;
         this._text = ottext.apply(this._text, clean) as string;
-        this._doc.submitOp(clean, { source: SOURCE });
 
-        // arm a stuck timer on the first apply after a drain. if the timer
-        // fires while ops remain pending, surface stuck so callers can decide
-        // (e.g., check connection, mark desync). 'no write pending' above
-        // cancels on ack.
-        if (this._watchdog === null && !this._stuck) {
-            this._watchdog = setTimeout(() => {
-                this._watchdog = null;
-                if (this._doc.hasPending()) {
-                    this._stuck = true;
-                    this.emit('stuck');
-                }
-            }, PENDING_TIMEOUT_MS);
+        // already stuck — submit without arming a redundant timer
+        if (this._stuck) {
+            this._doc.submitOp(clean, { source: SOURCE });
+            return;
         }
+
+        const timer = setTimeout(() => {
+            this._timers.delete(timer);
+            if (!this._stuck) {
+                this._stuck = true;
+                this.emit('stuck');
+            }
+        }, PENDING_TIMEOUT_MS);
+        this._timers.add(timer);
+
+        this._doc.submitOp(clean, { source: SOURCE }, (err) => {
+            clearTimeout(timer);
+            this._timers.delete(timer);
+
+            // explicit server rejection is a strictly stronger signal timeout
+            if (err && !this._stuck) {
+                this._stuck = true;
+                this.emit('stuck');
+            }
+        });
     }
 
     get pending() {

--- a/src/utils/ot-document.ts
+++ b/src/utils/ot-document.ts
@@ -7,16 +7,22 @@ import type { ShareDbTextOp } from '../typings/sharedb';
 import { EventEmitter } from './event-emitter';
 
 const SOURCE = ShareDb.SOURCE;
+const PENDING_TIMEOUT_MS = 5000;
 
 type OTDocumentEvents = {
     op: [ShareDbTextOp, string];
     reload: [];
+    stuck: [];
 };
 
 class OTDocument extends EventEmitter<OTDocumentEvents> {
     private _text: string;
 
     private _doc: Doc;
+
+    private _watchdog: NodeJS.Timeout | null = null;
+
+    private _stuck = false;
 
     constructor(doc: Doc) {
         super();
@@ -44,6 +50,21 @@ class OTDocument extends EventEmitter<OTDocumentEvents> {
             this._text = next;
             this.emit('reload');
         });
+
+        // submitted ops acknowledged — cancel any armed stuck timer.
+        doc.on('no write pending', () => {
+            if (this._watchdog) {
+                clearTimeout(this._watchdog);
+                this._watchdog = null;
+            }
+        });
+
+        doc.on('destroy', () => {
+            if (this._watchdog) {
+                clearTimeout(this._watchdog);
+                this._watchdog = null;
+            }
+        });
     }
 
     get text() {
@@ -55,6 +76,20 @@ class OTDocument extends EventEmitter<OTDocumentEvents> {
         const clean = (typeof op[0] === 'number' && op[0] === 0 ? op.slice(1) : op) as ShareDbTextOp;
         this._text = ottext.apply(this._text, clean) as string;
         this._doc.submitOp(clean, { source: SOURCE });
+
+        // arm a stuck timer on the first apply after a drain. if the timer
+        // fires while ops remain pending, surface stuck so callers can decide
+        // (e.g., check connection, mark desync). 'no write pending' above
+        // cancels on ack.
+        if (this._watchdog === null && !this._stuck) {
+            this._watchdog = setTimeout(() => {
+                this._watchdog = null;
+                if (this._doc.hasPending()) {
+                    this._stuck = true;
+                    this.emit('stuck');
+                }
+            }, PENDING_TIMEOUT_MS);
+        }
     }
 
     get pending() {
@@ -63,10 +98,6 @@ class OTDocument extends EventEmitter<OTDocumentEvents> {
 
     whenNothingPending(fn: () => void) {
         this._doc.whenNothingPending(fn);
-    }
-
-    get raw() {
-        return this._doc;
     }
 }
 


### PR DESCRIPTION
Partially implements #238

### What's Changed

- Detect when local OT ops remain unacknowledged past a 5s watchdog threshold and surface a `stuck` event from `OTDocument`.
- Flip a project-level `desync` signal when `stuck` fires while ShareDB is connected (offline queueing is ignored).
- Show a one-shot warning toast with a "Reload project" action on the false→true transition; signal resets on project unlink.
- Remove the unused `OTDocument.raw` accessor.