### PR TITLE
[CHORE] Bump playcanvas from 2.17.2 to 2.18.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -43,7 +43,7 @@
                 "eslint-plugin-prettier": "^5.5.4",
                 "globals": "^17.0.0",
                 "jsonc-eslint-parser": "^2.4.2",
-                "playcanvas": "2.17.2",
+                "playcanvas": "2.18.0",
                 "prettier": "^3.7.4",
                 "rollup": "^4.60.2",
                 "rollup-plugin-polyfill-node": "^0.13.0",
@@ -6795,9 +6795,9 @@
             }
         },
         "node_modules/playcanvas": {
-            "version": "2.17.2",
-            "resolved": "https://registry.npmjs.org/playcanvas/-/playcanvas-2.17.2.tgz",
-            "integrity": "sha512-+J3ewI2Zi2C1IZ/tZqubBBYSoruaMyPh9QD1/IQS/0QRmuZPNtx+9SwrYsK2QR91+ImeH0MRchkOFfNYWwEOVQ==",
+            "version": "2.18.0",
+            "resolved": "https://registry.npmjs.org/playcanvas/-/playcanvas-2.18.0.tgz",
+            "integrity": "sha512-UufnnYsYuTCQaeFvYiSjUrDTcX7jNfy8cOydAoAySK323nLVi+8CL+lzFcWUvB5J2LRoT2oYJnPby37/6O084A==",
             "dev": true,
             "license": "MIT",
             "dependencies": {

--- a/package.json
+++ b/package.json
@@ -184,7 +184,7 @@
         "eslint-plugin-prettier": "^5.5.4",
         "globals": "^17.0.0",
         "jsonc-eslint-parser": "^2.4.2",
-        "playcanvas": "2.17.2",
+        "playcanvas": "2.18.0",
         "prettier": "^3.7.4",
         "rollup": "^4.60.2",
         "rollup-plugin-polyfill-node": "^0.13.0",


### PR DESCRIPTION
### What's Changed

- Bump `playcanvas` dev dependency from 2.17.2 to 2.18.0