### PR TITLE
fix: prevent disk cleanup from cascading server-side asset deletions

### DIFF
--- a/src/disk.ts
+++ b/src/disk.ts
@@ -454,10 +454,11 @@ class Disk extends Linker<{ folderUri: vscode.Uri; projectManager: ProjectManage
                 return;
             }
 
-            // remove from disk
+            // remove from disk. callers iterate bottom-up so folders are
+            // always empty here — no recursion, no cascading OS events
             this._echo.set(`${uri}:delete`, '');
             await vscode.workspace.fs.delete(uri, {
-                recursive: true,
+                recursive: false,
                 useTrash: false
             });
 
@@ -1525,13 +1526,22 @@ class Disk extends Linker<{ folderUri: vscode.Uri; projectManager: ProjectManage
         // write type definition files to .pc/
         await this._writeTypeFiles(folderUri);
 
-        // remove old files
-        const existing = await readDirRecursive(folderUri);
-        for (const uri of existing) {
+        // remove old files deepest-first — siblings at each level parallelize
+        const levels = new Map<number, vscode.Uri[]>();
+        for (const uri of await readDirRecursive(folderUri)) {
             const path = relativePath(uri, folderUri);
             if (!projectManager.files.has(path) && path !== Disk.TYPE_DIR && !path.startsWith(`${Disk.TYPE_DIR}/`)) {
-                await this._delete(uri);
+                const depth = path.split('/').length;
+                const bucket = levels.get(depth);
+                if (bucket) {
+                    bucket.push(uri);
+                } else {
+                    levels.set(depth, [uri]);
+                }
             }
+        }
+        for (const depth of [...levels.keys()].sort((a, b) => b - a)) {
+            await pool(levels.get(depth)!, WRITE_CONCURRENCY, (uri) => this._delete(uri));
         }
 
         // watchers

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -202,9 +202,6 @@ export const activate = async (context: vscode.ExtensionContext) => {
             // update branch id if provided (branch switch flow)
             projectState.branchId = branchId ?? projectState.branchId;
 
-            // TODO: figure out why this is needed to avoid ShareDB issues
-            await wait(1000);
-
             // relink everything
             await projectManager.link(projectState);
             await disk.link(diskState);

--- a/src/project-manager.ts
+++ b/src/project-manager.ts
@@ -547,7 +547,7 @@ class ProjectManager extends Linker<{ projectId: number; branchId: string }> {
         });
         const assetDeleteHandle = this._messenger.on('assets.delete', async ({ data: { assets } }) => {
             // filter assets to only include valid ones
-            const valid: [number, string, Asset][] = assets.reduce(
+            const valid: [number, string, Asset, number][] = assets.reduce(
                 (paths, raw) => {
                     // check for valid number
                     const uniqueId = parseInt(raw, 10);
@@ -568,11 +568,14 @@ class ProjectManager extends Linker<{ projectId: number; branchId: string }> {
 
                     // get path
                     const path = this._assetPath(uniqueId);
-                    paths.push([uniqueId, path, asset]);
+                    paths.push([uniqueId, path, asset, path.split('/').length]);
                     return paths;
                 },
-                [] as [number, string, Asset][]
+                [] as [number, string, Asset, number][]
             );
+
+            // deepest-first so disk deletes reach empty folders, never non-empty ones
+            valid.sort((a, b) => b[3] - a[3]);
 
             let skipsDirty = false;
 


### PR DESCRIPTION
### What's Changed

Recursive `fs.delete` emits OS events for each descendant but only one echo entry, so descendant watcher events slipped past the echo guard and triggered folder-scoped ShareDB delete ops, cascading server-side to all children regardless of type.

- `_delete` now runs non-recursive with a single-URI echo.
- `Disk.link` cleanup groups entries by depth and runs a deepest-first `pool(WRITE_CONCURRENCY)` so folders are always empty when deleted and bulk cleanup stays parallel.
- `assets.delete` handler sorts valid entries deepest-first (depth precomputed in the tuple) so the write mutex's `pathsRelated` matcher serializes parents behind their descendants.
- Drop the `wait(1000)` in reload; no longer needed with the above.