### PR TITLE
feat: add report issue command (sentry destination)

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,9 @@
         "type": "git",
         "url": "https://github.com/playcanvas/vscode-extension.git"
     },
+    "bugs": {
+        "url": "https://github.com/playcanvas/vscode-extension/issues"
+    },
     "author": "PlayCanvas",
     "license": "MIT",
     "publisher": "PlayCanvas",
@@ -78,6 +81,10 @@
             {
                 "command": "playcanvas.showPathCollisions",
                 "title": "PlayCanvas: Show Path Collisions"
+            },
+            {
+                "command": "playcanvas.reportIssue",
+                "title": "PlayCanvas: Report Issue"
             },
             {
                 "command": "playcanvas.undo",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,4 +1,8 @@
+import * as os from 'os';
+
 import * as vscode from 'vscode';
+
+import packageJson from '../package.json';
 
 import { Auth } from './auth';
 import { API_URL, ENV, NAME, HOME_URL, MESSENGER_URL, REALTIME_URL, RELAY_URL, ROOT_FOLDER, DEBUG } from './config';
@@ -14,13 +18,22 @@ import { simpleNotification } from './notification';
 import { ProjectManager } from './project-manager';
 import { CollabProvider } from './providers/collab-provider';
 import { DecorationProvider } from './providers/decoration-provider';
-import { closeSentry, setSentryCollaborators, setSentryProject, setSentryUser } from './sentry';
+import {
+    addAttachment,
+    captureIssue,
+    closeSentry,
+    getLastSentryEventId,
+    setSentryCollaborators,
+    setSentryProject,
+    setSentryUser
+} from './sentry';
 import type { EventMap } from './typings/event-map';
 import type { Project } from './typings/models';
 import { fail } from './utils/error';
 import { EventEmitter } from './utils/event-emitter';
+import * as redact from './utils/redact';
 import { computed, effect } from './utils/signal';
-import { projectToName, tryCatch, uriStartsWith, wait } from './utils/utils';
+import { fmtLog, projectToName, tryCatch, uriStartsWith, wait } from './utils/utils';
 
 const HEARTBEAT_MS = 5 * 60 * 1000;
 const PING_SAMPLE_MS = 60 * 1000;
@@ -102,7 +115,11 @@ export const activate = async (context: vscode.ExtensionContext) => {
             await auth.reset(`Auth Error: ${error.message}`);
         }
 
-        void vscode.window.showErrorMessage(`PlayCanvas Error: ${error.message}`);
+        void vscode.window.showErrorMessage(`PlayCanvas Error: ${error.message}`, 'Report Issue').then((choice) => {
+            if (choice === 'Report Issue') {
+                void vscode.commands.executeCommand(`${NAME}.reportIssue`, error.message);
+            }
+        });
     };
 
     // create events
@@ -602,6 +619,52 @@ export const activate = async (context: vscode.ExtensionContext) => {
         })
     );
 
+    // report issue — accepts an optional defaultDescription so callers with
+    // an inherent context (error toast, desync toast) submit instantly.
+    context.subscriptions.push(
+        vscode.commands.registerCommand(`${NAME}.reportIssue`, async (defaultDescription?: string) => {
+            const description =
+                defaultDescription ??
+                (await vscode.window.showInputBox({
+                    title: 'PlayCanvas: Report Issue',
+                    prompt: 'Describe the issue',
+                    placeHolder: 'e.g. scripts are not syncing with online IDE',
+                    ignoreFocusOut: true,
+                    validateInput: (v) => (v.trim() ? undefined : 'Description is required')
+                }));
+            if (!description) {
+                return;
+            }
+
+            const project = state.projectId ? cache.get(state.projectId) : undefined;
+
+            const bundle = redact.text(Log.dump().map(fmtLog).join('\n'));
+            addAttachment({ filename: `${userId}.log`, data: bundle, contentType: 'text/plain' });
+
+            const eventId = captureIssue(description, {
+                report: {
+                    extension: packageJson.version,
+                    vscode: vscode.version,
+                    platform: `${process.platform} ${os.release()}`,
+                    env: ENV,
+                    project: state.projectId ?? 'none',
+                    branch: project?.branchId ?? 'none',
+                    desync: project?.projectManager.desync.get() ?? false,
+                    last_sentry_event: getLastSentryEventId() ?? 'none'
+                }
+            });
+
+            const copy = 'Copy ID';
+            void vscode.window
+                .showInformationMessage(`Report sent to PlayCanvas team. Reference: ${eventId}`, copy)
+                .then((choice) => {
+                    if (choice === copy) {
+                        void vscode.env.clipboard.writeText(eventId);
+                    }
+                });
+        })
+    );
+
     // load project
     const projects = await rest.userProjects(userId, 'profile');
     const valid: [vscode.WorkspaceFolder, Project][] = (vscode.workspace.workspaceFolders ?? []).reduce(
@@ -770,10 +833,21 @@ export const activate = async (context: vscode.ExtensionContext) => {
                 return;
             }
             void vscode.window
-                .showWarningMessage('PlayCanvas project is out of sync. Reload to recover.', 'Reload project')
+                .showWarningMessage(
+                    'PlayCanvas project is out of sync. Reload to recover.',
+                    'Reload project',
+                    'Report Issue'
+                )
                 .then((choice) => {
-                    if (choice === 'Reload project') {
-                        void vscode.commands.executeCommand(`${NAME}.reloadProject`);
+                    switch (choice) {
+                        case 'Reload project': {
+                            void vscode.commands.executeCommand(`${NAME}.reloadProject`);
+                            break;
+                        }
+                        case 'Report Issue': {
+                            void vscode.commands.executeCommand(`${NAME}.reportIssue`, 'Out of sync');
+                            break;
+                        }
                     }
                 });
         });

--- a/src/log.ts
+++ b/src/log.ts
@@ -1,9 +1,41 @@
 import * as vscode from 'vscode';
 
-import { captureException } from './sentry';
+import { addBreadcrumb, captureException } from './sentry';
+import * as redact from './utils/redact';
+import { tryCatchSync } from './utils/utils';
+
+// keep enough history to cover a typical bug repro window. each entry caps at
+// MAX_MSG_LEN so worst-case memory is ~5MB regardless of caller arg sizes.
+const MAX_LOG_BUFFER = 5000;
+const MAX_MSG_LEN = 1024;
+
+export type LogLevel = 'trace' | 'debug' | 'info' | 'warn' | 'error';
+
+export type LogEntry = {
+    ts: number;
+    level: LogLevel;
+    source: string;
+    message: string;
+};
+
+const LEVEL_TO_BREADCRUMB: Record<LogLevel, 'debug' | 'info' | 'warning' | 'error'> = {
+    trace: 'debug',
+    debug: 'debug',
+    info: 'info',
+    warn: 'warning',
+    error: 'error'
+};
 
 class Log {
     static channel = vscode.window.createOutputChannel('PlayCanvas', { log: true });
+
+    // ring buffer — O(1) writes regardless of buffer size. _cursor points to
+    // the next slot to write; _filled flips true after the first wrap-around.
+    private static _buffer: (LogEntry | undefined)[] = new Array(MAX_LOG_BUFFER);
+
+    private static _cursor = 0;
+
+    private static _filled = false;
 
     private _source: string;
 
@@ -11,24 +43,69 @@ class Log {
         this._source = source;
     }
 
+    private _record(level: LogLevel, args: unknown[]) {
+        const s = args
+            .map((a) => {
+                if (a instanceof Error) {
+                    return a.stack || `${a.name}: ${a.message}`;
+                }
+                if (typeof a === 'string') {
+                    return a;
+                }
+                if (a === null || a === undefined || typeof a !== 'object') {
+                    return String(a);
+                }
+                const [err, json] = tryCatchSync(() => JSON.stringify(a, redact.key));
+                return err ? String(a) : json;
+            })
+            .join(' ');
+        const message = s.length > MAX_MSG_LEN ? `${s.slice(0, MAX_MSG_LEN)}...` : s;
+
+        Log._buffer[Log._cursor] = { ts: Date.now(), level, source: this._source, message };
+        Log._cursor = (Log._cursor + 1) % MAX_LOG_BUFFER;
+        if (Log._cursor === 0) {
+            Log._filled = true;
+        }
+        addBreadcrumb({ level: LEVEL_TO_BREADCRUMB[level], category: this._source, message });
+    }
+
+    static dump(): LogEntry[] {
+        if (!Log._filled) {
+            return Log._buffer.slice(0, Log._cursor) as LogEntry[];
+        }
+        return [...Log._buffer.slice(Log._cursor), ...Log._buffer.slice(0, Log._cursor)] as LogEntry[];
+    }
+
+    // test-only — clear the ring buffer so tests have deterministic state
+    static reset() {
+        Log._buffer = new Array(MAX_LOG_BUFFER);
+        Log._cursor = 0;
+        Log._filled = false;
+    }
+
     trace(...args: unknown[]) {
         Log.channel.trace(`[${this._source}]`, ...args);
+        this._record('trace', args);
     }
 
     debug(...args: unknown[]) {
         Log.channel.debug(`[${this._source}]`, ...args);
+        this._record('debug', args);
     }
 
     info(...args: unknown[]) {
         Log.channel.info(`[${this._source}]`, ...args);
+        this._record('info', args);
     }
 
     warn(...args: unknown[]) {
         Log.channel.warn(`[${this._source}]`, ...args);
+        this._record('warn', args);
     }
 
     error(...args: unknown[]) {
         Log.channel.error(`[${this._source}]`, ...args);
+        this._record('error', args);
         const err = args[0] instanceof Error ? args[0] : new Error(args.map(String).join(' '));
         captureException(err, this._source);
     }

--- a/src/sentry.ts
+++ b/src/sentry.ts
@@ -6,7 +6,7 @@ import * as vscode from 'vscode';
 
 import packageJson from '../package.json';
 
-import { ENV, SENTRY_DSN } from './config';
+import { DEBUG, ENV, SENTRY_DSN } from './config';
 import type { FingerprintedError } from './utils/error';
 import * as redact from './utils/redact';
 
@@ -32,7 +32,7 @@ type GroupingEvent = {
 let _lastEventId: string | undefined;
 
 const client = new BrowserClient({
-    dsn: SENTRY_DSN,
+    dsn: DEBUG ? '' : SENTRY_DSN,
     transport: makeFetchTransport,
     stackParser: defaultStackParser,
     environment: `extension_${ENV === 'prod' ? 'live' : ENV}`,

--- a/src/sentry.ts
+++ b/src/sentry.ts
@@ -6,8 +6,9 @@ import * as vscode from 'vscode';
 
 import packageJson from '../package.json';
 
-import { DEBUG, ENV, SENTRY_DSN } from './config';
+import { ENV, SENTRY_DSN } from './config';
 import type { FingerprintedError } from './utils/error';
+import * as redact from './utils/redact';
 
 const OS_NAMES: Record<string, string> = {
     darwin: 'Mac OS X',
@@ -15,46 +16,23 @@ const OS_NAMES: Record<string, string> = {
     win32: 'Windows'
 };
 
+// sentry breadcrumb levels — log.ts maps trace→debug since sentry has no trace
+type BreadcrumbLevel = 'fatal' | 'error' | 'warning' | 'log' | 'info' | 'debug';
+
 const isFingerprintedError = (e: unknown): e is FingerprintedError =>
     e instanceof Error && 'fingerprint' in e && typeof (e as FingerprintedError).fingerprint === 'string';
-
-// NOTE: sensitive keys to scrub from event data (matches monorepo sentry-utils.js)
-const SANITIZE_KEYS = /password|token|secret|passwd|authorization|api_key|apikey|sentry_dsn|access_token|credentials/i;
 
 type GroupingEvent = {
     message?: string;
     extra?: Record<string, unknown>;
     fingerprint?: string[];
+    event_id?: string;
 };
 
-const sanitize = (obj: unknown, memo = new WeakSet()): unknown => {
-    if (Array.isArray(obj)) {
-        if (memo.has(obj)) {
-            return obj;
-        }
-        memo.add(obj);
-        const result = obj.map((v) => sanitize(v, memo));
-        memo.delete(obj);
-        return result;
-    }
-    if (obj && typeof obj === 'object' && Object.getPrototypeOf(obj) === Object.prototype) {
-        if (memo.has(obj)) {
-            return obj;
-        }
-        memo.add(obj);
-        const record = obj as Record<string, unknown>;
-        const result: Record<string, unknown> = {};
-        for (const key of Object.keys(record)) {
-            result[key] = SANITIZE_KEYS.test(key) ? '********' : sanitize(record[key], memo);
-        }
-        memo.delete(obj);
-        return result;
-    }
-    return obj;
-};
+let _lastEventId: string | undefined;
 
 const client = new BrowserClient({
-    dsn: DEBUG ? '' : SENTRY_DSN,
+    dsn: SENTRY_DSN,
     transport: makeFetchTransport,
     stackParser: defaultStackParser,
     environment: `extension_${ENV === 'prod' ? 'live' : ENV}`,
@@ -78,7 +56,11 @@ const client = new BrowserClient({
             };
         }
 
-        return sanitize(typedEvent) as typeof event;
+        if (typedEvent.event_id) {
+            _lastEventId = typedEvent.event_id;
+        }
+
+        return redact.object(typedEvent) as typeof event;
     }
 });
 
@@ -98,13 +80,38 @@ export const captureException = (error: Error, source?: string) => {
     s.captureException(error);
 };
 
-export const captureMessage = (message: string, level: 'warning' | 'error' = 'error', source?: string) => {
+export const captureMessage = (message: string, level: 'info' | 'warning' | 'error' = 'error', source?: string) => {
     const s = source ? scope.clone() : scope;
     if (source) {
         s.setTag('source', source);
     }
-    s.captureMessage(message, level);
+    return s.captureMessage(message, level);
 };
+
+// user-driven report — captureEvent directly so no synthetic stacktrace.
+// transaction → big main line (description), message → small top label.
+// fingerprint includes the description so distinct descriptions form distinct
+// issues (default grouping uses message, which is constant here).
+export const captureIssue = (description: string, contexts?: Record<string, Record<string, unknown>>) =>
+    scope.captureEvent({
+        message: 'User Report',
+        level: 'info',
+        tags: { kind: 'report' },
+        transaction: description,
+        fingerprint: ['playcanvas-user-report', description],
+        contexts
+    });
+
+export const addBreadcrumb = (b: { level: BreadcrumbLevel; category: string; message: string }) => {
+    scope.addBreadcrumb({ level: b.level, category: b.category, message: b.message });
+};
+
+// caller must redact — attachments bypass beforeSend
+export const addAttachment = (a: { filename: string; data: string | Uint8Array; contentType?: string }) => {
+    scope.addAttachment(a);
+};
+
+export const getLastSentryEventId = () => _lastEventId;
 
 export const setSentryUser = (id: number) => {
     scope.setUser({ id: String(id) });

--- a/src/test/suite/extension.test.ts
+++ b/src/test/suite/extension.test.ts
@@ -10,6 +10,8 @@ import * as relayModule from '../../connections/relay';
 import * as restModule from '../../connections/rest';
 import * as sharedbModule from '../../connections/sharedb';
 import * as uriHandlerModule from '../../handlers/uri-handler';
+import { Log } from '../../log';
+import * as sentryModule from '../../sentry';
 import type { Asset } from '../../typings/models';
 import * as buffer from '../../utils/buffer';
 import { hash, tryCatch, wait } from '../../utils/utils';
@@ -61,6 +63,11 @@ const errorMessageStub = sandbox.stub(vscode.window, 'showErrorMessage').resolve
 
 // spy vscode methods
 const openTextDocumentSpy = sandbox.spy(vscode.workspace, 'openTextDocument');
+
+// stub sentry submission for reportIssue test — keep call args inspectable
+const addAttachmentStub = sandbox.stub(sentryModule, 'addAttachment');
+const captureIssueStub = sandbox.stub(sentryModule, 'captureIssue').returns('test-event-id');
+const inputBoxStub = sandbox.stub(vscode.window, 'showInputBox');
 
 // FIXME: increase timeout to improve stability in CI environment
 const assertResolves = async <T>(promise: PromiseLike<T>, name: string, timeout = process.env.CI ? 2000 : 1000) => {
@@ -353,6 +360,56 @@ suite('extension', () => {
         const quickPickCall = quickPickStub.getCall(0);
         const quickPickOptions = quickPickCall.args[1] as { title: string };
         assert.ok(quickPickOptions.title.includes('Collision'), 'quick pick should have collision title');
+    });
+
+    test(`command ${NAME}.reportIssue`, async () => {
+        // reset and seed the log buffer with a known trace entry. the channel level
+        // may be anything — the buffer captures regardless, which is the point.
+        Log.reset();
+        const log = new Log('ReportIssueTest');
+        const marker = `marker-${Date.now()}`;
+        log.trace('seed', marker);
+
+        // reset spies/stubs
+        infoMessageStub.resetHistory();
+        infoMessageStub.resolves(undefined);
+        addAttachmentStub.resetHistory();
+        captureIssueStub.resetHistory();
+        inputBoxStub.resetHistory();
+
+        // simulate the user typing a description in the prompt
+        const description = 'scene fails to load on branch switch';
+        inputBoxStub.resolves(description);
+
+        await assertResolves(vscode.commands.executeCommand(`${NAME}.reportIssue`), `${NAME}.reportIssue`);
+
+        // attachment was added with a user-<id>.log filename and plain-text bundle
+        assert.ok(addAttachmentStub.calledOnce, 'addAttachment should fire');
+        const attachment = addAttachmentStub.getCall(0).args[0] as {
+            filename: string;
+            data: string;
+            contentType?: string;
+        };
+        assert.match(attachment.filename, /^\d+\.log$/, 'attachment filename should be <id>.log');
+        assert.strictEqual(attachment.contentType, 'text/plain');
+        // log dump only — env metadata lives in event.contexts.report; no header in the file
+        assert.ok(attachment.data.startsWith('['), 'attachment should start with a log line, no header');
+        assert.ok(!attachment.data.includes('Extension:'), 'attachment should not include env metadata');
+        assert.ok(!attachment.data.includes('user ('), 'attachment should not include a user/project header');
+        assert.ok(attachment.data.includes('[trace]'), 'attachment should include trace entries');
+        assert.ok(attachment.data.includes(marker), 'attachment should include the seeded marker');
+
+        // captureIssue fired with the description as message and the report context
+        assert.ok(captureIssueStub.calledOnce, 'captureIssue should fire');
+        const [msg, contexts] = captureIssueStub.getCall(0).args as [string, Record<string, Record<string, unknown>>];
+        assert.strictEqual(msg, description, 'first arg should be the user description');
+        assert.ok(contexts.report, 'report context should be set');
+        assert.ok('extension' in contexts.report, 'report context should include extension version');
+
+        // user saw a notification with the (stubbed) event id
+        assert.ok(infoMessageStub.called, 'follow-up info message should be shown');
+        const lastMsg = infoMessageStub.getCall(infoMessageStub.callCount - 1).args[0] as string;
+        assert.ok(/test-event-id/.test(lastMsg), 'notification should include the event id');
     });
 
     test('uri open - file', async () => {

--- a/src/utils/redact.ts
+++ b/src/utils/redact.ts
@@ -1,0 +1,44 @@
+// NOTE: sensitive keys to scrub from event data (matches monorepo sentry-utils.js)
+const SECRETS_RE = /password|token|secret|passwd|authorization|api_key|apikey|sentry_dsn|access_token|credentials/i;
+
+const BEARER_RE = /\b(Bearer)\s+[A-Za-z0-9._+/=-]+/gi;
+const AUTH_HEADER_RE = /\b(Authorization|Cookie|Set-Cookie)\s*[:=]\s*[^\s,;]+/gi;
+const QUERY_TOKEN_RE = /\b(access_token|token|api_key|apikey|password|secret|sentry_dsn)\s*=\s*[^\s&"']+/gi;
+const JWT_RE = /\beyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+/g;
+
+export const object = (obj: unknown, memo = new WeakSet()): unknown => {
+    if (Array.isArray(obj)) {
+        if (memo.has(obj)) {
+            return obj;
+        }
+        memo.add(obj);
+        const result = obj.map((v) => object(v, memo));
+        memo.delete(obj);
+        return result;
+    }
+    if (obj && typeof obj === 'object' && Object.getPrototypeOf(obj) === Object.prototype) {
+        if (memo.has(obj)) {
+            return obj;
+        }
+        memo.add(obj);
+        const record = obj as Record<string, unknown>;
+        const result: Record<string, unknown> = {};
+        for (const k of Object.keys(record)) {
+            result[k] = SECRETS_RE.test(k) ? '********' : object(record[k], memo);
+        }
+        memo.delete(obj);
+        return result;
+    }
+    return obj;
+};
+
+export const text = (s: string) =>
+    s
+        .replace(JWT_RE, '<jwt>')
+        .replace(BEARER_RE, '$1 <redacted>')
+        .replace(AUTH_HEADER_RE, '$1: <redacted>')
+        .replace(QUERY_TOKEN_RE, '$1=<redacted>');
+
+// JSON.stringify replacer — covers any shape (class instances, mixed prototypes)
+// that JSON.stringify walks into; redact.object only recurses Object.prototype.
+export const key = (k: string, value: unknown) => (SECRETS_RE.test(k) ? '********' : value);

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -2,6 +2,7 @@ import crypto from 'crypto';
 
 import * as vscode from 'vscode';
 
+import type { LogEntry } from '../log';
 import type { Project } from '../typings/models';
 
 import type { signal } from './signal';
@@ -41,6 +42,14 @@ export const withTimeout = <T>(promise: Promise<T>, ms: number, msg: string) => 
 export const tryCatch = async <T>(task: Promise<T> | (() => Promise<T>)): Promise<[Error, null] | [null, T]> => {
     try {
         return [null, await (typeof task === 'function' ? task() : task)];
+    } catch (err: unknown) {
+        return [err as Error, null];
+    }
+};
+
+export const tryCatchSync = <T>(task: () => T): [Error, null] | [null, T] => {
+    try {
+        return [null, task()];
     } catch (err: unknown) {
         return [err as Error, null];
     }
@@ -91,6 +100,15 @@ export const sanitizeName = (name: string) => {
 export const projectToName = (project: Project, encode = true) => {
     const name = encode ? sanitizeName(project.name) : project.name;
     return `${name} (${project.id})`;
+};
+
+export const fmtLog = (e: LogEntry) => {
+    const d = new Date(e.ts);
+    const hh = String(d.getHours()).padStart(2, '0');
+    const mm = String(d.getMinutes()).padStart(2, '0');
+    const ss = String(d.getSeconds()).padStart(2, '0');
+    const ms = String(d.getMilliseconds()).padStart(3, '0');
+    return `[${hh}:${mm}:${ss}.${ms}] [${e.level}] [${e.source}] ${e.message}`;
 };
 
 export const summarize = (data: unknown): string => {


### PR DESCRIPTION
## What's Changed

Adds a `PlayCanvas: Report Issue` command that ships a user-driven bug report straight to the team's Sentry project — internal-only, no public exposure of project IDs, asset names, or paths.

### How it works

- User invokes the command (Command Palette, error toast, or desync toast).
- From the error / desync toast, the description is auto-prefilled — one click sends the report immediately with the error context fresh.
- From the Command Palette, an input box prompts for a short description.
- Behind the scenes: redacted log dump is attached as `<userId>.log`, an info-level Sentry event is captured with `kind:report` tag, env metadata in `contexts.report`, and a per-description fingerprint so distinct descriptions form distinct issues.

### Key infrastructure

- **`Log` ring buffer** (5000 entries × 1 KB cap, O(1) writes): every log call is recorded regardless of the user's selected output-channel level. Same path also pushes a Sentry breadcrumb so error events ship with full trace context automatically.
- **`src/utils/redact.ts`** (namespaced flat exports matching `buffer.ts` pattern): `redact.object` for recursive plain-object key-scrubbing (used by Sentry `beforeSend`), `redact.text` for free-form string scrubbing (Bearer / JWT / Authorization / query-token patterns — applied to the log attachment), `redact.key` as a `JSON.stringify` replacer covering class instances.
- **Sentry façades** in `src/sentry.ts`: `addBreadcrumb`, `addAttachment`, `captureIssue`, `getLastSentryEventId`. `captureIssue` constructs the event directly via `scope.captureEvent` so there's no synthetic stacktrace polluting the issue title.
- **`tryCatchSync`** sync companion to the existing async `tryCatch`.
- **`fmtLog`** formatter in `utils.ts`.

### Sentry rendering

Each user report becomes its own Sentry Issue (per-description fingerprint), titled with the user's description as the prominent line and `User Report` as the small label above. The `<userId>.log` attachment carries the full redacted ring-buffer dump for deep triage; the `report` context block renders inline showing extension version, VS Code version, platform, env, project, branch, desync flag, and last Sentry event id.

### Privacy

The Sentry DSN points at the team's internal Sentry instance — events are not world-readable. Log content is redacted client-side (Bearer / JWT / Authorization / query-token patterns) before attachment. Sentry's server-side data scrubber adds a second layer for anything we miss.

## Test plan

- [ ] Run **PlayCanvas: Report Issue** from the Command Palette → input box appears, type a description, Enter → toast shows event ID
- [ ] Trigger an error → "Report Issue" button on the error toast → click once → instant submit, no prompt
- [ ] Force a desync state → "Report Issue" button on the desync toast → click once → instant submit
- [ ] Open the resulting Sentry issue → verify the description is the title, `<userId>.log` is attached, breadcrumbs and `contexts.report` are populated
- [ ] Submit two reports with different descriptions → two distinct Sentry issues
- [ ] Submit two reports with the same description → one issue with multiple events (or Dedupe drops the second within the same session)
- [ ] `npm run lint`, `npm run pretest`, `npm run compile` all clean