### PR TITLE
fix: don't stomp _diskHash on first-keystroke external false positive

### DIFF
--- a/src/disk.ts
+++ b/src/disk.ts
@@ -669,8 +669,17 @@ class Disk extends Linker<{ folderUri: vscode.Uri; projectManager: ProjectManage
         });
     }
 
-    private _dirtyReload(document: vscode.TextDocument, text: string) {
-        this._diskHash.set(document.uri.path, hash(text));
+    private async _dirtyReload(document: vscode.TextDocument, text: string) {
+        // only refresh _diskHash if buffer actually matches disk. external=true
+        // is also a false positive on the first keystroke (VS Code reports
+        // isDirty=false transiently), where buffer ≠ disk — and stomping
+        // _diskHash there breaks the discard guard on later close-discard (#278).
+        const [, bytes] = await tryCatch(
+            Promise.resolve(vscode.workspace.fs.readFile(document.uri) as Promise<Uint8Array>)
+        );
+        if (bytes && norm(buffer.toString(bytes)) === text) {
+            this._diskHash.set(document.uri.path, hash(text));
+        }
 
         // avoid touching eol chars
         const raw = document.getText();

--- a/src/test/suite/extension.test.ts
+++ b/src/test/suite/extension.test.ts
@@ -1222,6 +1222,55 @@ suite('extension', () => {
         assert.strictEqual(saveCalls.length, 0, 'should not send doc:save for external closed file change');
     });
 
+    test('file close - discard after first-keystroke does not roll back doc', async () => {
+        // regression #278: first onChange after open fires with isDirty=false
+        // (transient), so external=true was a false positive. _dirtyReload then
+        // stomped _diskHash to hash(buffer+keystroke), and a later close-discard
+        // failed the discard guard and submitted rollback ops.
+
+        const folderUri = vscode.workspace.workspaceFolders?.[0]?.uri;
+        assert.ok(folderUri, 'workspace folder should exist');
+
+        const asset = await assetCreate({
+            name: 'discard_after_first_keystroke.js',
+            content: '// ORIGINAL CONTENT'
+        });
+        assert.ok(asset, 'asset should be created');
+
+        const uri = vscode.Uri.joinPath(folderUri, asset.name);
+        const tdoc = await vscode.workspace.openTextDocument(uri);
+        await vscode.window.showTextDocument(tdoc);
+        await wait(50);
+
+        // first keystroke — fires onChange with isDirty=false (false positive external)
+        const first = new vscode.WorkspaceEdit();
+        first.insert(uri, new vscode.Position(0, 0), 'X');
+        await vscode.workspace.applyEdit(first);
+        await wait(50);
+
+        // more edits to grow the dirty state
+        const second = new vscode.WorkspaceEdit();
+        second.insert(uri, new vscode.Position(0, 1), 'YZ');
+        await vscode.workspace.applyEdit(second);
+        await wait(50);
+
+        const before = documents.get(asset.uniqueId);
+        assert.ok(before?.startsWith('XYZ'), 'doc state should reflect edits');
+
+        const doc = sharedb.subscriptions.get(`documents:${asset.uniqueId}`);
+        assert.ok(doc, 'subscription should exist');
+        doc.submitOp.resetHistory();
+
+        // close with discard — fires onChange (revert to disk) then onDidCloseTextDocument
+        await vscode.commands.executeCommand('workbench.action.revertAndCloseActiveEditor');
+        await wait(200);
+
+        assert.strictEqual(documents.get(asset.uniqueId), before, 'doc state should not roll back on dirty close');
+
+        const ops = doc.submitOp.getCalls();
+        assert.strictEqual(ops.length, 0, 'should not submit rollback ops on dirty close');
+    });
+
     test('file save - local to remote', async () => {
         // get folder uri
         const folderUri = vscode.workspace.workspaceFolders?.[0]?.uri;


### PR DESCRIPTION
Fixes #278

### What's Changed

- The first `onDidChangeTextDocument` after a fresh open fires with `document.isDirty=false` (transient), making `external = !reason && ops.length > 0 && !isDirty` a false positive on the first keystroke. `_dirtyReload` then stomped `_diskHash` to `hash(buffer-with-keystroke)` instead of `hash(disk-content)`. The discard guard at `disk.ts:949` later failed on close-discard, submitting rollback ops that reverted everyone's edits. The closing client's editor also visibly "reopened" the document because `_dirtyReload`'s `applyEdit` ran against the closing model.
- `_dirtyReload` now reads disk before refreshing `_diskHash`. If buffer matches disk → refresh as before (legitimate external file changes still work). If not → leave `_diskHash` untouched, so first-keystroke false positives can't corrupt it.
- Regression test in `extension.test.ts`: opens a file, applies a single-char insert (false-positive trigger), more edits, then `revertAndCloseActiveEditor`. Asserts no `submitOp` calls for the doc and that `documents.get(uniqueId)` is preserved.

### Trade-off

One extra `vscode.workspace.fs.readFile` per `_dirtyReload` call. Fires only on the first keystroke per fresh open and on legitimate external file changes, so the cost is rare. On read failure we conservatively skip the `_diskHash` update.

### Testing

- [x] Two-client manual repro per #278: open the same script in the VS Code extension (User A) and the online IDE (User B). User A types, User B types, User A closes the file with "Don't Save". Verify the file content is preserved for both users and the extension does not visibly reopen the document.
- [x] Verify legitimate external file changes still work: with the file open in the extension, modify it from a separate tool (e.g. `echo "..." > file`). The buffer should reload, the dirty indicator should appear, and a subsequent close-discard back to the new disk content should not submit ops.