### PR TITLE
fix: revert divergence-merge upstream push on closed-file update

### DIFF
--- a/src/disk.ts
+++ b/src/disk.ts
@@ -334,53 +334,8 @@ class Disk extends Linker<{ folderUri: vscode.Uri; projectManager: ProjectManage
                 const key = `${uri}`;
                 this._syncing.add(key);
 
-                // merge remote op with divergent disk content OT-style instead of clobbering
-                // (watcher miss, unlink gap, former .pcignore match). skip the check when
-                // our own write is pending or when stat matches the last-known anchor —
-                // disk can't have diverged in either case.
-                let next = buffer.from(snapshot);
-                const anchor = this._diskStat.get(uri.path);
-                const pending = this._debouncer.has(key);
-                const [, st] =
-                    !pending && anchor ? await tryCatch(Promise.resolve(vscode.workspace.fs.stat(uri))) : [null, null];
-                const fresh = !!st && st.mtime === anchor?.mtime && st.size === anchor?.size;
-
-                if (!pending && !fresh && this._projectManager && this._folderUri) {
-                    const [, existing] = await tryCatch(
-                        Promise.resolve(vscode.workspace.fs.readFile(uri) as Promise<Uint8Array>)
-                    );
-                    if (existing) {
-                        const known = this._diskHash.get(uri.path);
-                        const observed = hash(existing);
-                        const diskText = norm(buffer.toString(existing));
-                        if (known !== undefined && known !== observed && diskText !== snapshot) {
-                            const path = relativePath(uri, this._folderUri);
-                            const file = this._projectManager.files.get(path);
-                            const userOp = file?.type === 'file' ? delta(prev, diskText) : undefined;
-                            if (userOp && file?.type === 'file') {
-                                // transform local delta against remote op, then against any
-                                // advancement of file.doc from ops queued while we awaited readFile
-                                const postOp = ottext.transform(userOp, op, 'left') as ShareDbTextOp;
-                                const adv = delta(content, file.doc.text);
-                                const upstream = adv
-                                    ? (ottext.transform(postOp, adv, 'left') as ShareDbTextOp)
-                                    : postOp;
-                                file.doc.apply(upstream);
-
-                                next = buffer.from(file.doc.text);
-
-                                const wasDirty = file.dirty;
-                                file.dirty = true;
-                                if (!wasDirty) {
-                                    this._events.emit('asset:file:dirty', path, true);
-                                }
-                                this._log.info(`update.local.preserved ${uri} ${stat(op)}`);
-                            }
-                        }
-                    }
-                }
-
                 // debounce rapid changes to avoid overwhelming disk with writes
+                const next = buffer.from(snapshot);
                 void this._debouncer
                     .debounce(key, async () => {
                         const h = hash(next);

--- a/src/test/suite/extension.test.ts
+++ b/src/test/suite/extension.test.ts
@@ -1042,46 +1042,6 @@ suite('extension', () => {
         assert.strictEqual(buffer.toString(content), `// REMOTE COMMENT\n${document}`, 'file content should match');
     });
 
-    test('file change - closed remote sequence does not trigger spurious submissions', async () => {
-        // guards the divergence check: after a closed-file remote op, _diskHash must be
-        // advanced so subsequent remote ops don't mistake disk state as diverged and
-        // submit a bogus merge op upstream
-        const folderUri = vscode.workspace.workspaceFolders?.[0]?.uri;
-        assert.ok(folderUri, 'workspace folder should exist');
-
-        const asset = await assetCreate({ name: 'closed_remote_sequence.js', content: '// ORIGINAL\n' });
-        assert.ok(asset, 'asset should be created');
-
-        const doc = sharedb.subscriptions.get(`documents:${asset.uniqueId}`);
-        assert.ok(doc, 'sharedb document should exist');
-
-        // first remote op — bootstraps _diskHash + _diskStat via the debounced write
-        const watcher1 = watchFilePromise(folderUri, asset.name, 'change');
-        doc.submitOp(['// FIRST\n'], { source: 'remote' });
-        await assertResolves(watcher1, 'watcher.change 1');
-        await wait(process.env.CI ? 200 : 100);
-
-        // reset history so only post-op-1 submissions are counted
-        doc.submitOp.resetHistory();
-
-        // second remote op — should flow through as a pure remote update
-        const watcher2 = watchFilePromise(folderUri, asset.name, 'change');
-        doc.submitOp([8, 'SECOND\n'], { source: 'remote' });
-        await assertResolves(watcher2, 'watcher.change 2');
-        await wait(process.env.CI ? 200 : 100);
-
-        // local-sourced submitOps (source !== 'remote') indicate the merge branch
-        // spuriously fired and pushed disk content back upstream
-        const localCalls = doc.submitOp
-            .getCalls()
-            .filter((c) => (c.args[1] as { source?: string } | undefined)?.source !== 'remote');
-        assert.strictEqual(
-            localCalls.length,
-            0,
-            'no local submitOp should fire for pure remote updates (divergence branch must stay dormant)'
-        );
-    });
-
     test('file change - open local to remote', async () => {
         // get folder uri
         const folderUri = vscode.workspace.workspaceFolders?.[0]?.uri;


### PR DESCRIPTION
Fixes #270

### What's Changed

- Revert the merge-on-divergence branch in `_update` added by #264. When disk content diverged from the `_diskHash` baseline, the path submitted a `delta(prev, diskText)` back upstream as if the user had typed it — on project reopen with stale local files, this overwrote collaborator edits in the cloud.
- Restores v1.8.4 behavior for closed-file remote ops: server snapshot flows straight to the debounced disk write, no readback, no upstream push.
- `_diskStat`/`_diskHash` anchor writes and cleanup (#268) retained — inert without the merge branch, removing would be churn.

Re-opens #252 (watcher-blind external edits on closed files can still be clobbered). That window is narrow (unlink gap / former `.pcignore` match / watcher miss) and lower priority than the collab data-loss in #270.