### PR TITLE
feat: exclude .git/.hg/.svn directories from sync

### DIFF
--- a/src/disk.ts
+++ b/src/disk.ts
@@ -78,6 +78,9 @@ class Disk extends Linker<{ folderUri: vscode.Uri; projectManager: ProjectManage
 
     static TYPE_DIR = '.pc';
 
+    // injected into the ignore ruleset so vcs metadata dirs are never synced
+    static VCS_IGNORE = '.git\n.hg\n.svn\n';
+
     private _events: EventEmitter<EventMap>;
 
     private _folderUri?: vscode.Uri;
@@ -156,13 +159,8 @@ class Disk extends Linker<{ folderUri: vscode.Uri; projectManager: ProjectManage
     private _parseIgnoreText(text: string, folderUri: vscode.Uri, h = hash(text)) {
         this._ignoreHash = h;
 
-        if (!text) {
-            this._ignoring = (_uri: vscode.Uri) => false;
-            this._log.debug(`cleared ignore rules from empty ignore file`);
-            return;
-        }
-
-        const ig = ignore().add(text);
+        // prepend vcs rules so .git/.hg/.svn are always excluded (prevents binary round-trip corruption)
+        const ig = ignore().add(`${Disk.VCS_IGNORE}${text}`);
         this._ignoring = (uri: vscode.Uri) => {
             const path = relativePath(uri, folderUri);
 
@@ -178,7 +176,9 @@ class Disk extends Linker<{ folderUri: vscode.Uri; projectManager: ProjectManage
 
             return ig.ignores(path);
         };
-        this._log.debug(`parsed ignore file ${vscode.Uri.joinPath(folderUri, Disk.IGNORE_FILE)}`);
+        if (text) {
+            this._log.debug(`parsed ignore file ${vscode.Uri.joinPath(folderUri, Disk.IGNORE_FILE)}`);
+        }
     }
 
     private async _writeTypeFiles(folderUri: vscode.Uri) {
@@ -1458,6 +1458,10 @@ class Disk extends Linker<{ folderUri: vscode.Uri; projectManager: ProjectManage
         // drain stale cleanup from a previously failed link
         await super.unlink();
 
+        // install baseline vcs-aware ignore filter before any disk writes —
+        // .pcignore content is parsed later once stubs are on disk
+        this._parseIgnoreText('', folderUri);
+
         // sort into hierarchy
         // TODO: store as tree instead of flat map and sorting
         const ordered = Array.from(projectManager.files.entries()).sort((a, b) => {
@@ -1530,7 +1534,12 @@ class Disk extends Linker<{ folderUri: vscode.Uri; projectManager: ProjectManage
         const levels = new Map<number, vscode.Uri[]>();
         for (const uri of await readDirRecursive(folderUri)) {
             const path = relativePath(uri, folderUri);
-            if (!projectManager.files.has(path) && path !== Disk.TYPE_DIR && !path.startsWith(`${Disk.TYPE_DIR}/`)) {
+            if (
+                !projectManager.files.has(path) &&
+                path !== Disk.TYPE_DIR &&
+                !path.startsWith(`${Disk.TYPE_DIR}/`) &&
+                !this._ignoring(uri)
+            ) {
                 const depth = path.split('/').length;
                 const bucket = levels.get(depth);
                 if (bucket) {

--- a/src/test/suite/extension.test.ts
+++ b/src/test/suite/extension.test.ts
@@ -1878,6 +1878,136 @@ suite('extension', () => {
         assert.ok(infoMessageStub.notCalled, 'info message should not be shown for non-pcignore file');
     });
 
+    test('vcs exclusion - .git not synced', async () => {
+        const folderUri = vscode.workspace.workspaceFolders?.[0]?.uri;
+        assert.ok(folderUri, 'workspace folder should exist');
+
+        const gitDir = vscode.Uri.joinPath(folderUri, '.git');
+        await assertResolves(vscode.workspace.fs.createDirectory(gitDir), 'fs.createDirectory');
+
+        const watcher = watchFilePromise(folderUri, '.git/HEAD', 'create');
+        const headUri = vscode.Uri.joinPath(gitDir, 'HEAD');
+        await assertResolves(
+            vscode.workspace.fs.writeFile(headUri, buffer.from('ref: refs/heads/main\n')),
+            'fs.writeFile'
+        );
+        await assertResolves(watcher, 'watcher.create');
+
+        assert.strictEqual(
+            Array.from(assets.values()).find((a) => a.name === 'HEAD'),
+            undefined,
+            '.git/HEAD should not exist as asset'
+        );
+        assert.strictEqual(
+            Array.from(assets.values()).find((a) => a.name === '.git'),
+            undefined,
+            '.git folder should not exist as asset'
+        );
+    });
+
+    test('vcs exclusion - .git survives re-link cleanup', async () => {
+        const folderUri = vscode.workspace.workspaceFolders?.[0]?.uri;
+        assert.ok(folderUri, 'workspace folder should exist');
+
+        // ensure .git/ and a child file exist on disk before reload
+        const gitDir = vscode.Uri.joinPath(folderUri, '.git');
+        const headUri = vscode.Uri.joinPath(gitDir, 'HEAD');
+        await assertResolves(vscode.workspace.fs.createDirectory(gitDir), 'fs.createDirectory');
+        await assertResolves(
+            vscode.workspace.fs.writeFile(headUri, buffer.from('ref: refs/heads/main\n')),
+            'fs.writeFile'
+        );
+
+        // full unlink + link cycle
+        await assertResolves(
+            vscode.commands.executeCommand(`${NAME}.reloadProject`) as Promise<unknown>,
+            'reloadProject'
+        );
+
+        // .git/ and its contents must survive the cleanup loop
+        let gitExists = false;
+        try {
+            await vscode.workspace.fs.stat(gitDir);
+            gitExists = true;
+        } catch {
+            gitExists = false;
+        }
+        assert.ok(gitExists, '.git/ should still exist after re-link');
+
+        let headExists = false;
+        try {
+            await vscode.workspace.fs.stat(headUri);
+            headExists = true;
+        } catch {
+            headExists = false;
+        }
+        assert.ok(headExists, '.git/HEAD should still exist after re-link');
+    });
+
+    test('vcs exclusion - inbound .git/index not written', async () => {
+        const folderUri = vscode.workspace.workspaceFolders?.[0]?.uri;
+        assert.ok(folderUri, 'workspace folder should exist');
+
+        // inject a fake .git folder asset at the root
+        const gitFolderId = uniqueId.next().value as number;
+        const gitFolder: Asset = {
+            uniqueId: gitFolderId,
+            item_id: `${gitFolderId}`,
+            name: '.git',
+            type: 'folder',
+            path: []
+        };
+        assets.set(gitFolderId, gitFolder);
+        messenger.emit('asset.new', {
+            data: {
+                asset: {
+                    id: gitFolder.item_id,
+                    name: gitFolder.name,
+                    type: gitFolder.type,
+                    branchId: projectSettings.branch
+                }
+            }
+        });
+
+        // inject a child "index" file — so _assetPath() resolves to ".git/index"
+        const indexId = uniqueId.next().value as number;
+        const indexDoc = 'binary-junk';
+        const indexAsset: Asset = {
+            uniqueId: indexId,
+            item_id: `${indexId}`,
+            name: 'index',
+            type: 'script',
+            path: [gitFolderId],
+            file: { filename: 'index', hash: hash(indexDoc) }
+        };
+        assets.set(indexId, indexAsset);
+        documents.set(indexId, indexDoc);
+        messenger.emit('asset.new', {
+            data: {
+                asset: {
+                    id: indexAsset.item_id,
+                    name: indexAsset.name,
+                    type: indexAsset.type,
+                    branchId: projectSettings.branch
+                }
+            }
+        });
+
+        // let the subscribe + _addFile + asset:file:create pipeline settle
+        await wait(process.env.CI ? 500 : 200);
+
+        // .git/index must not be written to disk by the extension
+        const gitIndexUri = vscode.Uri.joinPath(folderUri, '.git', 'index');
+        let indexExists = false;
+        try {
+            await vscode.workspace.fs.stat(gitIndexUri);
+            indexExists = true;
+        } catch {
+            indexExists = false;
+        }
+        assert.strictEqual(indexExists, false, '.git/index should not be written to disk');
+    });
+
     test('collision - file path remote to local', async () => {
         // get folder uri
         const folderUri = vscode.workspace.workspaceFolders?.[0]?.uri;

--- a/src/test/suite/extension.test.ts
+++ b/src/test/suite/extension.test.ts
@@ -12,7 +12,7 @@ import * as sharedbModule from '../../connections/sharedb';
 import * as uriHandlerModule from '../../handlers/uri-handler';
 import type { Asset } from '../../typings/models';
 import * as buffer from '../../utils/buffer';
-import { hash, wait } from '../../utils/utils';
+import { hash, tryCatch, wait } from '../../utils/utils';
 import { MockAuth } from '../mocks/auth';
 import { MockMessenger } from '../mocks/messenger';
 import { assets, documents, branches, projectSettings, project, user, uniqueId } from '../mocks/models';
@@ -841,11 +841,7 @@ suite('extension', () => {
 
         // build a nested source structure outside the workspace so the watcher doesn't see it
         const tmpBase = vscode.Uri.file('/tmp/claude/race_test_src');
-        try {
-            await vscode.workspace.fs.delete(tmpBase, { recursive: true });
-        } catch {
-            // ignore if doesn't exist
-        }
+        await tryCatch(vscode.workspace.fs.delete(tmpBase, { recursive: true }) as Promise<void>);
         const srcSub = vscode.Uri.joinPath(tmpBase, 'race_sub');
         await vscode.workspace.fs.createDirectory(srcSub);
         await vscode.workspace.fs.writeFile(
@@ -1925,23 +1921,11 @@ suite('extension', () => {
         );
 
         // .git/ and its contents must survive the cleanup loop
-        let gitExists = false;
-        try {
-            await vscode.workspace.fs.stat(gitDir);
-            gitExists = true;
-        } catch {
-            gitExists = false;
-        }
-        assert.ok(gitExists, '.git/ should still exist after re-link');
+        const [gitErr] = await tryCatch(vscode.workspace.fs.stat(gitDir) as Promise<vscode.FileStat>);
+        assert.ok(!gitErr, '.git/ should still exist after re-link');
 
-        let headExists = false;
-        try {
-            await vscode.workspace.fs.stat(headUri);
-            headExists = true;
-        } catch {
-            headExists = false;
-        }
-        assert.ok(headExists, '.git/HEAD should still exist after re-link');
+        const [headErr] = await tryCatch(vscode.workspace.fs.stat(headUri) as Promise<vscode.FileStat>);
+        assert.ok(!headErr, '.git/HEAD should still exist after re-link');
     });
 
     test('vcs exclusion - inbound .git/index not written', async () => {
@@ -1998,14 +1982,8 @@ suite('extension', () => {
 
         // .git/index must not be written to disk by the extension
         const gitIndexUri = vscode.Uri.joinPath(folderUri, '.git', 'index');
-        let indexExists = false;
-        try {
-            await vscode.workspace.fs.stat(gitIndexUri);
-            indexExists = true;
-        } catch {
-            indexExists = false;
-        }
-        assert.strictEqual(indexExists, false, '.git/index should not be written to disk');
+        const [indexErr] = await tryCatch(vscode.workspace.fs.stat(gitIndexUri) as Promise<vscode.FileStat>);
+        assert.ok(indexErr, '.git/index should not be written to disk');
     });
 
     test('collision - file path remote to local', async () => {
@@ -2172,14 +2150,8 @@ suite('extension', () => {
         // child is skipped due to parent collision (not tracked as collision itself)
         // verify child file does not exist on disk
         const childUri = vscode.Uri.joinPath(folderUri, folderName, 'child.js');
-        let childExists = false;
-        try {
-            await vscode.workspace.fs.stat(childUri);
-            childExists = true;
-        } catch {
-            childExists = false;
-        }
-        assert.strictEqual(childExists, false, 'child file should not exist due to parent collision');
+        const [childErr] = await tryCatch(vscode.workspace.fs.stat(childUri) as Promise<vscode.FileStat>);
+        assert.ok(childErr, 'child file should not exist due to parent collision');
     });
 
     test('collision - rename remote to local', async () => {


### PR DESCRIPTION
Fixes #247

### What's Changed

- Prepends `.git\n.hg\n.svn\n` to the ignore ruleset so VCS dirs are always excluded — same mechanism as the documented `.pcignore` workaround, just baked in. All sync boundaries already go through `_ignoring(uri)`, so no boundary-site changes.
- Installs the filter at the start of `link()`, before the initial `writeAll`. Without this, a fresh client linking to ShareDB history that's already polluted by this bug would write the bad `.git/*` assets to disk before `.pcignore` is parsed.
- Switches the link cleanup loop to `!this._ignoring(uri)`. Intentional behavior change: files matching user `.pcignore` rules are now also preserved during cleanup, not just `.pc/` and VCS dirs.
- Tests: outbound `.git/HEAD` not uploaded; local `.git/` survives a re-link; inbound ShareDB `.git/index` asset not written to disk.

### Why

`git init` / `git add` inside a linked project corrupted `.git/index`: the watcher picked up binary git writes, round-tripped them through the text OT pipeline (invalid UTF-8 → U+FFFD), and wrote the mangled bytes back onto `.git/index`. Matches the default behavior of every other collaborative editor (Live Share, Cursor, Replit).