### PR TITLE
refactor: centralize extension command handling

### DIFF
--- a/src/commands.ts
+++ b/src/commands.ts
@@ -97,30 +97,30 @@ export const registerIdleCommands = ({
     context,
     auth,
     rootUri,
-    error
+    failure
 }: {
     context: vscode.ExtensionContext;
     auth: Auth;
     rootUri: vscode.Uri;
-    error: ReturnType<typeof signal<Error | undefined>>;
+    failure: ReturnType<typeof signal<{ err: Error; source?: string } | undefined>>;
 }) => {
     context.subscriptions.push(
         vscode.commands.registerCommand(`${NAME}.openProject`, async () => {
-            const [err1, client] = await tryCatch(auth.getClient(true));
-            if (err1) {
-                error.set(() => err1);
-                return;
+            const [err] = await tryCatch(async () => {
+                const client = await auth.getClient(true);
+                if (!client) {
+                    return;
+                }
+                const [err1, projects] = await tryCatch(client.rest.userProjects(client.userId, 'profile'));
+                client.rest.dispose();
+                if (err1) {
+                    throw err1;
+                }
+                await openFolder(rootUri, projects);
+            });
+            if (err) {
+                failure.set(() => ({ err, source: 'commands' }));
             }
-            if (!client) {
-                return;
-            }
-            const [err2, projects] = await tryCatch(client.rest.userProjects(client.userId, 'profile'));
-            client.rest.dispose();
-            if (err2) {
-                error.set(() => err2);
-                return;
-            }
-            await openFolder(rootUri, projects);
         })
     );
     context.subscriptions.push(vscode.commands.registerCommand(`${NAME}.reloadProject`, () => undefined));
@@ -134,15 +134,18 @@ export const registerIdleCommands = ({
     const disposeUriError = effect(() => {
         const err = uriHandler.error.get();
         if (err) {
-            error.set(() => err);
+            failure.set(() => ({ err, source: 'uri-handler' }));
         }
     });
     context.subscriptions.push(new vscode.Disposable(disposeUriError));
     context.subscriptions.push(vscode.window.registerUriHandler(uriHandler));
     context.subscriptions.push(
-        vscode.commands.registerCommand(`${NAME}.reportIssue`, (value?: string) =>
-            report({ value, userId: 'anonymous' })
-        )
+        vscode.commands.registerCommand(`${NAME}.reportIssue`, async (value?: string) => {
+            const [err] = await tryCatch(report({ value, userId: 'anonymous' }));
+            if (err) {
+                failure.set(() => ({ err, source: 'commands' }));
+            }
+        })
     );
 };
 
@@ -154,7 +157,8 @@ export const registerProjectCommands = ({
     metrics,
     state,
     cache,
-    reload
+    reload,
+    failure
 }: {
     context: vscode.ExtensionContext;
     rootUri: vscode.Uri;
@@ -164,112 +168,133 @@ export const registerProjectCommands = ({
     state: State;
     cache: Cache;
     reload: ReturnType<typeof signal<{ projectManager: ProjectManager } | undefined>>;
+    failure: ReturnType<typeof signal<{ err: Error; source?: string } | undefined>>;
 }) => {
     context.subscriptions.push(
         vscode.commands.registerCommand(`${NAME}.openProject`, async () => {
-            metrics.increment('command', { name: 'openProject' });
-            const projects = await rest.userProjects(userId, 'profile');
-            await openFolder(rootUri, projects);
+            const [err] = await tryCatch(async () => {
+                metrics.increment('command', { name: 'openProject' });
+                const projects = await rest.userProjects(userId, 'profile');
+                await openFolder(rootUri, projects);
+            });
+            if (err) {
+                failure.set(() => ({ err, source: 'commands' }));
+            }
         })
     );
     context.subscriptions.push(
         vscode.commands.registerCommand(`${NAME}.reloadProject`, async () => {
-            metrics.increment('command', { name: 'reloadProject' });
-            if (!state.projectId) {
-                return;
-            }
+            const [err] = await tryCatch(async () => {
+                metrics.increment('command', { name: 'reloadProject' });
+                if (!state.projectId) {
+                    return;
+                }
 
-            const { projectManager } = cache.get(state.projectId) ?? {};
-            if (!projectManager) {
-                return;
-            }
+                const { projectManager } = cache.get(state.projectId) ?? {};
+                if (!projectManager) {
+                    return;
+                }
 
-            reload.set(() => ({ projectManager }));
+                reload.set(() => ({ projectManager }));
+            });
+            if (err) {
+                failure.set(() => ({ err, source: 'commands' }));
+            }
         })
     );
     context.subscriptions.push(
         vscode.commands.registerCommand(`${NAME}.switchBranch`, async () => {
-            metrics.increment('command', { name: 'switchBranch' });
-            if (!state.projectId) {
-                return;
-            }
-
-            const { branchId } = cache.get(state.projectId) ?? {};
-            if (!branchId) {
-                return;
-            }
-
-            const branches = await rest.projectBranches(state.projectId);
-            const names = branches.reduce((acc: string[], b) => {
-                if (b.id !== branchId) {
-                    acc.push(b.name);
+            const [err] = await tryCatch(async () => {
+                metrics.increment('command', { name: 'switchBranch' });
+                if (!state.projectId) {
+                    return;
                 }
-                return acc;
-            }, []);
-            const chosen = await vscode.window.showQuickPick(names, {
-                placeHolder: 'Select a branch'
+
+                const { branchId } = cache.get(state.projectId) ?? {};
+                if (!branchId) {
+                    return;
+                }
+
+                const branches = await rest.projectBranches(state.projectId);
+                const names = branches.reduce((acc: string[], b) => {
+                    if (b.id !== branchId) {
+                        acc.push(b.name);
+                    }
+                    return acc;
+                }, []);
+                const chosen = await vscode.window.showQuickPick(names, {
+                    placeHolder: 'Select a branch'
+                });
+                if (!chosen) {
+                    return;
+                }
+
+                const branch = branches.find((b) => b.name === chosen);
+                if (!branch) {
+                    return;
+                }
+
+                await rest.branchCheckout(branch.id);
             });
-            if (!chosen) {
-                return;
+            if (err) {
+                failure.set(() => ({ err, source: 'commands' }));
             }
-
-            const branch = branches.find((b) => b.name === chosen);
-            if (!branch) {
-                return;
-            }
-
-            await rest.branchCheckout(branch.id);
         })
     );
     context.subscriptions.push(
         vscode.commands.registerCommand(`${NAME}.showPathCollisions`, async () => {
-            if (!state.projectId) {
-                return;
-            }
-            const { projectManager } = cache.get(state.projectId) ?? {};
-            if (!projectManager) {
-                return;
-            }
+            const [err] = await tryCatch(async () => {
+                if (!state.projectId) {
+                    return;
+                }
+                const { projectManager } = cache.get(state.projectId) ?? {};
+                if (!projectManager) {
+                    return;
+                }
 
-            const collisions = projectManager.collisions.snapshot();
-            if (collisions.size === 0) {
-                return;
-            }
+                const collisions = projectManager.collisions.snapshot();
+                if (collisions.size === 0) {
+                    return;
+                }
 
-            const options = ['Show Path Collisions', 'Reload project'];
-            void vscode.window
-                .showWarningMessage(
+                const options = ['Show Path Collisions', 'Reload project'];
+                const option = await vscode.window.showWarningMessage(
                     [
                         `${collisions.size} asset path collision${collisions.size !== 1 ? 's' : ''} found.`,
                         'Rename or move the colliding assets in the Editor to resolve.'
                     ].join('\n'),
                     ...options
-                )
-                .then((option) => {
-                    switch (option) {
-                        case options[0]: {
-                            const list = Array.from(collisions.entries()).map(([path, ids]) => ({
-                                label: path,
-                                description: `(${ids.join(', ')})`
-                            }));
-                            void vscode.window.showQuickPick(list, {
-                                title: 'Asset Path Collisions',
-                                placeHolder: 'Filter paths',
-                                canPickMany: false
-                            });
-                            break;
-                        }
-                        case options[1]: {
-                            void vscode.commands.executeCommand(`${NAME}.reloadProject`);
-                            break;
-                        }
+                );
+                switch (option) {
+                    case options[0]: {
+                        const list = Array.from(collisions.entries()).map(([path, ids]) => ({
+                            label: path,
+                            description: `(${ids.join(', ')})`
+                        }));
+                        await vscode.window.showQuickPick(list, {
+                            title: 'Asset Path Collisions',
+                            placeHolder: 'Filter paths',
+                            canPickMany: false
+                        });
+                        break;
                     }
-                });
+                    case options[1]: {
+                        await vscode.commands.executeCommand(`${NAME}.reloadProject`);
+                        break;
+                    }
+                }
+            });
+            if (err) {
+                failure.set(() => ({ err, source: 'commands' }));
+            }
         })
     );
     context.subscriptions.push(
-        vscode.commands.registerCommand(`${NAME}.reportIssue`, (value?: string) =>
-            report({ value, userId, state, cache })
-        )
+        vscode.commands.registerCommand(`${NAME}.reportIssue`, async (value?: string) => {
+            const [err] = await tryCatch(report({ value, userId, state, cache }));
+            if (err) {
+                failure.set(() => ({ err, source: 'commands' }));
+            }
+        })
     );
 };

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -1,0 +1,275 @@
+import * as os from 'os';
+
+import * as vscode from 'vscode';
+
+import type { Auth } from './auth';
+import { NAME, VERSION, ENV } from './config';
+import type { Rest } from './connections/rest';
+import { UriHandler } from './handlers/uri-handler';
+import { Log } from './log';
+import type { Metrics } from './metrics';
+import type { ProjectManager } from './project-manager';
+import { addAttachment, captureIssue, getLastSentryEventId } from './sentry';
+import * as redact from './utils/redact';
+import type { signal } from './utils/signal';
+import { effect } from './utils/signal';
+import { fmtLog, projectToName, tryCatch } from './utils/utils';
+
+type State = {
+    projectId: number | null;
+};
+
+type Cache = Map<
+    number,
+    {
+        branchId: string;
+        projectManager: ProjectManager;
+    }
+>;
+
+const openFolder = async (rootUri: vscode.Uri, projects: Awaited<ReturnType<Rest['userProjects']>>) => {
+    const list = projects.map((p) => projectToName(p, false)).reverse();
+    const chosen = await vscode.window.showQuickPick(list, {
+        placeHolder: 'Select a project'
+    });
+    const project = projects.find((p) => chosen === projectToName(p, false));
+    if (!project) {
+        return;
+    }
+
+    const folder = vscode.Uri.joinPath(rootUri, projectToName(project));
+    await vscode.workspace.fs.createDirectory(folder);
+    await vscode.commands.executeCommand('vscode.openFolder', folder, false);
+};
+
+const report = async ({
+    value,
+    userId,
+    state,
+    cache
+}: {
+    value?: string;
+    userId: number | 'anonymous';
+    state?: State;
+    cache?: Cache;
+}) => {
+    const text =
+        value ??
+        (await vscode.window.showInputBox({
+            title: 'PlayCanvas: Report Issue',
+            prompt: 'Describe the issue',
+            placeHolder: 'e.g. scripts are not syncing with online IDE',
+            ignoreFocusOut: true,
+            validateInput: (v) => (v.trim() ? undefined : 'Description is required')
+        }));
+    if (!text) {
+        return;
+    }
+
+    const project = state?.projectId ? cache?.get(state.projectId) : undefined;
+    const bundle = redact.text(Log.dump().map(fmtLog).join('\n'));
+    addAttachment({ filename: `${userId}.log`, data: bundle, contentType: 'text/plain' });
+
+    const eventId = captureIssue(text, {
+        report: {
+            extension: VERSION,
+            vscode: vscode.version,
+            platform: `${process.platform} ${os.release()}`,
+            env: ENV,
+            project: state?.projectId ?? 'none',
+            branch: project?.branchId ?? 'none',
+            desync: project?.projectManager.desync.get() ?? false,
+            last_sentry_event: getLastSentryEventId() ?? 'none'
+        }
+    });
+
+    const copy = 'Copy ID';
+    void vscode.window
+        .showInformationMessage(`Report sent to PlayCanvas team. Reference: ${eventId}`, copy)
+        .then((c) => {
+            if (c === copy) {
+                void vscode.env.clipboard.writeText(eventId);
+            }
+        });
+};
+
+export const registerIdleCommands = ({
+    context,
+    auth,
+    rootUri,
+    error
+}: {
+    context: vscode.ExtensionContext;
+    auth: Auth;
+    rootUri: vscode.Uri;
+    error: ReturnType<typeof signal<Error | undefined>>;
+}) => {
+    context.subscriptions.push(
+        vscode.commands.registerCommand(`${NAME}.openProject`, async () => {
+            const [err1, client] = await tryCatch(auth.getClient(true));
+            if (err1) {
+                error.set(() => err1);
+                return;
+            }
+            if (!client) {
+                return;
+            }
+            const [err2, projects] = await tryCatch(client.rest.userProjects(client.userId, 'profile'));
+            client.rest.dispose();
+            if (err2) {
+                error.set(() => err2);
+                return;
+            }
+            await openFolder(rootUri, projects);
+        })
+    );
+    context.subscriptions.push(vscode.commands.registerCommand(`${NAME}.reloadProject`, () => undefined));
+    context.subscriptions.push(vscode.commands.registerCommand(`${NAME}.switchBranch`, () => undefined));
+    context.subscriptions.push(vscode.commands.registerCommand(`${NAME}.showPathCollisions`, () => undefined));
+    const uriHandler = new UriHandler({
+        context,
+        rootUri,
+        auth
+    });
+    const disposeUriError = effect(() => {
+        const err = uriHandler.error.get();
+        if (err) {
+            error.set(() => err);
+        }
+    });
+    context.subscriptions.push(new vscode.Disposable(disposeUriError));
+    context.subscriptions.push(vscode.window.registerUriHandler(uriHandler));
+    context.subscriptions.push(
+        vscode.commands.registerCommand(`${NAME}.reportIssue`, (value?: string) =>
+            report({ value, userId: 'anonymous' })
+        )
+    );
+};
+
+export const registerProjectCommands = ({
+    context,
+    rootUri,
+    userId,
+    rest,
+    metrics,
+    state,
+    cache,
+    reload
+}: {
+    context: vscode.ExtensionContext;
+    rootUri: vscode.Uri;
+    userId: number;
+    rest: Rest;
+    metrics: Metrics;
+    state: State;
+    cache: Cache;
+    reload: ReturnType<typeof signal<{ projectManager: ProjectManager } | undefined>>;
+}) => {
+    context.subscriptions.push(
+        vscode.commands.registerCommand(`${NAME}.openProject`, async () => {
+            metrics.increment('command', { name: 'openProject' });
+            const projects = await rest.userProjects(userId, 'profile');
+            await openFolder(rootUri, projects);
+        })
+    );
+    context.subscriptions.push(
+        vscode.commands.registerCommand(`${NAME}.reloadProject`, async () => {
+            metrics.increment('command', { name: 'reloadProject' });
+            if (!state.projectId) {
+                return;
+            }
+
+            const { projectManager } = cache.get(state.projectId) ?? {};
+            if (!projectManager) {
+                return;
+            }
+
+            reload.set(() => ({ projectManager }));
+        })
+    );
+    context.subscriptions.push(
+        vscode.commands.registerCommand(`${NAME}.switchBranch`, async () => {
+            metrics.increment('command', { name: 'switchBranch' });
+            if (!state.projectId) {
+                return;
+            }
+
+            const { branchId } = cache.get(state.projectId) ?? {};
+            if (!branchId) {
+                return;
+            }
+
+            const branches = await rest.projectBranches(state.projectId);
+            const names = branches.reduce((acc: string[], b) => {
+                if (b.id !== branchId) {
+                    acc.push(b.name);
+                }
+                return acc;
+            }, []);
+            const chosen = await vscode.window.showQuickPick(names, {
+                placeHolder: 'Select a branch'
+            });
+            if (!chosen) {
+                return;
+            }
+
+            const branch = branches.find((b) => b.name === chosen);
+            if (!branch) {
+                return;
+            }
+
+            await rest.branchCheckout(branch.id);
+        })
+    );
+    context.subscriptions.push(
+        vscode.commands.registerCommand(`${NAME}.showPathCollisions`, async () => {
+            if (!state.projectId) {
+                return;
+            }
+            const { projectManager } = cache.get(state.projectId) ?? {};
+            if (!projectManager) {
+                return;
+            }
+
+            const collisions = projectManager.collisions.snapshot();
+            if (collisions.size === 0) {
+                return;
+            }
+
+            const options = ['Show Path Collisions', 'Reload project'];
+            void vscode.window
+                .showWarningMessage(
+                    [
+                        `${collisions.size} asset path collision${collisions.size !== 1 ? 's' : ''} found.`,
+                        'Rename or move the colliding assets in the Editor to resolve.'
+                    ].join('\n'),
+                    ...options
+                )
+                .then((option) => {
+                    switch (option) {
+                        case options[0]: {
+                            const list = Array.from(collisions.entries()).map(([path, ids]) => ({
+                                label: path,
+                                description: `(${ids.join(', ')})`
+                            }));
+                            void vscode.window.showQuickPick(list, {
+                                title: 'Asset Path Collisions',
+                                placeHolder: 'Filter paths',
+                                canPickMany: false
+                            });
+                            break;
+                        }
+                        case options[1]: {
+                            void vscode.commands.executeCommand(`${NAME}.reloadProject`);
+                            break;
+                        }
+                    }
+                });
+        })
+    );
+    context.subscriptions.push(
+        vscode.commands.registerCommand(`${NAME}.reportIssue`, (value?: string) =>
+            report({ value, userId, state, cache })
+        )
+    );
+};

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,8 +1,7 @@
-import * as os from 'os';
-
 import * as vscode from 'vscode';
 
 import { Auth } from './auth';
+import { registerIdleCommands, registerProjectCommands } from './commands';
 import {
     DEBUG,
     ENV,
@@ -26,22 +25,13 @@ import { simpleNotification } from './notification';
 import { ProjectManager } from './project-manager';
 import { CollabProvider } from './providers/collab-provider';
 import { DecorationProvider } from './providers/decoration-provider';
-import {
-    addAttachment,
-    captureIssue,
-    closeSentry,
-    getLastSentryEventId,
-    setSentryCollaborators,
-    setSentryProject,
-    setSentryUser
-} from './sentry';
+import { closeSentry, setSentryCollaborators, setSentryProject, setSentryUser } from './sentry';
 import type { EventMap } from './typings/event-map';
 import type { Project } from './typings/models';
 import { fail } from './utils/error';
 import { EventEmitter } from './utils/event-emitter';
-import * as redact from './utils/redact';
-import { computed, effect } from './utils/signal';
-import { fmtLog, projectToName, tryCatch, uriStartsWith, wait } from './utils/utils';
+import { computed, effect, signal } from './utils/signal';
+import { projectToName, tryCatch, uriStartsWith, wait } from './utils/utils';
 
 const HEARTBEAT_MS = 5 * 60 * 1000;
 const PING_SAMPLE_MS = 60 * 1000;
@@ -104,119 +94,30 @@ export const activate = async (context: vscode.ExtensionContext) => {
     context.subscriptions.push(vscode.commands.registerCommand(`${NAME}.logout`, () => auth.logout()));
     const folders = (vscode.workspace.workspaceFolders ?? []).filter((f) => uriStartsWith(f.uri, rootUri));
     const projectWindow = folders.length > 0;
-    const showError = (error: Error) => {
-        log.error(error);
-        void vscode.window.showErrorMessage(`PlayCanvas Error: ${error.message}`);
-    };
-    const openProject = async () => {
-        const [clientErr, client] = await tryCatch(auth.getClient(true));
-        if (clientErr) {
-            showError(clientErr);
-            return;
-        }
-        if (!client) {
-            return;
-        }
-        const [projectsErr, projects] = await tryCatch(client.rest.userProjects(client.userId, 'profile'));
-        client.rest.dispose();
-        if (projectsErr) {
-            showError(projectsErr);
-            return;
-        }
 
-        const list = projects.map((p) => projectToName(p, false)).reverse();
-        const chosen = await vscode.window.showQuickPick(list, {
-            placeHolder: 'Select a project'
+    // idle commands
+    const registerIdle = () => {
+        const error = signal<Error | undefined>(undefined);
+        registerIdleCommands({ context, auth, rootUri, error });
+        const disposeCommandsError = effect(() => {
+            const err = error.get();
+            if (err) {
+                log.error(err);
+                void vscode.window.showErrorMessage(`PlayCanvas Error: ${err.message}`);
+            }
         });
-        const project = projects.find((p) => chosen === projectToName(p, false));
-        if (!project) {
-            return;
-        }
-
-        const folder = vscode.Uri.joinPath(rootUri, projectToName(project));
-        await vscode.workspace.fs.createDirectory(folder);
-        await vscode.commands.executeCommand('vscode.openFolder', folder, false);
+        context.subscriptions.push(new vscode.Disposable(disposeCommandsError));
     };
-    const registerIdleCommands = () => {
-        context.subscriptions.push(vscode.commands.registerCommand(`${NAME}.openProject`, openProject));
-        context.subscriptions.push(vscode.commands.registerCommand(`${NAME}.reloadProject`, () => undefined));
-        context.subscriptions.push(vscode.commands.registerCommand(`${NAME}.switchBranch`, () => undefined));
-        context.subscriptions.push(vscode.commands.registerCommand(`${NAME}.showPathCollisions`, () => undefined));
-        context.subscriptions.push(
-            vscode.window.registerUriHandler({
-                handleUri: async (uri) => {
-                    const [clientErr, client] = await tryCatch(auth.getClient(true));
-                    if (clientErr) {
-                        showError(clientErr);
-                        return;
-                    }
-                    if (!client) {
-                        return;
-                    }
-                    const handler = new UriHandler({
-                        context,
-                        rootUri,
-                        userId: client.userId,
-                        rest: client.rest
-                    });
-                    const [handleErr] = await tryCatch(handler.handleUri(uri));
-                    client.rest.dispose();
-                    if (handleErr) {
-                        showError(handleErr);
-                    }
-                }
-            })
-        );
-        context.subscriptions.push(
-            vscode.commands.registerCommand(`${NAME}.reportIssue`, async (defaultDescription?: string) => {
-                const description =
-                    defaultDescription ??
-                    (await vscode.window.showInputBox({
-                        title: 'PlayCanvas: Report Issue',
-                        prompt: 'Describe the issue',
-                        placeHolder: 'e.g. scripts are not syncing with online IDE',
-                        ignoreFocusOut: true,
-                        validateInput: (v) => (v.trim() ? undefined : 'Description is required')
-                    }));
-                if (!description) {
-                    return;
-                }
-                const bundle = redact.text(Log.dump().map(fmtLog).join('\n'));
-                addAttachment({ filename: 'anonymous.log', data: bundle, contentType: 'text/plain' });
-                const eventId = captureIssue(description, {
-                    report: {
-                        extension: VERSION,
-                        vscode: vscode.version,
-                        platform: `${process.platform} ${os.release()}`,
-                        env: ENV,
-                        project: 'none',
-                        branch: 'none',
-                        desync: false,
-                        last_sentry_event: getLastSentryEventId() ?? 'none'
-                    }
-                });
-                const copy = 'Copy ID';
-                void vscode.window
-                    .showInformationMessage(`Report sent to PlayCanvas team. Reference: ${eventId}`, copy)
-                    .then((choice) => {
-                        if (choice === copy) {
-                            void vscode.env.clipboard.writeText(eventId);
-                        }
-                    });
-            })
-        );
-    };
-
     if (!projectWindow) {
-        registerIdleCommands();
+        registerIdle();
         return;
     }
-    const [clientErr, client] = await tryCatch(auth.getClient(false));
-    if (clientErr) {
-        throw clientErr;
+    const [err1, client] = await tryCatch(auth.getClient(false));
+    if (err1) {
+        throw err1;
     }
     if (!client) {
-        registerIdleCommands();
+        registerIdle();
         await auth.promptProjectLogin();
         return;
     }
@@ -493,10 +394,10 @@ export const activate = async (context: vscode.ExtensionContext) => {
             const branchSwitchDone = await simpleNotification(`Switching to branch ${name}...`);
 
             // reload project
-            const [reloadErr, reloaded] = await tryCatch(reload(projectManager, branch_id));
+            const [err1, reloaded] = await tryCatch(reload(projectManager, branch_id));
             branchSwitchDone();
-            if (reloadErr) {
-                throw reloadErr;
+            if (err1) {
+                throw err1;
             }
             if (!reloaded) {
                 return;
@@ -567,10 +468,10 @@ export const activate = async (context: vscode.ExtensionContext) => {
             const checkpointDone = await simpleNotification(`Restoring to checkpoint ${checkpoint_id}. Reloading...`);
 
             // reload project
-            const [reloadErr, reloaded] = await tryCatch(reload(projectManager));
+            const [err1, reloaded] = await tryCatch(reload(projectManager));
             checkpointDone();
-            if (reloadErr) {
-                throw reloadErr;
+            if (err1) {
+                throw err1;
             }
             if (!reloaded) {
                 return;
@@ -591,198 +492,33 @@ export const activate = async (context: vscode.ExtensionContext) => {
         })
     );
 
-    // open project
+    // project commands
+    const commandReload = signal<{ projectManager: ProjectManager } | undefined>(undefined);
+    registerProjectCommands({
+        context,
+        rootUri,
+        userId,
+        rest,
+        metrics,
+        state,
+        cache,
+        reload: commandReload
+    });
     context.subscriptions.push(
-        vscode.commands.registerCommand(`${NAME}.openProject`, async () => {
-            metrics.increment('command', { name: 'openProject' });
-            // fetch all user projects
-            const projects = await rest.userProjects(userId, 'profile');
-
-            // show picker
-            const list = projects.map((p) => projectToName(p, false)).reverse();
-            const chosen = await vscode.window.showQuickPick(list, {
-                placeHolder: 'Select a project'
-            });
-            const project = projects.find((p) => chosen === projectToName(p, false));
-            if (!project) {
-                return;
-            }
-
-            // open project folder
-            const folder = vscode.Uri.joinPath(rootUri, projectToName(project));
-            await vscode.workspace.fs.createDirectory(folder);
-            await vscode.commands.executeCommand('vscode.openFolder', folder, false);
-        })
-    );
-
-    // reload project
-    context.subscriptions.push(
-        vscode.commands.registerCommand(`${NAME}.reloadProject`, async () => {
-            metrics.increment('command', { name: 'reloadProject' });
-            // check if we have an active editor
-            if (!state.projectId) {
-                return;
-            }
-
-            // fetch from cache
-            const { projectManager } = cache.get(state.projectId) ?? {};
-            if (!projectManager) {
-                return;
-            }
-
-            const reloadDone = await simpleNotification('Reloading project...');
-
-            // reload project
-            const [err, reloaded] = await tryCatch(reload(projectManager));
-            reloadDone();
-            if (err) {
-                void handleError(err).catch((e) => log.error(e.message));
-                return;
-            }
-            if (!reloaded) {
-                return;
-            }
-        })
-    );
-
-    // switch branch
-    context.subscriptions.push(
-        vscode.commands.registerCommand(`${NAME}.switchBranch`, async () => {
-            metrics.increment('command', { name: 'switchBranch' });
-            // check if we have an active project
-            if (!state.projectId) {
-                return;
-            }
-
-            // fetch from cache
-            const { branchId } = cache.get(state.projectId) ?? {};
-            if (!branchId) {
-                return;
-            }
-
-            // fetch project branches (excluding current branch)
-            const branches = await rest.projectBranches(state.projectId);
-            const branchNames = branches.reduce((acc: string[], b) => {
-                if (b.id === branchId) {
-                    return acc;
-                }
-                acc.push(b.name);
-                return acc;
-            }, []);
-
-            // show picker
-            const chosen = await vscode.window.showQuickPick(branchNames, {
-                placeHolder: 'Select a branch'
-            });
-            if (!chosen) {
-                return;
-            }
-
-            // find branch
-            const branch = branches.find((b) => b.name === chosen);
-            if (!branch) {
-                return;
-            }
-
-            // checkout branch
-            // NOTE: branch switch flow continues in messenger event above
-            await rest.branchCheckout(branch.id);
-        })
-    );
-
-    // view collisions
-    context.subscriptions.push(
-        vscode.commands.registerCommand(`${NAME}.showPathCollisions`, async () => {
-            if (!state.projectId) {
-                return;
-            }
-            const { projectManager } = cache.get(state.projectId) ?? {};
-            if (!projectManager) {
-                return;
-            }
-
-            const collisions = projectManager.collisions.snapshot();
-            if (collisions.size === 0) {
-                return;
-            }
-
-            // show warning message
-            const options = ['Show Path Collisions', 'Reload project'];
-            void vscode.window
-                .showWarningMessage(
-                    [
-                        `${collisions.size} asset path collision${collisions.size !== 1 ? 's' : ''} found.`,
-                        'Rename or move the colliding assets in the Editor to resolve.'
-                    ].join('\n'),
-                    ...options
-                )
-                .then((option) => {
-                    switch (option) {
-                        case options[0]: {
-                            const list = Array.from(collisions.entries()).map(([path, ids]) => ({
-                                label: path,
-                                description: `(${ids.join(', ')})`
-                            }));
-                            void vscode.window.showQuickPick(list, {
-                                title: 'Asset Path Collisions',
-                                placeHolder: 'Filter paths',
-                                canPickMany: false
-                            });
-                            break;
+        new vscode.Disposable(
+            effect(() => {
+                const req = commandReload.get();
+                if (req) {
+                    void simpleNotification('Reloading project...').then(async (reloadDone) => {
+                        const [err] = await tryCatch(reload(req.projectManager));
+                        reloadDone();
+                        if (err) {
+                            void handleError(err).catch((e) => log.error(e.message));
                         }
-                        case options[1]: {
-                            void vscode.commands.executeCommand(`${NAME}.reloadProject`);
-                            break;
-                        }
-                    }
-                });
-        })
-    );
-
-    // report issue — accepts an optional defaultDescription so callers with
-    // an inherent context (error toast, desync toast) submit instantly.
-    context.subscriptions.push(
-        vscode.commands.registerCommand(`${NAME}.reportIssue`, async (defaultDescription?: string) => {
-            const description =
-                defaultDescription ??
-                (await vscode.window.showInputBox({
-                    title: 'PlayCanvas: Report Issue',
-                    prompt: 'Describe the issue',
-                    placeHolder: 'e.g. scripts are not syncing with online IDE',
-                    ignoreFocusOut: true,
-                    validateInput: (v) => (v.trim() ? undefined : 'Description is required')
-                }));
-            if (!description) {
-                return;
-            }
-
-            const project = state.projectId ? cache.get(state.projectId) : undefined;
-
-            const bundle = redact.text(Log.dump().map(fmtLog).join('\n'));
-            addAttachment({ filename: `${userId}.log`, data: bundle, contentType: 'text/plain' });
-
-            const eventId = captureIssue(description, {
-                report: {
-                    extension: VERSION,
-                    vscode: vscode.version,
-                    platform: `${process.platform} ${os.release()}`,
-                    env: ENV,
-                    project: state.projectId ?? 'none',
-                    branch: project?.branchId ?? 'none',
-                    desync: project?.projectManager.desync.get() ?? false,
-                    last_sentry_event: getLastSentryEventId() ?? 'none'
+                    });
                 }
-            });
-
-            const copy = 'Copy ID';
-            void vscode.window
-                .showInformationMessage(`Report sent to PlayCanvas team. Reference: ${eventId}`, copy)
-                .then((choice) => {
-                    if (choice === copy) {
-                        void vscode.env.clipboard.writeText(eventId);
-                    }
-                });
-        })
+            })
+        )
     );
 
     // load project

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -90,23 +90,64 @@ export const activate = async (context: vscode.ExtensionContext) => {
 
     // auth
     const auth = new Auth(context);
-    context.subscriptions.push(vscode.commands.registerCommand(`${NAME}.login`, async () => auth.getAccessToken(true)));
-    context.subscriptions.push(vscode.commands.registerCommand(`${NAME}.logout`, () => auth.logout()));
     const folders = (vscode.workspace.workspaceFolders ?? []).filter((f) => uriStartsWith(f.uri, rootUri));
     const projectWindow = folders.length > 0;
+    const telemetry: { metrics?: Metrics } = {};
+
+    // error handler
+    const handleError = async (err?: Error, source?: string) => {
+        if (!err) {
+            return;
+        }
+
+        // log to output channel (also reports to sentry)
+        log.error(err);
+
+        telemetry.metrics?.logError(err, source ? { source } : undefined);
+
+        // handle auth errors
+        if (/access token/.test(err.message)) {
+            await auth.reset(`Auth Error: ${err.message}`);
+        }
+
+        void vscode.window.showErrorMessage(`PlayCanvas Error: ${err.message}`, 'Report Issue').then((choice) => {
+            if (choice === 'Report Issue') {
+                void vscode.commands.executeCommand(`${NAME}.reportIssue`, err.message);
+            }
+        });
+    };
+
+    const failure = signal<{ err: Error; source?: string } | undefined>(undefined);
+    context.subscriptions.push(
+        new vscode.Disposable(
+            effect(() => {
+                const f = failure.get();
+                if (f) {
+                    void handleError(f.err, f.source).catch((e) => log.error(e.message));
+                }
+            })
+        )
+    );
+    context.subscriptions.push(
+        vscode.commands.registerCommand(`${NAME}.login`, async () => {
+            const [err] = await tryCatch(auth.getAccessToken(true));
+            if (err) {
+                failure.set(() => ({ err, source: 'auth' }));
+            }
+        })
+    );
+    context.subscriptions.push(
+        vscode.commands.registerCommand(`${NAME}.logout`, async () => {
+            const [err] = await tryCatch(auth.logout());
+            if (err) {
+                failure.set(() => ({ err, source: 'auth' }));
+            }
+        })
+    );
 
     // idle commands
     const registerIdle = () => {
-        const error = signal<Error | undefined>(undefined);
-        registerIdleCommands({ context, auth, rootUri, error });
-        const disposeCommandsError = effect(() => {
-            const err = error.get();
-            if (err) {
-                log.error(err);
-                void vscode.window.showErrorMessage(`PlayCanvas Error: ${err.message}`);
-            }
-        });
-        context.subscriptions.push(new vscode.Disposable(disposeCommandsError));
+        registerIdleCommands({ context, auth, rootUri, failure });
     };
     if (!projectWindow) {
         registerIdle();
@@ -114,11 +155,16 @@ export const activate = async (context: vscode.ExtensionContext) => {
     }
     const [err1, client] = await tryCatch(auth.getClient(false));
     if (err1) {
-        throw err1;
+        registerIdle();
+        failure.set(() => ({ err: err1, source: 'auth' }));
+        return;
     }
     if (!client) {
         registerIdle();
-        await auth.promptProjectLogin();
+        const [err2] = await tryCatch(auth.promptProjectLogin());
+        if (err2) {
+            failure.set(() => ({ err: err2, source: 'auth' }));
+        }
         return;
     }
     const { accessToken, rest, userId } = client;
@@ -126,33 +172,11 @@ export const activate = async (context: vscode.ExtensionContext) => {
 
     // metrics
     const metrics = new Metrics(accessToken);
+    telemetry.metrics = metrics;
     context.subscriptions.push(metrics.disposable);
     metrics.increment('session.start', SESSION_DIMENSIONS);
     const heartbeat = setInterval(() => metrics.increment('session.heartbeat'), HEARTBEAT_MS);
     context.subscriptions.push(new vscode.Disposable(() => clearInterval(heartbeat)));
-
-    // error handler
-    const handleError = async (error?: Error, source?: string) => {
-        if (!error) {
-            return;
-        }
-
-        // log to output channel (also reports to sentry)
-        log.error(error);
-
-        metrics.logError(error, source ? { source } : undefined);
-
-        // handle auth errors
-        if (/access token/.test(error.message)) {
-            await auth.reset(`Auth Error: ${error.message}`);
-        }
-
-        void vscode.window.showErrorMessage(`PlayCanvas Error: ${error.message}`, 'Report Issue').then((choice) => {
-            if (choice === 'Report Issue') {
-                void vscode.commands.executeCommand(`${NAME}.reportIssue`, error.message);
-            }
-        });
-    };
 
     // create events
     const events = new EventEmitter<EventMap>();
@@ -170,7 +194,7 @@ export const activate = async (context: vscode.ExtensionContext) => {
     effect(() => {
         const err = sharedb.error.get();
         if (err) {
-            void handleError(err, 'sharedb').catch((e) => log.error(e.message));
+            failure.set(() => ({ err, source: 'sharedb' }));
         }
     });
 
@@ -188,7 +212,7 @@ export const activate = async (context: vscode.ExtensionContext) => {
     effect(() => {
         const err = relay.error.get();
         if (err) {
-            void handleError(err, 'relay').catch((e) => log.error(e.message));
+            failure.set(() => ({ err, source: 'relay' }));
         }
     });
 
@@ -218,7 +242,7 @@ export const activate = async (context: vscode.ExtensionContext) => {
     effect(() => {
         const err = disk.error.get();
         if (err) {
-            void handleError(err, 'disk').catch((e) => log.error(e.message));
+            failure.set(() => ({ err, source: 'disk' }));
         }
     });
 
@@ -265,7 +289,7 @@ export const activate = async (context: vscode.ExtensionContext) => {
     effect(() => {
         const err = uriHandler.error.get();
         if (err) {
-            void handleError(err, 'uri-handler').catch((e) => log.error(e.message));
+            failure.set(() => ({ err, source: 'uri-handler' }));
         }
     });
     context.subscriptions.push(vscode.window.registerUriHandler(uriHandler));
@@ -278,7 +302,7 @@ export const activate = async (context: vscode.ExtensionContext) => {
     effect(() => {
         const err = collabProvider.error.get();
         if (err) {
-            void handleError(err, 'collab-provider').catch((e) => log.error(e.message));
+            failure.set(() => ({ err, source: 'collab-provider' }));
         }
     });
     context.subscriptions.push(vscode.window.registerTreeDataProvider('collab-view', collabProvider));
@@ -294,7 +318,7 @@ export const activate = async (context: vscode.ExtensionContext) => {
     effect(() => {
         const err = decorationProvider.error.get();
         if (err) {
-            void handleError(err, 'dirty-decoration-provider').catch((e) => log.error(e.message));
+            failure.set(() => ({ err, source: 'dirty-decoration-provider' }));
         }
     });
     context.subscriptions.push(vscode.window.registerFileDecorationProvider(decorationProvider));
@@ -411,7 +435,7 @@ export const activate = async (context: vscode.ExtensionContext) => {
             branchStatusBarItem.show();
         });
         if (err) {
-            void handleError(err);
+            failure.set(() => ({ err, source: 'messenger' }));
         }
     });
     const branchClose = messenger.on('branch.close', async (e) => {
@@ -439,7 +463,7 @@ export const activate = async (context: vscode.ExtensionContext) => {
             await rest.branchCheckout(main.id);
         });
         if (err) {
-            void handleError(err);
+            failure.set(() => ({ err, source: 'messenger' }));
         }
     });
     const checkpointRestore = async (data: {
@@ -478,7 +502,7 @@ export const activate = async (context: vscode.ExtensionContext) => {
             }
         });
         if (err) {
-            void handleError(err);
+            failure.set(() => ({ err, source: 'messenger' }));
         }
     };
     const checkpointRevert = messenger.on('checkpoint.revertEnded', (e) => checkpointRestore(e.data));
@@ -502,7 +526,8 @@ export const activate = async (context: vscode.ExtensionContext) => {
         metrics,
         state,
         cache,
-        reload: commandReload
+        reload: commandReload,
+        failure
     });
     context.subscriptions.push(
         new vscode.Disposable(
@@ -513,7 +538,7 @@ export const activate = async (context: vscode.ExtensionContext) => {
                         const [err] = await tryCatch(reload(req.projectManager));
                         reloadDone();
                         if (err) {
-                            void handleError(err).catch((e) => log.error(e.message));
+                            failure.set(() => ({ err, source: 'commands' }));
                         }
                     });
                 }
@@ -522,7 +547,11 @@ export const activate = async (context: vscode.ExtensionContext) => {
     );
 
     // load project
-    const projects = await rest.userProjects(userId, 'profile');
+    const [projectsErr, projects] = await tryCatch(rest.userProjects(userId, 'profile'));
+    if (projectsErr) {
+        failure.set(() => ({ err: projectsErr, source: 'rest' }));
+        return;
+    }
     const valid: [vscode.WorkspaceFolder, Project][] = folders.reduce(
         (list, f) => {
             // ensure folder matches a user project
@@ -548,7 +577,8 @@ export const activate = async (context: vscode.ExtensionContext) => {
             const [err] = await tryCatch(sharedb.connect(() => accessToken));
             if (err) {
                 sharedb.disconnect();
-                throw err;
+                failure.set(() => ({ err, source: 'sharedb' }));
+                return;
             }
             context.subscriptions.push(
                 new vscode.Disposable(() => {
@@ -560,7 +590,8 @@ export const activate = async (context: vscode.ExtensionContext) => {
             const [err] = await tryCatch(messenger.connect(() => accessToken));
             if (err) {
                 messenger.disconnect();
-                throw err;
+                failure.set(() => ({ err, source: 'messenger' }));
+                return;
             }
             context.subscriptions.push(
                 new vscode.Disposable(() => {
@@ -572,7 +603,8 @@ export const activate = async (context: vscode.ExtensionContext) => {
             const [err] = await tryCatch(relay.connect(() => accessToken));
             if (err) {
                 relay.disconnect();
-                throw err;
+                failure.set(() => ({ err, source: 'relay' }));
+                return;
             }
             context.subscriptions.push(
                 new vscode.Disposable(() => {
@@ -584,7 +616,10 @@ export const activate = async (context: vscode.ExtensionContext) => {
         // load branch info
         const doc = await sharedb.subscribe('settings', `project_${project.id}_${userId}`);
         if (!doc) {
-            void handleError(fail`Failed to load project settings for project ${project.id}`);
+            failure.set(() => ({
+                err: fail`Failed to load project settings for project ${project.id}`,
+                source: 'sharedb'
+            }));
             return;
         }
         context.subscriptions.push(
@@ -622,7 +657,7 @@ export const activate = async (context: vscode.ExtensionContext) => {
         effect(() => {
             const err = projectManager.error.get();
             if (err) {
-                void handleError(err, 'project-manager').catch((e) => log.error(e.message));
+                failure.set(() => ({ err, source: 'project-manager' }));
             }
         });
         effect(() => {

--- a/src/handlers/uri-handler.ts
+++ b/src/handlers/uri-handler.ts
@@ -263,7 +263,15 @@ class UriHandler
 
         this._cleanup.push(async () => this._clearErrorDecoration());
 
-        // retrieve and clear stored open file (always consume)
+        await this._openFile(folderUri, projectManager);
+
+        this._folderUri = folderUri;
+        this._projectManager = projectManager;
+
+        this._log.info(`linked to ${folderUri.toString()}`);
+    }
+
+    protected async _openFile(folderUri: vscode.Uri, projectManager: ProjectManager) {
         const open = this._context.globalState.get<
             OpenFile & {
                 folderUriStr: string;
@@ -273,11 +281,6 @@ class UriHandler
         if (open?.assetId && open.folderUriStr === folderUri.toString()) {
             await this._openDocument(folderUri, projectManager, open);
         }
-
-        this._folderUri = folderUri;
-        this._projectManager = projectManager;
-
-        this._log.info(`linked to ${folderUri.toString()}`);
     }
 
     async unlink() {

--- a/src/handlers/uri-handler.ts
+++ b/src/handlers/uri-handler.ts
@@ -1,12 +1,13 @@
 import * as vscode from 'vscode';
 
+import type { Auth } from '../auth';
 import { NAME, PUBLISHER } from '../config';
 import type { Rest } from '../connections/rest';
 import type { ProjectManager } from '../project-manager';
 import { fail } from '../utils/error';
 import { Linker } from '../utils/linker';
 import { signal } from '../utils/signal';
-import { fileExists, projectToName, guard } from '../utils/utils';
+import { fileExists, projectToName, guard, tryCatch } from '../utils/utils';
 
 type OpenFile = {
     assetId: number;
@@ -27,9 +28,11 @@ class UriHandler
 
     private _rootUri: vscode.Uri;
 
-    private _userId: number;
+    private _userId?: number;
 
-    private _rest: Rest;
+    private _rest?: Rest;
+
+    private _auth?: Auth;
 
     private _folderUri?: vscode.Uri;
 
@@ -51,23 +54,30 @@ class UriHandler
         this._errorDisposable = undefined;
     }
 
-    constructor({
-        context,
-        rootUri,
-        userId,
-        rest
-    }: {
-        context: vscode.ExtensionContext;
-        rootUri: vscode.Uri;
-        userId: number;
-        rest: Rest;
-    }) {
+    constructor(
+        options:
+            | {
+                  context: vscode.ExtensionContext;
+                  rootUri: vscode.Uri;
+                  userId: number;
+                  rest: Rest;
+              }
+            | {
+                  context: vscode.ExtensionContext;
+                  rootUri: vscode.Uri;
+                  auth: Auth;
+              }
+    ) {
         super();
 
-        this._context = context;
-        this._rootUri = rootUri;
-        this._userId = userId;
-        this._rest = rest;
+        this._context = options.context;
+        this._rootUri = options.rootUri;
+        if ('auth' in options) {
+            this._auth = options.auth;
+        } else {
+            this._userId = options.userId;
+            this._rest = options.rest;
+        }
 
         this._context.subscriptions.push(this._errorDecoration);
     }
@@ -143,30 +153,7 @@ class UriHandler
         this._log.info(`opened asset ${assetId} at ${filePath}`);
     }
 
-    protected async _openFile(folderUri: vscode.Uri, projectManager: ProjectManager) {
-        // retrieve and clear stored open file (always consume)
-        const open = this._context.globalState.get<
-            OpenFile & {
-                folderUriStr: string;
-            }
-        >(UriHandler.OPEN_FILE_KEY);
-        await this._context.globalState.update(UriHandler.OPEN_FILE_KEY, undefined);
-
-        // check if we need to open a file
-        if (!open || !open.assetId) {
-            return;
-        }
-
-        // check if file is for the current project
-        if (open.folderUriStr !== folderUri.toString()) {
-            return;
-        }
-
-        // open text document
-        await this._openDocument(folderUri, projectManager, open);
-    }
-
-    async handleUri(uri: vscode.Uri) {
+    private async _handleUri(uri: vscode.Uri, userId: number, rest: Rest) {
         if (uri.authority !== `${PUBLISHER}.${NAME}`) {
             return;
         }
@@ -208,7 +195,7 @@ class UriHandler
         );
 
         // fetch all user projects
-        const projects = await guard(this._rest.userProjects(this._userId, 'profile'), this.error);
+        const projects = await guard(rest.userProjects(userId, 'profile'), this.error);
 
         // find matching project
         const project = projects.find((p) => p.id === projectId);
@@ -243,6 +230,29 @@ class UriHandler
         await vscode.commands.executeCommand('vscode.openFolder', folderUri, false);
     }
 
+    async handleUri(uri: vscode.Uri) {
+        if (this._auth) {
+            const [err1, client] = await tryCatch(this._auth.getClient(true));
+            if (err1) {
+                this.error.set(() => err1);
+                return;
+            }
+            if (!client) {
+                return;
+            }
+            const [err2] = await tryCatch(this._handleUri(uri, client.userId, client.rest));
+            client.rest.dispose();
+            if (err2) {
+                this.error.set(() => err2);
+            }
+            return;
+        }
+        if (this._userId === undefined || !this._rest) {
+            return;
+        }
+        await this._handleUri(uri, this._userId, this._rest);
+    }
+
     async link({ folderUri, projectManager }: { folderUri: vscode.Uri; projectManager: ProjectManager }) {
         if (this._folderUri !== undefined) {
             throw this.error.set(() => fail`manager already linked`);
@@ -253,7 +263,16 @@ class UriHandler
 
         this._cleanup.push(async () => this._clearErrorDecoration());
 
-        await this._openFile(folderUri, projectManager);
+        // retrieve and clear stored open file (always consume)
+        const open = this._context.globalState.get<
+            OpenFile & {
+                folderUriStr: string;
+            }
+        >(UriHandler.OPEN_FILE_KEY);
+        await this._context.globalState.update(UriHandler.OPEN_FILE_KEY, undefined);
+        if (open?.assetId && open.folderUriStr === folderUri.toString()) {
+            await this._openDocument(folderUri, projectManager, open);
+        }
 
         this._folderUri = folderUri;
         this._projectManager = projectManager;
@@ -275,4 +294,4 @@ class UriHandler
     }
 }
 
-export { type OpenFile, UriHandler };
+export { UriHandler };

--- a/src/test/suite/extension.test.ts
+++ b/src/test/suite/extension.test.ts
@@ -58,7 +58,7 @@ const warningMessageStub = sandbox.stub(vscode.window, 'showWarningMessage').res
 // stub info message for ignore update prompts
 const infoMessageStub = sandbox.stub(vscode.window, 'showInformationMessage').resolves(undefined);
 
-// stub error message — handleError() in extension.ts:105 surfaces pm.error here
+// stub error message — handleError surfaces pm.error here
 const errorMessageStub = sandbox.stub(vscode.window, 'showErrorMessage').resolves(undefined);
 
 // spy vscode methods
@@ -263,6 +263,19 @@ suite('extension', () => {
 
         // check if open folder was called
         assert.ok(openFolderStub.called, 'open folder should have been called');
+    });
+
+    test(`command ${NAME}.openProject failure surfaces error`, async () => {
+        errorMessageStub.resetHistory();
+        rest.failNext('userProjects', new Error('mock 500: userProjects refused'));
+
+        await assertResolves(vscode.commands.executeCommand(`${NAME}.openProject`), `${NAME}.openProject`);
+        await wait(50);
+
+        const errorCall = errorMessageStub
+            .getCalls()
+            .find((c) => String(c.args[0]).includes('mock 500: userProjects refused'));
+        assert.ok(errorCall, 'openProject failure should be handled by handleError');
     });
 
     test(`command ${NAME}.switchBranch`, async () => {
@@ -2912,7 +2925,7 @@ suite('extension', () => {
 
     test('rest assetCreate failure surfaces error to user', async () => {
         // production: pm.create wraps rest.assetCreate in guard() (project-manager.ts:939)
-        // which sets pm.error on throw; the effect at extension.ts:706 calls handleError
+        // which sets pm.error on throw; the extension error effect calls handleError
         // which posts via vscode.window.showErrorMessage. without P2.4's failNext hook
         // this entire user-visible path was unreachable from tests.
         const folderUri = vscode.workspace.workspaceFolders?.[0]?.uri;


### PR DESCRIPTION
### What's Changed

- Move command registration out of the extension entrypoint.
- Fold idle URI handling into UriHandler.
- Route command and component failures through one extension failure signal and handleError path.

Manual tests: not run