### PR TITLE
fix: let project tsconfig override plugin compiler options

### DIFF
--- a/plugin/src/index.ts
+++ b/plugin/src/index.ts
@@ -47,11 +47,18 @@ const init = (modules: { typescript: typeof ts }): ts.server.PluginModule => {
         const readFile = proxy.readFile.bind(proxy);
         const getCompilationSettings = proxy.getCompilationSettings.bind(proxy);
 
-        // intercept to merge custom compiler options to enable JS support
+        // project tsconfig wins over plugin defaults; cache by settings
+        // identity since ts reuses the object until tsconfig reloads
+        let cache: { settings: ts.CompilerOptions; merged: ts.CompilerOptions } | undefined;
         proxy.getCompilationSettings = () => {
             const settings = getCompilationSettings();
-            log(info.project, `Merging custom compiler options into project settings.`);
-            return Object.assign(settings, compilerOptions);
+            if (cache?.settings === settings) {
+                return cache.merged;
+            }
+            const merged = { ...compilerOptions, ...settings };
+            merged.lib = [...(compilerOptions.lib ?? []), ...(settings.lib ?? [])];
+            cache = { settings, merged };
+            return merged;
         };
 
         // intercept getScriptSnapshot to provide a snapshot for the virtual file


### PR DESCRIPTION
### What's Changed

- Flip merge direction in the TS plugin so a project's tsconfig wins over plugin defaults (previously plugin options overrode `checkJs`, `target`, etc. from user tsconfigs)
- Concatenate `lib` arrays instead of replacing, so DOM libs stay present when a user tsconfig sets `lib`
- Cache the merged result by settings-object identity; TS reuses the object until tsconfig reloads, so the hot path becomes a single reference check
- Drop the per-call log that was firing on every language-service settings lookup