### PR TITLE
[FIX] Keep _bufferState in sync on external buffer reload

### DIFF
--- a/src/disk.ts
+++ b/src/disk.ts
@@ -654,6 +654,9 @@ class Disk extends Linker<{ folderUri: vscode.Uri; projectManager: ProjectManage
     private _dirtyReload(document: vscode.TextDocument, text: string) {
         this._diskHash.set(document.uri.path, hash(text));
 
+        // keep _bufferState fresh so the next _update doesn't re-submit the external content
+        this._bufferState.set(document.uri.path, text);
+
         // avoid touching eol chars
         const raw = document.getText();
         const i = raw.search(/[^\r\n]/);


### PR DESCRIPTION
Partially addresses #249

### What's Changed

- `_dirtyReload` now updates `_bufferState` alongside `_diskHash`. Previously, only `_diskHash` was refreshed after VS Code reloaded an open buffer from disk (Copilot Agent Mode / Claude Code / git), leaving the baseline that `_update` uses at `disk.ts:367-368` stale.
- Without this, a remote op landing after the external write caused `newUserOp = delta(staleBaseline, bufferText)` to re-submit the external content on top of the inflight op, advancing OT past disk and producing the "wholesale rewritten" / "partial rewrite" appearance on PC Editor refresh.