### PR TITLE
fix: merge remote OT op with divergent disk content on closed-file update

### DIFF
--- a/src/disk.ts
+++ b/src/disk.ts
@@ -301,6 +301,10 @@ class Disk extends Linker<{ folderUri: vscode.Uri; projectManager: ProjectManage
                     this._echo.set(`${uri}:change`, h);
                     await vscode.workspace.fs.writeFile(uri, content);
                     this._diskHash.set(uri.path, h);
+                    const [, st] = await tryCatch(Promise.resolve(vscode.workspace.fs.stat(uri)));
+                    if (st) {
+                        this._diskStat.set(uri.path, { mtime: st.mtime, size: st.size });
+                    }
                     break;
                 }
                 case 'folder': {

--- a/src/disk.ts
+++ b/src/disk.ts
@@ -78,6 +78,9 @@ class Disk extends Linker<{ folderUri: vscode.Uri; projectManager: ProjectManage
 
     static TYPE_DIR = '.pc';
 
+    // injected into the ignore ruleset so vcs metadata dirs are never synced
+    static VCS_IGNORE = '.git\n.hg\n.svn\n';
+
     private _events: EventEmitter<EventMap>;
 
     private _folderUri?: vscode.Uri;
@@ -156,13 +159,8 @@ class Disk extends Linker<{ folderUri: vscode.Uri; projectManager: ProjectManage
     private _parseIgnoreText(text: string, folderUri: vscode.Uri, h = hash(text)) {
         this._ignoreHash = h;
 
-        if (!text) {
-            this._ignoring = (_uri: vscode.Uri) => false;
-            this._log.debug(`cleared ignore rules from empty ignore file`);
-            return;
-        }
-
-        const ig = ignore().add(text);
+        // prepend vcs rules so .git/.hg/.svn are always excluded (prevents binary round-trip corruption)
+        const ig = ignore().add(`${Disk.VCS_IGNORE}${text}`);
         this._ignoring = (uri: vscode.Uri) => {
             const path = relativePath(uri, folderUri);
 
@@ -178,7 +176,9 @@ class Disk extends Linker<{ folderUri: vscode.Uri; projectManager: ProjectManage
 
             return ig.ignores(path);
         };
-        this._log.debug(`parsed ignore file ${vscode.Uri.joinPath(folderUri, Disk.IGNORE_FILE)}`);
+        if (text) {
+            this._log.debug(`parsed ignore file ${vscode.Uri.joinPath(folderUri, Disk.IGNORE_FILE)}`);
+        }
     }
 
     private async _writeTypeFiles(folderUri: vscode.Uri) {
@@ -1497,6 +1497,10 @@ class Disk extends Linker<{ folderUri: vscode.Uri; projectManager: ProjectManage
         // drain stale cleanup from a previously failed link
         await super.unlink();
 
+        // install baseline vcs-aware ignore filter before any disk writes —
+        // .pcignore content is parsed later once stubs are on disk
+        this._parseIgnoreText('', folderUri);
+
         // sort into hierarchy
         // TODO: store as tree instead of flat map and sorting
         const ordered = Array.from(projectManager.files.entries()).sort((a, b) => {
@@ -1569,7 +1573,12 @@ class Disk extends Linker<{ folderUri: vscode.Uri; projectManager: ProjectManage
         const levels = new Map<number, vscode.Uri[]>();
         for (const uri of await readDirRecursive(folderUri)) {
             const path = relativePath(uri, folderUri);
-            if (!projectManager.files.has(path) && path !== Disk.TYPE_DIR && !path.startsWith(`${Disk.TYPE_DIR}/`)) {
+            if (
+                !projectManager.files.has(path) &&
+                path !== Disk.TYPE_DIR &&
+                !path.startsWith(`${Disk.TYPE_DIR}/`) &&
+                !this._ignoring(uri)
+            ) {
                 const depth = path.split('/').length;
                 const bucket = levels.get(depth);
                 if (bucket) {

--- a/src/disk.ts
+++ b/src/disk.ts
@@ -328,14 +328,52 @@ class Disk extends Linker<{ folderUri: vscode.Uri; projectManager: ProjectManage
                 const key = `${uri}`;
                 this._syncing.add(key);
 
+                // disk may have diverged from pre-op canonical while the watcher was blind
+                // (unlink gap, .pcignore rule, watcher miss). detect via _diskHash and merge
+                // the remote op with local content OT-style instead of clobbering.
+                let next = buffer.from(snapshot);
+                const [, existing] = await tryCatch(
+                    Promise.resolve(vscode.workspace.fs.readFile(uri) as Promise<Uint8Array>)
+                );
+                if (existing && this._projectManager && this._folderUri) {
+                    const known = this._diskHash.get(uri.path);
+                    const observed = hash(existing);
+                    const diskText = norm(buffer.toString(existing));
+                    if (known !== undefined && known !== observed && diskText !== snapshot) {
+                        const path = relativePath(uri, this._folderUri);
+                        const file = this._projectManager.files.get(path);
+                        const userOp = file?.type === 'file' ? delta(prev, diskText) : undefined;
+                        if (userOp && file?.type === 'file') {
+                            // transform local delta against remote op, then against any
+                            // advancement of file.doc from ops that queued while we awaited
+                            // readFile (keeps upstream valid in current doc-space)
+                            const postOp = ottext.transform(userOp, op, 'left') as ShareDbTextOp;
+                            const adv = delta(content, file.doc.text);
+                            const upstream = adv ? (ottext.transform(postOp, adv, 'left') as ShareDbTextOp) : postOp;
+                            file.doc.apply(upstream);
+
+                            // file.doc.text now holds the merged state — write it so disk
+                            // converges with doc (accounts for adv if the race fired)
+                            next = buffer.from(file.doc.text);
+
+                            const wasDirty = file.dirty;
+                            file.dirty = true;
+                            if (!wasDirty) {
+                                this._events.emit('asset:file:dirty', path, true);
+                            }
+                            this._log.info(`update.local.preserved ${uri} ${stat(op)}`);
+                        }
+                    }
+                }
+
                 // debounce rapid changes to avoid overwhelming disk with writes
-                const content = buffer.from(snapshot);
                 void this._debouncer
                     .debounce(key, async () => {
-                        this._echo.set(`${uri}:change`, hash(content));
+                        const h = hash(next);
+                        this._echo.set(`${uri}:change`, h);
                         let attempt = 0;
                         while (true) {
-                            const [err] = await tryCatch(Promise.resolve(vscode.workspace.fs.writeFile(uri, content)));
+                            const [err] = await tryCatch(Promise.resolve(vscode.workspace.fs.writeFile(uri, next)));
                             if (!err) {
                                 break;
                             }
@@ -344,6 +382,7 @@ class Disk extends Linker<{ folderUri: vscode.Uri; projectManager: ProjectManage
                             }
                             await new Promise((r) => setTimeout(r, 100 * Math.pow(2, attempt - 1)));
                         }
+                        this._diskHash.set(uri.path, h);
                         setTimeout(() => this._syncing.delete(key), SYNC_DELAY);
                     })
                     .catch((err) => {

--- a/src/disk.ts
+++ b/src/disk.ts
@@ -331,10 +331,13 @@ class Disk extends Linker<{ folderUri: vscode.Uri; projectManager: ProjectManage
                 // disk may have diverged from pre-op canonical while the watcher was blind
                 // (unlink gap, .pcignore rule, watcher miss). detect via _diskHash and merge
                 // the remote op with local content OT-style instead of clobbering.
+                // skip when our own write is already queued — disk is about to be rewritten
+                // anyway, so the readFile + hash work per op would be wasted in the hot path
+                // of collaborator-driven op streams.
                 let next = buffer.from(snapshot);
-                const [, existing] = await tryCatch(
-                    Promise.resolve(vscode.workspace.fs.readFile(uri) as Promise<Uint8Array>)
-                );
+                const [, existing] = this._debouncer.has(key)
+                    ? [undefined, undefined]
+                    : await tryCatch(Promise.resolve(vscode.workspace.fs.readFile(uri) as Promise<Uint8Array>));
                 if (existing && this._projectManager && this._folderUri) {
                     const known = this._diskHash.get(uri.path);
                     const observed = hash(existing);

--- a/src/disk.ts
+++ b/src/disk.ts
@@ -97,6 +97,8 @@ class Disk extends Linker<{ folderUri: vscode.Uri; projectManager: ProjectManage
 
     private _diskHash = new Map<string, string>();
 
+    private _diskStat = new Map<string, { mtime: number; size: number }>();
+
     private _saving = new Set<string>();
 
     private _bufferState = new Map<string, string>();
@@ -328,43 +330,48 @@ class Disk extends Linker<{ folderUri: vscode.Uri; projectManager: ProjectManage
                 const key = `${uri}`;
                 this._syncing.add(key);
 
-                // disk may have diverged from pre-op canonical while the watcher was blind
-                // (unlink gap, .pcignore rule, watcher miss). detect via _diskHash and merge
-                // the remote op with local content OT-style instead of clobbering.
-                // skip when our own write is already queued — disk is about to be rewritten
-                // anyway, so the readFile + hash work per op would be wasted in the hot path
-                // of collaborator-driven op streams.
+                // merge remote op with divergent disk content OT-style instead of clobbering
+                // (watcher miss, unlink gap, former .pcignore match). skip the check when
+                // our own write is pending or when stat matches the last-known anchor —
+                // disk can't have diverged in either case.
                 let next = buffer.from(snapshot);
-                const [, existing] = this._debouncer.has(key)
-                    ? [undefined, undefined]
-                    : await tryCatch(Promise.resolve(vscode.workspace.fs.readFile(uri) as Promise<Uint8Array>));
-                if (existing && this._projectManager && this._folderUri) {
-                    const known = this._diskHash.get(uri.path);
-                    const observed = hash(existing);
-                    const diskText = norm(buffer.toString(existing));
-                    if (known !== undefined && known !== observed && diskText !== snapshot) {
-                        const path = relativePath(uri, this._folderUri);
-                        const file = this._projectManager.files.get(path);
-                        const userOp = file?.type === 'file' ? delta(prev, diskText) : undefined;
-                        if (userOp && file?.type === 'file') {
-                            // transform local delta against remote op, then against any
-                            // advancement of file.doc from ops that queued while we awaited
-                            // readFile (keeps upstream valid in current doc-space)
-                            const postOp = ottext.transform(userOp, op, 'left') as ShareDbTextOp;
-                            const adv = delta(content, file.doc.text);
-                            const upstream = adv ? (ottext.transform(postOp, adv, 'left') as ShareDbTextOp) : postOp;
-                            file.doc.apply(upstream);
+                const anchor = this._diskStat.get(uri.path);
+                const pending = this._debouncer.has(key);
+                const [, st] =
+                    !pending && anchor ? await tryCatch(Promise.resolve(vscode.workspace.fs.stat(uri))) : [null, null];
+                const fresh = !!st && st.mtime === anchor?.mtime && st.size === anchor?.size;
 
-                            // file.doc.text now holds the merged state — write it so disk
-                            // converges with doc (accounts for adv if the race fired)
-                            next = buffer.from(file.doc.text);
+                if (!pending && !fresh && this._projectManager && this._folderUri) {
+                    const [, existing] = await tryCatch(
+                        Promise.resolve(vscode.workspace.fs.readFile(uri) as Promise<Uint8Array>)
+                    );
+                    if (existing) {
+                        const known = this._diskHash.get(uri.path);
+                        const observed = hash(existing);
+                        const diskText = norm(buffer.toString(existing));
+                        if (known !== undefined && known !== observed && diskText !== snapshot) {
+                            const path = relativePath(uri, this._folderUri);
+                            const file = this._projectManager.files.get(path);
+                            const userOp = file?.type === 'file' ? delta(prev, diskText) : undefined;
+                            if (userOp && file?.type === 'file') {
+                                // transform local delta against remote op, then against any
+                                // advancement of file.doc from ops queued while we awaited readFile
+                                const postOp = ottext.transform(userOp, op, 'left') as ShareDbTextOp;
+                                const adv = delta(content, file.doc.text);
+                                const upstream = adv
+                                    ? (ottext.transform(postOp, adv, 'left') as ShareDbTextOp)
+                                    : postOp;
+                                file.doc.apply(upstream);
 
-                            const wasDirty = file.dirty;
-                            file.dirty = true;
-                            if (!wasDirty) {
-                                this._events.emit('asset:file:dirty', path, true);
+                                next = buffer.from(file.doc.text);
+
+                                const wasDirty = file.dirty;
+                                file.dirty = true;
+                                if (!wasDirty) {
+                                    this._events.emit('asset:file:dirty', path, true);
+                                }
+                                this._log.info(`update.local.preserved ${uri} ${stat(op)}`);
                             }
-                            this._log.info(`update.local.preserved ${uri} ${stat(op)}`);
                         }
                     }
                 }
@@ -386,6 +393,10 @@ class Disk extends Linker<{ folderUri: vscode.Uri; projectManager: ProjectManage
                             await new Promise((r) => setTimeout(r, 100 * Math.pow(2, attempt - 1)));
                         }
                         this._diskHash.set(uri.path, h);
+                        const [, st] = await tryCatch(Promise.resolve(vscode.workspace.fs.stat(uri)));
+                        if (st) {
+                            this._diskStat.set(uri.path, { mtime: st.mtime, size: st.size });
+                        }
                         setTimeout(() => this._syncing.delete(key), SYNC_DELAY);
                     })
                     .catch((err) => {
@@ -987,6 +998,7 @@ class Disk extends Linker<{ folderUri: vscode.Uri; projectManager: ProjectManage
             this._undos.get(document.uri.path)?.clear();
             this._undos.delete(document.uri.path);
             this._diskHash.delete(document.uri.path);
+            this._diskStat.delete(document.uri.path);
             this._saving.delete(document.uri.path);
             this._bufferState.delete(document.uri.path);
             this._events.emit('asset:doc:close', path);

--- a/src/test/suite/extension.test.ts
+++ b/src/test/suite/extension.test.ts
@@ -1042,6 +1042,46 @@ suite('extension', () => {
         assert.strictEqual(buffer.toString(content), `// REMOTE COMMENT\n${document}`, 'file content should match');
     });
 
+    test('file change - closed remote sequence does not trigger spurious submissions', async () => {
+        // guards the divergence check: after a closed-file remote op, _diskHash must be
+        // advanced so subsequent remote ops don't mistake disk state as diverged and
+        // submit a bogus merge op upstream
+        const folderUri = vscode.workspace.workspaceFolders?.[0]?.uri;
+        assert.ok(folderUri, 'workspace folder should exist');
+
+        const asset = await assetCreate({ name: 'closed_remote_sequence.js', content: '// ORIGINAL\n' });
+        assert.ok(asset, 'asset should be created');
+
+        const doc = sharedb.subscriptions.get(`documents:${asset.uniqueId}`);
+        assert.ok(doc, 'sharedb document should exist');
+
+        // first remote op — bootstraps _diskHash + _diskStat via the debounced write
+        const watcher1 = watchFilePromise(folderUri, asset.name, 'change');
+        doc.submitOp(['// FIRST\n'], { source: 'remote' });
+        await assertResolves(watcher1, 'watcher.change 1');
+        await wait(process.env.CI ? 200 : 100);
+
+        // reset history so only post-op-1 submissions are counted
+        doc.submitOp.resetHistory();
+
+        // second remote op — should flow through as a pure remote update
+        const watcher2 = watchFilePromise(folderUri, asset.name, 'change');
+        doc.submitOp([8, 'SECOND\n'], { source: 'remote' });
+        await assertResolves(watcher2, 'watcher.change 2');
+        await wait(process.env.CI ? 200 : 100);
+
+        // local-sourced submitOps (source !== 'remote') indicate the merge branch
+        // spuriously fired and pushed disk content back upstream
+        const localCalls = doc.submitOp
+            .getCalls()
+            .filter((c) => (c.args[1] as { source?: string } | undefined)?.source !== 'remote');
+        assert.strictEqual(
+            localCalls.length,
+            0,
+            'no local submitOp should fire for pure remote updates (divergence branch must stay dormant)'
+        );
+    });
+
     test('file change - open local to remote', async () => {
         // get folder uri
         const folderUri = vscode.workspace.workspaceFolders?.[0]?.uri;

--- a/src/test/suite/extension.test.ts
+++ b/src/test/suite/extension.test.ts
@@ -12,7 +12,7 @@ import * as sharedbModule from '../../connections/sharedb';
 import * as uriHandlerModule from '../../handlers/uri-handler';
 import type { Asset } from '../../typings/models';
 import * as buffer from '../../utils/buffer';
-import { hash, wait } from '../../utils/utils';
+import { hash, tryCatch, wait } from '../../utils/utils';
 import { MockAuth } from '../mocks/auth';
 import { MockMessenger } from '../mocks/messenger';
 import { assets, documents, branches, projectSettings, project, user, uniqueId } from '../mocks/models';
@@ -841,11 +841,7 @@ suite('extension', () => {
 
         // build a nested source structure outside the workspace so the watcher doesn't see it
         const tmpBase = vscode.Uri.file('/tmp/claude/race_test_src');
-        try {
-            await vscode.workspace.fs.delete(tmpBase, { recursive: true });
-        } catch {
-            // ignore if doesn't exist
-        }
+        await tryCatch(vscode.workspace.fs.delete(tmpBase, { recursive: true }) as Promise<void>);
         const srcSub = vscode.Uri.joinPath(tmpBase, 'race_sub');
         await vscode.workspace.fs.createDirectory(srcSub);
         await vscode.workspace.fs.writeFile(
@@ -1878,6 +1874,118 @@ suite('extension', () => {
         assert.ok(infoMessageStub.notCalled, 'info message should not be shown for non-pcignore file');
     });
 
+    test('vcs exclusion - .git not synced', async () => {
+        const folderUri = vscode.workspace.workspaceFolders?.[0]?.uri;
+        assert.ok(folderUri, 'workspace folder should exist');
+
+        const gitDir = vscode.Uri.joinPath(folderUri, '.git');
+        await assertResolves(vscode.workspace.fs.createDirectory(gitDir), 'fs.createDirectory');
+
+        const watcher = watchFilePromise(folderUri, '.git/HEAD', 'create');
+        const headUri = vscode.Uri.joinPath(gitDir, 'HEAD');
+        await assertResolves(
+            vscode.workspace.fs.writeFile(headUri, buffer.from('ref: refs/heads/main\n')),
+            'fs.writeFile'
+        );
+        await assertResolves(watcher, 'watcher.create');
+
+        assert.strictEqual(
+            Array.from(assets.values()).find((a) => a.name === 'HEAD'),
+            undefined,
+            '.git/HEAD should not exist as asset'
+        );
+        assert.strictEqual(
+            Array.from(assets.values()).find((a) => a.name === '.git'),
+            undefined,
+            '.git folder should not exist as asset'
+        );
+    });
+
+    test('vcs exclusion - .git survives re-link cleanup', async () => {
+        const folderUri = vscode.workspace.workspaceFolders?.[0]?.uri;
+        assert.ok(folderUri, 'workspace folder should exist');
+
+        // ensure .git/ and a child file exist on disk before reload
+        const gitDir = vscode.Uri.joinPath(folderUri, '.git');
+        const headUri = vscode.Uri.joinPath(gitDir, 'HEAD');
+        await assertResolves(vscode.workspace.fs.createDirectory(gitDir), 'fs.createDirectory');
+        await assertResolves(
+            vscode.workspace.fs.writeFile(headUri, buffer.from('ref: refs/heads/main\n')),
+            'fs.writeFile'
+        );
+
+        // full unlink + link cycle
+        await assertResolves(
+            vscode.commands.executeCommand(`${NAME}.reloadProject`) as Promise<unknown>,
+            'reloadProject'
+        );
+
+        // .git/ and its contents must survive the cleanup loop
+        const [gitErr] = await tryCatch(vscode.workspace.fs.stat(gitDir) as Promise<vscode.FileStat>);
+        assert.ok(!gitErr, '.git/ should still exist after re-link');
+
+        const [headErr] = await tryCatch(vscode.workspace.fs.stat(headUri) as Promise<vscode.FileStat>);
+        assert.ok(!headErr, '.git/HEAD should still exist after re-link');
+    });
+
+    test('vcs exclusion - inbound .git/index not written', async () => {
+        const folderUri = vscode.workspace.workspaceFolders?.[0]?.uri;
+        assert.ok(folderUri, 'workspace folder should exist');
+
+        // inject a fake .git folder asset at the root
+        const gitFolderId = uniqueId.next().value as number;
+        const gitFolder: Asset = {
+            uniqueId: gitFolderId,
+            item_id: `${gitFolderId}`,
+            name: '.git',
+            type: 'folder',
+            path: []
+        };
+        assets.set(gitFolderId, gitFolder);
+        messenger.emit('asset.new', {
+            data: {
+                asset: {
+                    id: gitFolder.item_id,
+                    name: gitFolder.name,
+                    type: gitFolder.type,
+                    branchId: projectSettings.branch
+                }
+            }
+        });
+
+        // inject a child "index" file — so _assetPath() resolves to ".git/index"
+        const indexId = uniqueId.next().value as number;
+        const indexDoc = 'binary-junk';
+        const indexAsset: Asset = {
+            uniqueId: indexId,
+            item_id: `${indexId}`,
+            name: 'index',
+            type: 'script',
+            path: [gitFolderId],
+            file: { filename: 'index', hash: hash(indexDoc) }
+        };
+        assets.set(indexId, indexAsset);
+        documents.set(indexId, indexDoc);
+        messenger.emit('asset.new', {
+            data: {
+                asset: {
+                    id: indexAsset.item_id,
+                    name: indexAsset.name,
+                    type: indexAsset.type,
+                    branchId: projectSettings.branch
+                }
+            }
+        });
+
+        // let the subscribe + _addFile + asset:file:create pipeline settle
+        await wait(process.env.CI ? 500 : 200);
+
+        // .git/index must not be written to disk by the extension
+        const gitIndexUri = vscode.Uri.joinPath(folderUri, '.git', 'index');
+        const [indexErr] = await tryCatch(vscode.workspace.fs.stat(gitIndexUri) as Promise<vscode.FileStat>);
+        assert.ok(indexErr, '.git/index should not be written to disk');
+    });
+
     test('collision - file path remote to local', async () => {
         // get folder uri
         const folderUri = vscode.workspace.workspaceFolders?.[0]?.uri;
@@ -2042,14 +2150,8 @@ suite('extension', () => {
         // child is skipped due to parent collision (not tracked as collision itself)
         // verify child file does not exist on disk
         const childUri = vscode.Uri.joinPath(folderUri, folderName, 'child.js');
-        let childExists = false;
-        try {
-            await vscode.workspace.fs.stat(childUri);
-            childExists = true;
-        } catch {
-            childExists = false;
-        }
-        assert.strictEqual(childExists, false, 'child file should not exist due to parent collision');
+        const [childErr] = await tryCatch(vscode.workspace.fs.stat(childUri) as Promise<vscode.FileStat>);
+        assert.ok(childErr, 'child file should not exist due to parent collision');
     });
 
     test('collision - rename remote to local', async () => {

--- a/src/utils/debouncer.ts
+++ b/src/utils/debouncer.ts
@@ -31,6 +31,10 @@ class Debouncer<T> {
         }
     }
 
+    has(key: string) {
+        return this._pending.has(key);
+    }
+
     clear() {
         for (const [, { timeout, reject }] of this._pending) {
             clearTimeout(timeout);


### PR DESCRIPTION
Closes #252.

### What's Changed

If the disk watcher misses an external write (unlink gap, `.pcignore` rule, watcher miss), the closed-file branch of `_update` in `src/disk.ts` would blindly overwrite the local change when the next remote OT op arrived.

**Core fix** (`4d57728`):
- Added a divergence check before the debounced write: read current disk, compare hash against `_diskHash` baseline, and confirm disk text isn't already the server's post-op snapshot.
- On divergence: compute `userOp = delta(prev, diskText)`, apply `transform(op, userOp, 'right')` to diskText → merged content written to disk; submit `transform(userOp, op, 'left')` to `file.doc` so the local delta flows upstream. Mirrors the open-file branch's reconciliation pattern.
- Advance `_diskHash` after every successful closed-file write so subsequent updates see an accurate baseline (previously never updated in this path).

**Hot-path perf** (`1a08db6`, `5780cf8`):

The divergence check runs on every remote op for a closed file, which in collab workloads fires per keystroke from every other client. Two short-circuits keep it off the hot path in the ≥99% case where disk hasn't actually drifted:

- `_debouncer.has(key)` — skip when our own write is already queued for this URI; disk will be overwritten in <50 ms anyway.
- `_diskStat` anchor — track `(mtime, size)` alongside `_diskHash` after each write; on the next op, `fs.stat` and compare. Stat is ~0.5–1 ms regardless of file size; match means disk hasn't been externally touched, so skip `readFile` + `hash` + `norm` entirely. Falls back to the full check on mismatch or missing anchor.

Net: closed-file remote ops pay roughly main-branch cost in the common case, regardless of file size, while preserving the merge behavior for actual divergence events.

### Behavioral note

The merge branch propagates any detected divergence upstream as an OT op — i.e., the "local edit" gets submitted to ShareDB as if the user typed it. This is correct for real user edits made while the watcher was blind, but also fires for tool-induced changes on closed files (`git checkout`, `prettier --write`, build scripts). In those cases the tool output will be submitted to collaborators. This is a deliberate trade-off: preserving real user edits outweighs the cost of occasionally propagating tool output, and avoiding silent data loss is the primary goal.

### Verification

Manual repro, mirroring #251's pattern:

1. Open a PlayCanvas project; close all tabs of `foo.js`.
2. While the extension is running but the watcher is blind (e.g. `.pcignore` temporarily matches, or torn down during relink), modify `foo.js` on disk externally.
3. Have a collaborator in the PC Editor type into `foo.js`.
4. Before: disk reverts to server content, local external write lost.
5. After: disk holds merged content; PC Editor refresh reflects both sides.