### PR TITLE
fix: don't drop server doc state on dirty close

### DIFF
--- a/src/project-manager.ts
+++ b/src/project-manager.ts
@@ -1328,6 +1328,13 @@ class ProjectManager extends Linker<{ projectId: number; branchId: string }> {
             return;
         }
 
+        // close:document drops in-memory ShareDB state; sending it while dirty
+        // rolls back peer edits on re-hydration (#278)
+        if (file.dirty) {
+            this._log.debug(`skipping unsubscribe of ${path} (dirty)`);
+            return;
+        }
+
         const uniqueId = file.uniqueId;
         await this._sharedb.unsubscribe('documents', `${uniqueId}`);
         this._sharedb.sendRaw(`close:document:${uniqueId}`);

--- a/src/test/mocks/models.ts
+++ b/src/test/mocks/models.ts
@@ -46,6 +46,9 @@ export const projectSettings = {
 
 export const documents = new Map<number, string>([[1, `console.log('Hello, World!');`]]);
 
+// S3 baseline per uniqueId; re-syncs on doc:save, replaces `documents` on close:document
+export const persisted = new Map<number, string>(documents);
+
 export const assets = new Map<number, Asset>(
     [
         {

--- a/src/test/mocks/rest.ts
+++ b/src/test/mocks/rest.ts
@@ -7,7 +7,7 @@ import type { Asset, Branch, Project, User } from '../../typings/models';
 import { hash } from '../../utils/utils';
 
 import type { MockMessenger } from './messenger';
-import { user, project, assets, branches, documents, accessToken, uniqueId } from './models';
+import { user, project, assets, branches, documents, persisted, accessToken, uniqueId } from './models';
 import type { MockShareDb } from './sharedb';
 
 class MockRest extends Rest {
@@ -156,8 +156,9 @@ class MockRest extends Rest {
                 };
                 assets.set(id, asset);
 
-                // add document to documents map
+                // add document to documents map (in-memory) and persisted (S3 baseline)
                 documents.set(asset.uniqueId, document);
+                persisted.set(asset.uniqueId, document);
 
                 // call messenger assetCreated signal
                 messenger.emit('asset.new', {

--- a/src/test/mocks/sharedb.ts
+++ b/src/test/mocks/sharedb.ts
@@ -9,7 +9,7 @@ import { ShareDb } from '../../connections/sharedb';
 import type { ShareDbOp, ShareDbTextOp } from '../../typings/sharedb';
 
 import type { MockMessenger } from './messenger';
-import { projectSettings, assets, documents } from './models';
+import { projectSettings, assets, documents, persisted } from './models';
 
 class Doc implements sharedb.Doc {
     id = '';
@@ -424,7 +424,30 @@ class MockShareDb extends ShareDb {
                 const id = parseInt(raw, 10);
                 const q = this.saveResponses.get(id);
                 const state = q?.shift() ?? 'success';
+                if (state === 'success') {
+                    const current = documents.get(id);
+                    if (current !== undefined) {
+                        persisted.set(id, current);
+                    }
+                }
                 this.emit('doc:save', state, id);
+                return;
+            }
+
+            // server drops in-memory state on close:document; mirror by reverting
+            // `documents` to the persisted baseline (and 'load'-emit any subscriber)
+            if (`${data}`.startsWith('close:document:')) {
+                const raw = data.toString().slice('close:document:'.length);
+                const id = parseInt(raw, 10);
+                const baseline = persisted.get(id);
+                const current = documents.get(id);
+                if (baseline !== undefined && current !== undefined && baseline !== current) {
+                    documents.set(id, baseline);
+                    const doc = this.subscriptions.get(`documents:${id}`);
+                    if (doc) {
+                        doc.reload(baseline);
+                    }
+                }
                 return;
             }
             return;

--- a/src/test/suite/extension.test.ts
+++ b/src/test/suite/extension.test.ts
@@ -1222,6 +1222,45 @@ suite('extension', () => {
         assert.strictEqual(saveCalls.length, 0, 'should not send doc:save for external closed file change');
     });
 
+    test('file close - dirty without save preserves in-memory doc', async () => {
+        // regression #278: dirty close sent close:document, reverting peer edits
+
+        const folderUri = vscode.workspace.workspaceFolders?.[0]?.uri;
+        assert.ok(folderUri, 'workspace folder should exist');
+
+        const asset = await assetCreate({ name: 'dirty_close_preserves.js', content: '// ORIGINAL' });
+        assert.ok(asset, 'asset should be created');
+
+        const uri = vscode.Uri.joinPath(folderUri, asset.name);
+        const tdoc = await vscode.workspace.openTextDocument(uri);
+        await vscode.window.showTextDocument(tdoc);
+
+        const edit = new vscode.WorkspaceEdit();
+        edit.insert(uri, new vscode.Position(0, 0), '// LOCAL EDIT\n');
+        await vscode.workspace.applyEdit(edit);
+        await wait(100);
+
+        const before = documents.get(asset.uniqueId);
+        assert.ok(before?.includes('LOCAL EDIT'), 'in-memory doc should reflect edit');
+
+        sharedb.sendRaw.resetHistory();
+
+        // revert+close fires asset:doc:close → unsubscribe without prompting
+        await vscode.commands.executeCommand('workbench.action.revertAndCloseActiveEditor');
+        await wait(200);
+
+        const closeCalls = sharedb.sendRaw
+            .getCalls()
+            .filter((c) => `${c.args[0]}` === `close:document:${asset.uniqueId}`);
+        assert.strictEqual(closeCalls.length, 0, 'should not send close:document for dirty file');
+
+        assert.strictEqual(
+            documents.get(asset.uniqueId),
+            before,
+            'in-memory ShareDB doc should not be reverted on dirty close'
+        );
+    });
+
     test('file save - local to remote', async () => {
         // get folder uri
         const folderUri = vscode.workspace.workspaceFolders?.[0]?.uri;


### PR DESCRIPTION
Fixes #278

### What's Changed

- Skip `unsubscribe()` in `ProjectManager` when `file.dirty` is true. Closing a dirty file used to send `close:document` to the collab server, which dropped the in-memory ShareDB doc and re-hydrated from S3 on next subscribe — silently rolling back peer edits. The local subscription now stays alive until a save converges S3 with in-memory state.
- Extend the ShareDB mock so `doc:save` updates the persisted baseline and `close:document` reverts the in-memory `documents` map to that baseline (and emits `'load'` to any still-subscribed `MockDoc`). This mirrors server semantics so future regressions of this class fail loudly in tests.
- Add regression test `file close - dirty without save preserves in-memory doc` that opens a file, edits it, closes via `revertAndCloseActiveEditor`, and asserts both that `close:document` is not sent and that the in-memory doc is preserved.

### Trade-off

A dirty close keeps the ShareDB subscription alive locally for the rest of the session. Bounded by the number of files touched per session and cleaned up on project unlink. Acceptable vs. the collab data loss it prevents; a follow-up could retry the unsubscribe once a peer save flips `dirty=false` and the file is no longer locally open.