### PR TITLE
fix: quiet startup auth flow

### DIFF
--- a/src/auth.ts
+++ b/src/auth.ts
@@ -7,11 +7,67 @@ import { AUTH_TIMEOUT_MS } from './connections/constants';
 import { Rest } from './connections/rest';
 import { tryCatch } from './utils/utils';
 
+const LOGIN_OPTION = 'Login';
+const DISMISS_OPTION = 'Dismiss';
+
 class Auth {
     private _context: vscode.ExtensionContext;
 
     constructor(context: vscode.ExtensionContext) {
         this._context = context;
+    }
+
+    async getStoredAccessToken() {
+        return this._context.secrets.get(`${NAME}.accessToken`);
+    }
+
+    async clearAccessToken() {
+        await this._context.secrets.delete(`${NAME}.accessToken`);
+    }
+
+    async getClient(manual = false) {
+        let accessToken = await this.getStoredAccessToken();
+        while (true) {
+            if (!accessToken) {
+                if (!manual) {
+                    return;
+                }
+                accessToken = await this.getAccessToken(true, false);
+                if (!accessToken) {
+                    return;
+                }
+            }
+
+            const rest = new Rest({
+                url: API_URL,
+                origin: HOME_URL,
+                accessToken
+            });
+            const [error, userId] = await tryCatch(rest.id());
+            if (!error) {
+                return { accessToken, rest, userId };
+            }
+            rest.dispose();
+            if (!/HTTP 4\d{2}/.test(error.message)) {
+                throw error;
+            }
+            await this.clearAccessToken();
+            if (!manual) {
+                return;
+            }
+            accessToken = undefined;
+        }
+    }
+
+    async promptProjectLogin() {
+        const choice = await vscode.window.showInformationMessage(
+            'Sign in to PlayCanvas to sync this project.',
+            LOGIN_OPTION,
+            DISMISS_OPTION
+        );
+        if (choice === LOGIN_OPTION) {
+            await this.getAccessToken(true);
+        }
     }
 
     private async _validateAccessToken(accessToken?: string) {
@@ -24,6 +80,7 @@ class Auth {
             accessToken
         });
         const [error] = await tryCatch(rest.id());
+        rest.dispose();
         if (error && /HTTP 4\d{2}/.test(error.message)) {
             await vscode.window.showErrorMessage('Invalid PlayCanvas Access Token', { modal: true });
             return undefined;
@@ -144,7 +201,7 @@ class Auth {
         });
     }
 
-    async getAccessToken(manual = false) {
+    async getAccessToken(manual = false, reload = manual) {
         let accessToken: string | undefined = undefined;
         if (!manual) {
             // retrieve stored token
@@ -174,7 +231,7 @@ class Auth {
             await this._context.secrets.store(`${NAME}.accessToken`, accessToken);
             void vscode.window.showInformationMessage('PlayCanvas Access Token validated');
 
-            if (manual) {
+            if (reload) {
                 // reload window to ensure all components use the new token
                 await vscode.window.showInformationMessage('Token updated, the window will be reloaded.', {
                     modal: true

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -7,9 +7,6 @@ import { AUTH_TIMEOUT_MS } from './connections/constants';
 import { Rest } from './connections/rest';
 import { tryCatch } from './utils/utils';
 
-const LOGIN_OPTION = 'Login';
-const DISMISS_OPTION = 'Dismiss';
-
 class Auth {
     private _context: vscode.ExtensionContext;
 
@@ -60,12 +57,14 @@ class Auth {
     }
 
     async promptProjectLogin() {
+        const login = 'Login';
+        const dismiss = 'Dismiss';
         const choice = await vscode.window.showInformationMessage(
             'Sign in to PlayCanvas to sync this project.',
-            LOGIN_OPTION,
-            DISMISS_OPTION
+            login,
+            dismiss
         );
-        if (choice === LOGIN_OPTION) {
+        if (choice === login) {
             await this.getAccessToken(true);
         }
     }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -4,7 +4,6 @@ import * as vscode from 'vscode';
 
 import { Auth } from './auth';
 import {
-    API_URL,
     DEBUG,
     ENV,
     HOME_URL,
@@ -18,7 +17,6 @@ import {
 } from './config';
 import { Messenger } from './connections/messenger';
 import { Relay } from './connections/relay';
-import { Rest } from './connections/rest';
 import { ShareDb } from './connections/sharedb';
 import { Disk } from './disk';
 import { UriHandler } from './handlers/uri-handler';
@@ -104,7 +102,126 @@ export const activate = async (context: vscode.ExtensionContext) => {
     const auth = new Auth(context);
     context.subscriptions.push(vscode.commands.registerCommand(`${NAME}.login`, async () => auth.getAccessToken(true)));
     context.subscriptions.push(vscode.commands.registerCommand(`${NAME}.logout`, () => auth.logout()));
-    const accessToken = await auth.getAccessToken();
+    const folders = (vscode.workspace.workspaceFolders ?? []).filter((f) => uriStartsWith(f.uri, rootUri));
+    const projectWindow = folders.length > 0;
+    const showError = (error: Error) => {
+        log.error(error);
+        void vscode.window.showErrorMessage(`PlayCanvas Error: ${error.message}`);
+    };
+    const openProject = async () => {
+        const [clientErr, client] = await tryCatch(auth.getClient(true));
+        if (clientErr) {
+            showError(clientErr);
+            return;
+        }
+        if (!client) {
+            return;
+        }
+        const [projectsErr, projects] = await tryCatch(client.rest.userProjects(client.userId, 'profile'));
+        client.rest.dispose();
+        if (projectsErr) {
+            showError(projectsErr);
+            return;
+        }
+
+        const list = projects.map((p) => projectToName(p, false)).reverse();
+        const chosen = await vscode.window.showQuickPick(list, {
+            placeHolder: 'Select a project'
+        });
+        const project = projects.find((p) => chosen === projectToName(p, false));
+        if (!project) {
+            return;
+        }
+
+        const folder = vscode.Uri.joinPath(rootUri, projectToName(project));
+        await vscode.workspace.fs.createDirectory(folder);
+        await vscode.commands.executeCommand('vscode.openFolder', folder, false);
+    };
+    const registerIdleCommands = () => {
+        context.subscriptions.push(vscode.commands.registerCommand(`${NAME}.openProject`, openProject));
+        context.subscriptions.push(vscode.commands.registerCommand(`${NAME}.reloadProject`, () => undefined));
+        context.subscriptions.push(vscode.commands.registerCommand(`${NAME}.switchBranch`, () => undefined));
+        context.subscriptions.push(vscode.commands.registerCommand(`${NAME}.showPathCollisions`, () => undefined));
+        context.subscriptions.push(
+            vscode.window.registerUriHandler({
+                handleUri: async (uri) => {
+                    const [clientErr, client] = await tryCatch(auth.getClient(true));
+                    if (clientErr) {
+                        showError(clientErr);
+                        return;
+                    }
+                    if (!client) {
+                        return;
+                    }
+                    const handler = new UriHandler({
+                        context,
+                        rootUri,
+                        userId: client.userId,
+                        rest: client.rest
+                    });
+                    const [handleErr] = await tryCatch(handler.handleUri(uri));
+                    client.rest.dispose();
+                    if (handleErr) {
+                        showError(handleErr);
+                    }
+                }
+            })
+        );
+        context.subscriptions.push(
+            vscode.commands.registerCommand(`${NAME}.reportIssue`, async (defaultDescription?: string) => {
+                const description =
+                    defaultDescription ??
+                    (await vscode.window.showInputBox({
+                        title: 'PlayCanvas: Report Issue',
+                        prompt: 'Describe the issue',
+                        placeHolder: 'e.g. scripts are not syncing with online IDE',
+                        ignoreFocusOut: true,
+                        validateInput: (v) => (v.trim() ? undefined : 'Description is required')
+                    }));
+                if (!description) {
+                    return;
+                }
+                const bundle = redact.text(Log.dump().map(fmtLog).join('\n'));
+                addAttachment({ filename: 'anonymous.log', data: bundle, contentType: 'text/plain' });
+                const eventId = captureIssue(description, {
+                    report: {
+                        extension: VERSION,
+                        vscode: vscode.version,
+                        platform: `${process.platform} ${os.release()}`,
+                        env: ENV,
+                        project: 'none',
+                        branch: 'none',
+                        desync: false,
+                        last_sentry_event: getLastSentryEventId() ?? 'none'
+                    }
+                });
+                const copy = 'Copy ID';
+                void vscode.window
+                    .showInformationMessage(`Report sent to PlayCanvas team. Reference: ${eventId}`, copy)
+                    .then((choice) => {
+                        if (choice === copy) {
+                            void vscode.env.clipboard.writeText(eventId);
+                        }
+                    });
+            })
+        );
+    };
+
+    if (!projectWindow) {
+        registerIdleCommands();
+        return;
+    }
+    const [clientErr, client] = await tryCatch(auth.getClient(false));
+    if (clientErr) {
+        throw clientErr;
+    }
+    if (!client) {
+        registerIdleCommands();
+        await auth.promptProjectLogin();
+        return;
+    }
+    const { accessToken, rest, userId } = client;
+    context.subscriptions.push(new vscode.Disposable(() => rest.dispose()));
 
     // metrics
     const metrics = new Metrics(accessToken);
@@ -144,14 +261,6 @@ export const activate = async (context: vscode.ExtensionContext) => {
         })
     );
 
-    // rest client
-    const rest = new Rest({
-        url: API_URL,
-        origin: HOME_URL,
-        accessToken
-    });
-    context.subscriptions.push(new vscode.Disposable(() => rest.dispose()));
-
     // realtime connection
     const sharedb = new ShareDb({
         url: REALTIME_URL,
@@ -182,8 +291,6 @@ export const activate = async (context: vscode.ExtensionContext) => {
         }
     });
 
-    // find user id
-    const userId = await rest.id();
     setSentryUser(userId);
 
     // state
@@ -297,7 +404,6 @@ export const activate = async (context: vscode.ExtensionContext) => {
     connectionStatusItem.color = COLORS.error;
     connectionStatusItem.text = `$(primitive-dot) Disconnected`;
     connectionStatusItem.tooltip = 'PlayCanvas Connection';
-    connectionStatusItem.show();
     const connected = computed(() => {
         return sharedb.connected.get() && messenger.connected.get() && relay.connected.get();
     });
@@ -371,7 +477,6 @@ export const activate = async (context: vscode.ExtensionContext) => {
     branchStatusBarItem.command = `${NAME}.switchBranch`;
     branchStatusBarItem.text = `$(git-branch) no branch`;
     branchStatusBarItem.tooltip = 'Switch Branch';
-    branchStatusBarItem.show();
 
     // watch for version control changes
     const branchSwitch = messenger.on('branch.switch', async (e) => {
@@ -402,6 +507,7 @@ export const activate = async (context: vscode.ExtensionContext) => {
 
             // update branch status bar item
             branchStatusBarItem.text = `$(git-branch) ${name}`;
+            branchStatusBarItem.show();
         });
         if (err) {
             void handleError(err);
@@ -681,13 +787,8 @@ export const activate = async (context: vscode.ExtensionContext) => {
 
     // load project
     const projects = await rest.userProjects(userId, 'profile');
-    const valid: [vscode.WorkspaceFolder, Project][] = (vscode.workspace.workspaceFolders ?? []).reduce(
+    const valid: [vscode.WorkspaceFolder, Project][] = folders.reduce(
         (list, f) => {
-            // ensure folder is in home directory
-            if (!uriStartsWith(f.uri, rootUri)) {
-                return list;
-            }
-
             // ensure folder matches a user project
             const project = projects.find((p) => projectToName(p) === f.name);
             if (!project) {
@@ -701,6 +802,8 @@ export const activate = async (context: vscode.ExtensionContext) => {
     );
 
     for (const [folder, project] of valid) {
+        connectionStatusItem.show();
+
         // ensure folder directory exists
         await vscode.workspace.fs.createDirectory(folder.uri);
 
@@ -761,6 +864,7 @@ export const activate = async (context: vscode.ExtensionContext) => {
         if (branch) {
             // set branch name
             branchStatusBarItem.text = `$(git-branch) ${branch.name}`;
+            branchStatusBarItem.show();
         }
 
         // watch project

--- a/src/test/mocks/auth.ts
+++ b/src/test/mocks/auth.ts
@@ -6,7 +6,11 @@ import { Auth } from '../../auth';
 import { accessToken } from './models';
 
 class MockAuth extends Auth {
-    getAccessToken: sinon.SinonSpy<[], Promise<string>>;
+    getAccessToken: sinon.SinonSpy<[manual?: boolean, reload?: boolean], Promise<string>>;
+
+    getStoredAccessToken: sinon.SinonSpy<[], Promise<string>>;
+
+    clearAccessToken: sinon.SinonSpy<[], Promise<void>>;
 
     reset: sinon.SinonSpy<[reason?: string], Promise<void>>;
 
@@ -14,6 +18,8 @@ class MockAuth extends Auth {
         super({} as vscode.ExtensionContext);
 
         this.getAccessToken = sandbox.spy(async () => accessToken);
+        this.getStoredAccessToken = sandbox.spy(async () => accessToken);
+        this.clearAccessToken = sandbox.spy(async () => undefined);
         this.reset = sandbox.spy(async () => undefined);
     }
 }


### PR DESCRIPTION
### What's Changed

- Avoid showing disconnected status or login prompts for non-PlayCanvas windows.
- Prompt signed-out users only when opening a PlayCanvas project window.
- Keep project loading on the existing fast path when auth is available.

Manual tests: not run