### PR TITLE
test: extend mock fidelity to asset OT and error injection

### DIFF
--- a/src/test/mocks/rest.ts
+++ b/src/test/mocks/rest.ts
@@ -43,6 +43,41 @@ class MockRest extends Rest {
 
     assetFile: sinon.SinonSpy<[number, string, string], Promise<ArrayBuffer>>;
 
+    // FIFO of errors to throw on the next N calls of a given method. mirrors a final
+    // post-retry failure from src/connections/rest.ts (MAX_RETRIES=3) — exercises the
+    // ProjectManager error/guard path without simulating the retry loop itself.
+    private _failures = new Map<string, Error[]>();
+
+    failNext(
+        method:
+            | 'id'
+            | 'user'
+            | 'userThumb'
+            | 'userProjects'
+            | 'projectAssets'
+            | 'projectBranches'
+            | 'branchCheckout'
+            | 'assetCreate'
+            | 'assetRename'
+            | 'assetFile',
+        err: Error = new Error(`HTTP 500 (mock): ${method}`)
+    ) {
+        const q = this._failures.get(method) ?? [];
+        q.push(err);
+        this._failures.set(method, q);
+    }
+
+    resetFailures() {
+        this._failures.clear();
+    }
+
+    private _maybeFail(method: string) {
+        const err = this._failures.get(method)?.shift();
+        if (err) {
+            throw err;
+        }
+    }
+
     constructor(sandbox: sinon.SinonSandbox, messenger: MockMessenger, sharedb: MockShareDb) {
         super({
             url: '',
@@ -50,13 +85,34 @@ class MockRest extends Rest {
             accessToken
         });
 
-        this.id = sandbox.spy(async () => user.id);
-        this.user = sandbox.spy(async () => user);
-        this.userThumb = sandbox.spy(async () => new ArrayBuffer(0));
-        this.userProjects = sandbox.spy(async (_userId: number, _view?: string) => [project]);
-        this.projectAssets = sandbox.spy(async (_projectId: number) => Array.from(assets.values()));
-        this.projectBranches = sandbox.spy(async (_projectId: number) => Array.from(branches.values()));
-        this.branchCheckout = sandbox.spy(async (branchId: string) => branches.get(branchId)!);
+        this.id = sandbox.spy(async () => {
+            this._maybeFail('id');
+            return user.id;
+        });
+        this.user = sandbox.spy(async () => {
+            this._maybeFail('user');
+            return user;
+        });
+        this.userThumb = sandbox.spy(async () => {
+            this._maybeFail('userThumb');
+            return new ArrayBuffer(0);
+        });
+        this.userProjects = sandbox.spy(async (_userId: number, _view?: string) => {
+            this._maybeFail('userProjects');
+            return [project];
+        });
+        this.projectAssets = sandbox.spy(async (_projectId: number) => {
+            this._maybeFail('projectAssets');
+            return Array.from(assets.values());
+        });
+        this.projectBranches = sandbox.spy(async (_projectId: number) => {
+            this._maybeFail('projectBranches');
+            return Array.from(branches.values());
+        });
+        this.branchCheckout = sandbox.spy(async (branchId: string) => {
+            this._maybeFail('branchCheckout');
+            return branches.get(branchId)!;
+        });
         this.assetCreate = sandbox.spy(
             async (
                 _projectId: number,
@@ -70,6 +126,7 @@ class MockRest extends Rest {
                     file?: Blob;
                 }
             ) => {
+                this._maybeFail('assetCreate');
                 // calculate path
                 let path: number[] = [];
                 if (data.parent) {
@@ -118,6 +175,7 @@ class MockRest extends Rest {
             }
         );
         this.assetRename = sandbox.spy(async (_projectId: number, _branchId: string, assetId: number, name: string) => {
+            this._maybeFail('assetRename');
             // find asset and document
             const asset = assets.get(assetId);
             assert(asset, `asset with ID ${assetId} not found`);
@@ -143,6 +201,7 @@ class MockRest extends Rest {
             return asset;
         });
         this.assetFile = sandbox.spy(async (assetId: number, _branchId: string, _filename: string) => {
+            this._maybeFail('assetFile');
             const content = documents.get(assetId) ?? '';
             return new TextEncoder().encode(content).buffer;
         });

--- a/src/test/mocks/sharedb.ts
+++ b/src/test/mocks/sharedb.ts
@@ -6,7 +6,7 @@ import type { Snapshot, Callback, ShareDBSourceOptions, DocEventMap, Error } fro
 import type sinon from 'sinon';
 
 import { ShareDb } from '../../connections/sharedb';
-import type { ShareDbTextOp } from '../../typings/sharedb';
+import type { ShareDbOp, ShareDbTextOp } from '../../typings/sharedb';
 
 import type { MockMessenger } from './messenger';
 import { projectSettings, assets, documents } from './models';
@@ -153,6 +153,41 @@ class Doc implements sharedb.Doc {
 // the wire is canonicalized to LF. norm() in src/utils/text.ts mirrors this on the client.
 const normLF = (data: unknown) => (typeof data === 'string' ? data.replace(/\r\n|\r/g, '\n') : data);
 
+// in-place applier that mirrors the loose semantics of ProjectManager._addAsset
+// (src/project-manager.ts:189-239). production walks o.p[0..n-2], reads o.p[n-1] as
+// a key, and applies array ops via splice(parseInt(key,10) || 0, ...). existing tests
+// submit ops shaped like [{p:['path'], li: folderId}] which strict ot-json0 would
+// reject (parent is the asset object, not the array) — the loose form is load-bearing,
+// so we hand-roll instead of importing ot-json0.
+const applyAssetOp = (data: Record<string, unknown>, ops: ShareDbOp[]) => {
+    for (const o of ops) {
+        let obj = data as Record<string, unknown>;
+        for (let i = 0; i < o.p.length - 1; i++) {
+            const p = o.p[i];
+            if (obj[p] == null) {
+                obj[p] = {};
+            }
+            obj = obj[p] as Record<string, unknown>;
+        }
+        const key = o.p[o.p.length - 1];
+        const idx = parseInt(String(key), 10) || 0;
+        const val = obj[key];
+        if (o.oi !== undefined && o.od !== undefined) {
+            obj[key] = o.oi;
+        } else if (o.oi !== undefined) {
+            obj[key] = o.oi;
+        } else if (o.od !== undefined) {
+            delete obj[key];
+        } else if (o.li !== undefined && o.ld !== undefined && Array.isArray(val)) {
+            val[idx] = o.li;
+        } else if (o.li !== undefined && Array.isArray(val)) {
+            val.splice(idx, 0, o.li);
+        } else if (o.ld !== undefined && Array.isArray(val)) {
+            val.splice(idx, 1);
+        }
+    }
+};
+
 class MockDoc extends Doc {
     on: sinon.SinonSpy<[type: string, listener: (...args: unknown[]) => void], this>;
 
@@ -238,6 +273,16 @@ class MockDoc extends Doc {
                 if (Array.isArray(op) && type === 'documents' && typeof this.data === 'string') {
                     this.data = ottext.apply(this.data, op as ShareDbTextOp) as string;
                     documents.set(parseInt(key, 10), this.data as string);
+                } else if (
+                    Array.isArray(op) &&
+                    (type === 'assets' || type === 'settings') &&
+                    this.data &&
+                    typeof this.data === 'object'
+                ) {
+                    // mutate in place — this.data shares its reference with the assets
+                    // Map / projectSettings singleton (sharedb.ts:187/195), so cloning
+                    // would silently desync the mock from the maps.
+                    applyAssetOp(this.data as Record<string, unknown>, op as ShareDbOp[]);
                 }
                 events.emit('op', op as unknown[], options?.source || '');
                 this._pending--;
@@ -276,6 +321,19 @@ class MockShareDb extends ShareDb {
 
     resetAdversarial!: () => void;
 
+    // FIFO of save responses to inject per uniqueId. empty queue → emit 'success'
+    // (today's default). drives ProjectManager._verifySave's retry path
+    // (src/project-manager.ts:399-422), which re-sends doc:reconnect + doc:save.
+    saveResponses = new Map<number, ('success' | 'error')[]>();
+
+    failNextSave(uniqueId: number, count = 1) {
+        const q = this.saveResponses.get(uniqueId) ?? [];
+        for (let i = 0; i < count; i++) {
+            q.push('error');
+        }
+        this.saveResponses.set(uniqueId, q);
+    }
+
     constructor(sandbox: sinon.SinonSandbox, messenger: MockMessenger) {
         super({ url: '', origin: '' });
 
@@ -307,6 +365,7 @@ class MockShareDb extends ShareDb {
                 doc._latency = 0;
                 doc._rejectNext = null;
             }
+            this.saveResponses.clear();
         };
         this.sendRaw = sandbox.spy(async (data: Parameters<WebSocket['send']>[0]) => {
             // check for fs operations
@@ -363,7 +422,9 @@ class MockShareDb extends ShareDb {
             if (`${data}`.startsWith('doc:save')) {
                 const raw = data.toString().slice(9);
                 const id = parseInt(raw, 10);
-                this.emit('doc:save', 'success', id);
+                const q = this.saveResponses.get(id);
+                const state = q?.shift() ?? 'success';
+                this.emit('doc:save', state, id);
                 return;
             }
             return;

--- a/src/test/suite/extension.test.ts
+++ b/src/test/suite/extension.test.ts
@@ -56,6 +56,9 @@ const warningMessageStub = sandbox.stub(vscode.window, 'showWarningMessage').res
 // stub info message for ignore update prompts
 const infoMessageStub = sandbox.stub(vscode.window, 'showInformationMessage').resolves(undefined);
 
+// stub error message — handleError() in extension.ts:105 surfaces pm.error here
+const errorMessageStub = sandbox.stub(vscode.window, 'showErrorMessage').resolves(undefined);
+
 // spy vscode methods
 const openTextDocumentSpy = sandbox.spy(vscode.workspace, 'openTextDocument');
 
@@ -175,6 +178,9 @@ suite('extension', () => {
         // clear per-doc test-injection flags (_latency, _rejectNext) so a stuck/desync
         // test in one slot doesn't bleed into the next test's first submit.
         sharedb.resetAdversarial();
+        // clear per-method REST failure queues so a failNext from one test doesn't
+        // get consumed by the next test's first call.
+        rest.resetFailures();
         // settle deferred queue / mutex between tests
         await wait(process.env.CI ? 2000 : 50);
     });
@@ -2707,5 +2713,117 @@ suite('extension', () => {
         // ops, when applied in their submitted order, reproduce the buffer state.
         assert.strictEqual(tdoc.getText(), '1AAA\n2BBB\n3CCC\n', 'buffer content sanity');
         assert.strictEqual(documents.get(asset.uniqueId), '1AAA\n2BBB\n3CCC\n', 'mock-applied ops must match buffer');
+    });
+
+    test('mock fidelity - asset doc op mutates snapshot (rename)', async () => {
+        // production handler at src/project-manager.ts:212-216 applies oi/od/li/ld
+        // against an internal snapshot when the asset doc emits an 'op' event. mock
+        // must mirror this so doc.data and assets.get(id) stay in lockstep — without
+        // the applier, an asset rename test would only pass because MockRest.assetRename
+        // mutates the assets map directly, masking real op-handler regressions.
+        const asset = await assetCreate({ name: 'rename_via_op.js', content: '// X\n' });
+        const doc = sharedb.subscriptions.get(`assets:${asset.uniqueId}`);
+        assert.ok(doc, 'asset doc should exist');
+
+        doc.submitOp([{ p: ['name'], oi: 'renamed_via_op.js' }], { source: 'remote' });
+        await wait(0);
+
+        const data = doc.data as { name: string };
+        assert.strictEqual(data.name, 'renamed_via_op.js', 'doc.data should reflect oi');
+        assert.strictEqual(assets.get(asset.uniqueId)?.name, 'renamed_via_op.js', 'assets map shares the reference');
+    });
+
+    test('mock fidelity - asset doc op updates path on folder move', async () => {
+        // exercises the loose splice semantics: [{p:['path'], li: folderId}] lands
+        // li at index parseInt('path',10)||0 === 0 — same as production's _addAsset
+        // handler at src/project-manager.ts:227-231.
+        const folder = await assetCreate({ name: 'move_target_folder' });
+        const file = await assetCreate({ name: 'move_subject.js', content: '// X\n' });
+        const doc = sharedb.subscriptions.get(`assets:${file.uniqueId}`);
+        assert.ok(doc, 'asset doc should exist');
+
+        doc.submitOp([{ p: ['path'], li: folder.uniqueId }], { source: 'remote' });
+        await wait(0);
+
+        const data = doc.data as { path: number[] };
+        assert.deepStrictEqual(data.path, [folder.uniqueId], 'path array should have the folder id appended at idx 0');
+    });
+
+    test('mock fidelity - settings doc remote op mutates singleton', async () => {
+        // settings doc.data is a reference to the projectSettings singleton
+        // (src/test/mocks/sharedb.ts:195) — mutation must land on the same object so
+        // production-style settings consumers (none today, but forward-insurance) see
+        // the change. use an unused field so other tests reading projectSettings.branch
+        // are unaffected.
+        const doc = sharedb.subscriptions.get(`settings:project_${project.id}_${user.id}`);
+        assert.ok(doc, 'settings doc should exist');
+
+        doc.submitOp([{ p: ['_p2_marker'], oi: 'x' }], { source: 'remote' });
+        await wait(0);
+
+        const data = doc.data as Record<string, unknown>;
+        assert.strictEqual(data._p2_marker, 'x', 'doc.data should reflect oi');
+        assert.strictEqual(
+            (projectSettings as Record<string, unknown>)._p2_marker,
+            'x',
+            'projectSettings singleton should be mutated in place'
+        );
+        // cleanup so the marker doesn't leak into a downstream test
+        delete (projectSettings as Record<string, unknown>)._p2_marker;
+    });
+
+    test('save retry recovers after single doc:save:error', async () => {
+        // collab-server may respond doc:save:error:N (e.g. transient S3 hiccup).
+        // ProjectManager._verifySave (src/project-manager.ts:399-422) schedules a
+        // retry after SAVE_RETRY_DELAY_MS (2000ms): doc:reconnect:N then doc:save:N.
+        // without P2.3's failNextSave hook this branch was unreachable from tests.
+        const folderUri = vscode.workspace.workspaceFolders?.[0]?.uri;
+        assert.ok(folderUri, 'workspace folder should exist');
+
+        const asset = await assetCreate({ name: 'save_retry.js', content: '// ORIG\n' });
+        const uri = vscode.Uri.joinPath(folderUri, asset.name);
+        const tdoc = await vscode.workspace.openTextDocument(uri);
+        await vscode.window.showTextDocument(tdoc);
+
+        // dirty the doc so a save actually rounds the server
+        const edit = new vscode.WorkspaceEdit();
+        edit.insert(uri, new vscode.Position(0, 0), '// EDIT\n');
+        await vscode.workspace.applyEdit(edit);
+
+        sharedb.failNextSave(asset.uniqueId, 1);
+        sharedb.sendRaw.resetHistory();
+        await tdoc.save();
+
+        // wait past the retry delay (2s) + small buffer for the reconnect/save round trip
+        await wait(2200);
+
+        const calls = sharedb.sendRaw.getCalls().map((c) => `${c.args[0]}`);
+        const docSaves = calls.filter((c) => c === `doc:save:${asset.uniqueId}`);
+        const reconnects = calls.filter((c) => c === `doc:reconnect:${asset.uniqueId}`);
+        assert.strictEqual(docSaves.length, 2, 'expected initial doc:save + retry doc:save');
+        assert.strictEqual(reconnects.length, 1, 'expected one doc:reconnect during retry');
+    });
+
+    test('rest assetCreate failure surfaces error to user', async () => {
+        // production: pm.create wraps rest.assetCreate in guard() (project-manager.ts:939)
+        // which sets pm.error on throw; the effect at extension.ts:706 calls handleError
+        // which posts via vscode.window.showErrorMessage. without P2.4's failNext hook
+        // this entire user-visible path was unreachable from tests.
+        const folderUri = vscode.workspace.workspaceFolders?.[0]?.uri;
+        assert.ok(folderUri, 'workspace folder should exist');
+
+        errorMessageStub.resetHistory();
+        rest.failNext('assetCreate', new Error('mock 500: assetCreate refused'));
+
+        const fileUri = vscode.Uri.joinPath(folderUri, 'rest_fail_create.js');
+        await vscode.workspace.fs.writeFile(fileUri, new TextEncoder().encode('// LOCAL\n'));
+
+        // wait for the disk watcher → pm.create → rest.assetCreate → guard → error effect chain
+        await wait(process.env.CI ? 1500 : 500);
+
+        const errorCall = errorMessageStub
+            .getCalls()
+            .find((c) => `${c.args[0]}`.includes('mock 500: assetCreate refused'));
+        assert.ok(errorCall, 'showErrorMessage must surface the rest failure');
     });
 });


### PR DESCRIPTION
### What's Changed

Phase 2 of the mock-vs-cluster fidelity plan. Builds on PR #276 (Phase 1). All changes in \`src/test/\`; no production code touched.

**\`MockDoc\` (src/test/mocks/sharedb.ts):**
- New \`applyAssetOp\` — hand-rolled json0-style applier mirroring the loose \`parseInt(o.p[n-1], 10) || 0\` semantics in \`ProjectManager._addAsset\` (src/project-manager.ts:222-237). Strict ot-json0 would reject existing ops shaped like \`[{p:['path'], li: folderId}]\`, so the loose form is load-bearing.
- \`submitOp\` for \`'assets'\` and \`'settings'\` now mutates \`this.data\` in place (the data is a reference into the \`assets\` Map / \`projectSettings\` singleton — cloning would silently desync the mock from the maps).

**\`MockShareDb\` (src/test/mocks/sharedb.ts):**
- \`saveResponses: Map<number, ('success'|'error')[]>\` + \`failNextSave(uniqueId, count = 1)\` — FIFO of save-error responses consumed by the existing \`doc:save\` \`sendRaw\` branch. Drives the retry path in \`ProjectManager._verifySave\` (src/project-manager.ts:399-422).
- \`resetAdversarial\` extended to clear the queue at teardown.

**\`MockRest\` (src/test/mocks/rest.ts):**
- \`failNext(method, err?)\` / \`resetFailures()\` / private \`_maybeFail(method)\` — FIFO of errors to throw on the next N calls of a given REST method. Matches a post-retry final failure from \`src/connections/rest.ts\`. Each spy gets a one-line \`_maybeFail\` at the top of its body.
- \`teardown()\` now also calls \`rest.resetFailures()\`.

**Test wiring (src/test/suite/extension.test.ts):**
- New \`errorMessageStub\` for \`vscode.window.showErrorMessage\` so REST-failure surfacing is observable.
- Five new tests:
  - \`mock fidelity - asset doc op mutates snapshot (rename)\`
  - \`mock fidelity - asset doc op updates path on folder move\`
  - \`mock fidelity - settings doc remote op mutates singleton\`
  - \`save retry recovers after single doc:save:error\` (~2.4s — uses real \`SAVE_RETRY_DELAY_MS = 2000\`)
  - \`rest assetCreate failure surfaces error to user\`

**Skipped from the original Phase 2 spec:**
- \`bulkSubscribe\` with version maps — production's \`bulkSubscribe\` is a thin \`startBulk\`/\`endBulk\` wrapper with no client-observable behavior distinct from N parallel \`subscribe()\` calls. Already covered by Phase 1's \`MockDoc.reload()\`.
- \`save retry — exhausts max retries\` — would add ~12s wall time to lock in a single dead-code branch. Cut by user choice.
- \`save retry — bails on unlink mid-retry\` — requires triggering project unlink mid-flight; fragile in vscode-test.
- \`assetRename failure leaves file state consistent\` — has dirty-rollback complexity worth a follow-up.

69 tests pass (60 + 4 from Phase 1 + 5 from Phase 2). Phase 3 (auth/protocol + missing message types) follows in a separate branch when needed.