### PR TITLE
fix: reveal cursor in viewport on local undo/redo

### DIFF
--- a/src/disk.ts
+++ b/src/disk.ts
@@ -909,6 +909,7 @@ class Disk extends Linker<{ folderUri: vscode.Uri; projectManager: ProjectManage
                     }
                     const pos = doc.positionAt(cursor);
                     active.selection = new vscode.Selection(pos, pos);
+                    active.revealRange(new vscode.Range(pos, pos), vscode.TextEditorRevealType.Default);
                 }
 
                 // mark dirty


### PR DESCRIPTION
Fixes #239

### What's Changed

- Local `playcanvas.undo` / `playcanvas.redo` now call `editor.revealRange()` after setting the cursor, matching VS Code's native undo/redo behavior so the viewport follows the cursor when the edit site is off-screen.
- Guarded to the active editor only; remote ops still flow through `_update()` and do not move the local viewport.