### PR TITLE
fix: clean up _diskHash and _diskStat on delete, rename, and unlink

### DIFF
--- a/src/disk.ts
+++ b/src/disk.ts
@@ -519,6 +519,9 @@ class Disk extends Linker<{ folderUri: vscode.Uri; projectManager: ProjectManage
                 useTrash: false
             });
 
+            this._diskHash.delete(uri.path);
+            this._diskStat.delete(uri.path);
+
             this._log.debug(`delete.remote file ${uri}`);
         });
     }
@@ -541,6 +544,10 @@ class Disk extends Linker<{ folderUri: vscode.Uri; projectManager: ProjectManage
             await vscode.workspace.fs.rename(oldUri, newUri, {
                 overwrite: false
             });
+
+            // next _update or _create write on newUri.path will repopulate
+            this._diskHash.delete(oldUri.path);
+            this._diskStat.delete(oldUri.path);
 
             this._log.debug(`rename.remote ${oldUri.path} -> ${newUri.path}`);
         });
@@ -1653,6 +1660,8 @@ class Disk extends Linker<{ folderUri: vscode.Uri; projectManager: ProjectManage
         this._folderUri = undefined;
         this._projectManager = undefined;
         this._bufferState.clear();
+        this._diskHash.clear();
+        this._diskStat.clear();
         this._undos.forEach((m) => m.clear());
         this._undos.clear();
         void vscode.commands.executeCommand('setContext', 'playcanvas.active', false);


### PR DESCRIPTION
Fixes #267

### What's Changed

- `_delete`: drop `_diskHash` / `_diskStat` entries for the URI after `fs.delete`
- `_rename`: drop `oldUri.path` entries in both maps after `fs.rename`; `newUri.path` repopulates on next `_update`/`_create` write
- `unlink`: clear both maps alongside the existing `_bufferState.clear()`

No behavioral change — stale anchors were inert (fall through to the `readFile` merge check). This just stops the maps from growing unbounded over long sessions with many creates/renames/deletes.