### PR TITLE
fix: improve signed out project sign in

### DIFF
--- a/src/auth.ts
+++ b/src/auth.ts
@@ -7,8 +7,21 @@ import { AUTH_TIMEOUT_MS } from './connections/constants';
 import { Rest } from './connections/rest';
 import { tryCatch } from './utils/utils';
 
+type Session = {
+    accessToken: string;
+    userId: number;
+};
+
 class Auth {
     private _context: vscode.ExtensionContext;
+
+    private _session?: Session;
+
+    private _validating = new Map<string, Promise<Session | undefined>>();
+
+    private _login?: Promise<string>;
+
+    private _reload?: Promise<void>;
 
     constructor(context: vscode.ExtensionContext) {
         this._context = context;
@@ -19,7 +32,15 @@ class Auth {
     }
 
     async clearAccessToken() {
+        this._clear();
         await this._context.secrets.delete(`${NAME}.accessToken`);
+    }
+
+    private _clear() {
+        this._session = undefined;
+        this._validating.clear();
+        this._login = undefined;
+        this._reload = undefined;
     }
 
     async getClient(manual = false) {
@@ -35,19 +56,19 @@ class Auth {
                 }
             }
 
-            const rest = new Rest({
-                url: API_URL,
-                origin: HOME_URL,
-                accessToken
-            });
-            const [error, userId] = await tryCatch(rest.id());
-            if (!error) {
-                return { accessToken, rest, userId };
+            const session = await this._validateAccessToken(accessToken, false);
+            if (session) {
+                return {
+                    accessToken: session.accessToken,
+                    userId: session.userId,
+                    rest: new Rest({
+                        url: API_URL,
+                        origin: HOME_URL,
+                        accessToken: session.accessToken
+                    })
+                };
             }
-            rest.dispose();
-            if (!/HTTP 4\d{2}/.test(error.message)) {
-                throw error;
-            }
+
             await this.clearAccessToken();
             if (!manual) {
                 return;
@@ -56,22 +77,50 @@ class Auth {
         }
     }
 
-    private async _validateAccessToken(accessToken?: string) {
-        if (!accessToken) {
-            return;
-        }
+    private async _validate(accessToken: string, notify = true) {
         const rest = new Rest({
             url: API_URL,
             origin: HOME_URL,
             accessToken
         });
-        const [error] = await tryCatch(rest.id());
+        const [err, userId] = await tryCatch(rest.id());
         rest.dispose();
-        if (error && /HTTP 4\d{2}/.test(error.message)) {
-            await vscode.window.showErrorMessage('Invalid PlayCanvas Access Token', { modal: true });
-            return undefined;
+        if (!err) {
+            const session = { accessToken, userId };
+            this._session = session;
+            return session;
         }
-        return accessToken;
+        if (/HTTP 4\d{2}/.test(err.message)) {
+            if (notify) {
+                await vscode.window.showErrorMessage('Invalid PlayCanvas Access Token', { modal: true });
+            }
+            return;
+        }
+        throw err;
+    }
+
+    private async _validateAccessToken(accessToken?: string, notify = true) {
+        if (!accessToken) {
+            return;
+        }
+
+        if (this._session?.accessToken === accessToken) {
+            return this._session;
+        }
+
+        const running = this._validating.get(accessToken);
+        if (running) {
+            return running;
+        }
+
+        const task = this._validate(accessToken, notify);
+        this._validating.set(accessToken, task);
+        const [err, session] = await tryCatch(task);
+        this._validating.delete(accessToken);
+        if (err) {
+            throw err;
+        }
+        return session;
     }
 
     private _requestToken() {
@@ -187,18 +236,25 @@ class Auth {
         });
     }
 
-    async getAccessToken(manual = false, reload = manual) {
-        let accessToken: string | undefined = undefined;
-        if (!manual) {
-            // retrieve stored token
-            accessToken = await this._context.secrets.get(`${NAME}.accessToken`);
-
-            // validate token
-            accessToken = await this._validateAccessToken(accessToken);
+    private async _loginAccessToken(manual: boolean) {
+        if (this._login) {
+            return this._login;
         }
-        while (!accessToken) {
+
+        const task = this._loginFlow(manual);
+        this._login = task;
+        const [err, accessToken] = await tryCatch(task);
+        this._login = undefined;
+        if (err) {
+            throw err;
+        }
+        return accessToken;
+    }
+
+    private async _loginFlow(manual: boolean) {
+        while (true) {
             // request token
-            accessToken = await this._requestToken();
+            const accessToken = await this._requestToken();
             if (!accessToken) {
                 if (manual) {
                     void vscode.window.showInformationMessage('Aborted updating PlayCanvas Access Token');
@@ -208,22 +264,56 @@ class Auth {
             }
 
             // validate token
-            accessToken = await this._validateAccessToken(accessToken);
-            if (!accessToken) {
+            const session = await this._validateAccessToken(accessToken);
+            if (!session) {
                 continue;
             }
 
             // store token
             await this._context.secrets.store(`${NAME}.accessToken`, accessToken);
             void vscode.window.showInformationMessage('PlayCanvas Access Token validated');
+            return accessToken;
+        }
+    }
 
-            if (reload) {
-                // reload window to ensure all components use the new token
-                await vscode.window.showInformationMessage('Token updated, the window will be reloaded.', {
-                    modal: true
-                });
-                void vscode.commands.executeCommand('workbench.action.reloadWindow');
-            }
+    private async _reloadWindow() {
+        if (this._reload) {
+            return this._reload;
+        }
+
+        // reload window to ensure all components use the new token
+        const task = Promise.resolve(
+            vscode.window.showInformationMessage('Token updated, the window will be reloaded.', {
+                modal: true
+            })
+        ).then(() => {
+            void vscode.commands.executeCommand('workbench.action.reloadWindow');
+        });
+        this._reload = task;
+        const [err] = await tryCatch(task);
+        this._reload = undefined;
+        if (err) {
+            throw err;
+        }
+    }
+
+    async getAccessToken(manual = false, reload = manual) {
+        let accessToken: string | undefined = undefined;
+        if (!manual) {
+            // retrieve stored token
+            accessToken = await this._context.secrets.get(`${NAME}.accessToken`);
+
+            // validate token
+            const session = await this._validateAccessToken(accessToken);
+            accessToken = session?.accessToken;
+        }
+
+        if (!accessToken) {
+            accessToken = await this._loginAccessToken(manual);
+        }
+
+        if (accessToken && reload) {
+            await this._reloadWindow();
         }
 
         return accessToken;
@@ -238,7 +328,7 @@ class Auth {
         if (confirmed !== 'Logout') {
             return;
         }
-        await this._context.secrets.delete(`${NAME}.accessToken`);
+        await this.clearAccessToken();
         void vscode.commands.executeCommand('workbench.action.reloadWindow');
     }
 
@@ -249,7 +339,7 @@ class Auth {
                 modal: true
             }
         );
-        await this._context.secrets.delete(`${NAME}.accessToken`);
+        await this.clearAccessToken();
         void vscode.commands.executeCommand('workbench.action.reloadWindow');
     }
 }

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -56,19 +56,6 @@ class Auth {
         }
     }
 
-    async promptProjectLogin() {
-        const login = 'Login';
-        const dismiss = 'Dismiss';
-        const choice = await vscode.window.showInformationMessage(
-            'Sign in to PlayCanvas to sync this project.',
-            login,
-            dismiss
-        );
-        if (choice === login) {
-            await this.getAccessToken(true);
-        }
-    }
-
     private async _validateAccessToken(accessToken?: string) {
         if (!accessToken) {
             return;

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -153,18 +153,29 @@ export const activate = async (context: vscode.ExtensionContext) => {
         registerIdle();
         return;
     }
+
+    // connection status bar item
+    const connectionStatusItem = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Right, -10001);
+    context.subscriptions.push(connectionStatusItem);
+    connectionStatusItem.color = COLORS.error;
+    connectionStatusItem.text = `$(primitive-dot) Disconnected`;
+    connectionStatusItem.tooltip = 'PlayCanvas Connection';
+
     const [err1, client] = await tryCatch(auth.getClient(false));
     if (err1) {
         registerIdle();
+        connectionStatusItem.show();
         failure.set(() => ({ err: err1, source: 'auth' }));
         return;
     }
     if (!client) {
         registerIdle();
-        const [err2] = await tryCatch(auth.promptProjectLogin());
-        if (err2) {
-            failure.set(() => ({ err: err2, source: 'auth' }));
-        }
+        connectionStatusItem.show();
+        void tryCatch(auth.getAccessToken(true)).then(([err2]) => {
+            if (err2) {
+                failure.set(() => ({ err: err2, source: 'auth' }));
+            }
+        });
         return;
     }
     const { accessToken, rest, userId } = client;
@@ -323,12 +334,6 @@ export const activate = async (context: vscode.ExtensionContext) => {
     });
     context.subscriptions.push(vscode.window.registerFileDecorationProvider(decorationProvider));
 
-    // connection status bar item
-    const connectionStatusItem = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Right, -10001);
-    context.subscriptions.push(connectionStatusItem);
-    connectionStatusItem.color = COLORS.error;
-    connectionStatusItem.text = `$(primitive-dot) Disconnected`;
-    connectionStatusItem.tooltip = 'PlayCanvas Connection';
     const connected = computed(() => {
         return sharedb.connected.get() && messenger.connected.get() && relay.connected.get();
     });

--- a/src/handlers/uri-handler.ts
+++ b/src/handlers/uri-handler.ts
@@ -231,6 +231,10 @@ class UriHandler
     }
 
     async handleUri(uri: vscode.Uri) {
+        if (uri.authority !== `${PUBLISHER}.${NAME}` || !uri.path.startsWith('/project/')) {
+            return;
+        }
+
         if (this._auth) {
             const [err1, client] = await tryCatch(this._auth.getClient(true));
             if (err1) {

--- a/src/test/suite/extension.test.ts
+++ b/src/test/suite/extension.test.ts
@@ -17,7 +17,7 @@ import * as buffer from '../../utils/buffer';
 import { hash, tryCatch, wait } from '../../utils/utils';
 import { MockAuth } from '../mocks/auth';
 import { MockMessenger } from '../mocks/messenger';
-import { assets, documents, branches, projectSettings, project, user, uniqueId } from '../mocks/models';
+import { assets, documents, branches, projectSettings, project, user, accessToken, uniqueId } from '../mocks/models';
 import { MockRelay } from '../mocks/relay';
 import { MockRest } from '../mocks/rest';
 import { MockShareDb } from '../mocks/sharedb';
@@ -278,6 +278,61 @@ suite('extension', () => {
         assert.ok(errorCall, 'openProject failure should be handled by handleError');
     });
 
+    test('auth caches user id validation', async () => {
+        const RealAuth = (authModule.Auth as unknown as sinon.SinonStub)
+            .wrappedMethod as unknown as typeof authModule.Auth;
+        const secrets = new Map([[`${NAME}.accessToken`, accessToken]]);
+        const a = new RealAuth({
+            secrets: {
+                get: sandbox.spy(async (key: string) => secrets.get(key)),
+                store: sandbox.spy(async (key: string, value: string) => {
+                    secrets.set(key, value);
+                }),
+                delete: sandbox.spy(async (key: string) => {
+                    secrets.delete(key);
+                })
+            }
+        } as unknown as vscode.ExtensionContext);
+
+        rest.id.resetHistory();
+        const clients = await Promise.all([a.getClient(), a.getClient(), a.getClient()]);
+
+        assert.strictEqual(rest.id.callCount, 1, 'id should be validated once');
+        assert.deepStrictEqual(
+            clients.map((client) => client?.userId),
+            [user.id, user.id, user.id],
+            'clients should reuse cached user id'
+        );
+    });
+
+    test('auth dedupes concurrent login', async () => {
+        const RealAuth = (authModule.Auth as unknown as sinon.SinonStub)
+            .wrappedMethod as unknown as typeof authModule.Auth;
+        const secrets = new Map<string, string>();
+        const a = new RealAuth({
+            secrets: {
+                get: sandbox.spy(async (key: string) => secrets.get(key)),
+                store: sandbox.spy(async (key: string, value: string) => {
+                    secrets.set(key, value);
+                }),
+                delete: sandbox.spy(async (key: string) => {
+                    secrets.delete(key);
+                })
+            }
+        } as unknown as vscode.ExtensionContext);
+        const requestTokenStub = sandbox
+            .stub(a as unknown as Record<'_requestToken', () => Promise<string>>, '_requestToken')
+            .resolves(accessToken);
+
+        rest.id.resetHistory();
+        infoMessageStub.resetHistory();
+        const tokens = await Promise.all([a.getAccessToken(true, false), a.getAccessToken(true, false)]);
+
+        assert.deepStrictEqual(tokens, [accessToken, accessToken], 'login callers should share token');
+        assert.strictEqual(requestTokenStub.callCount, 1, 'external login should start once');
+        assert.strictEqual(rest.id.callCount, 1, 'login token should be validated once');
+    });
+
     test(`command ${NAME}.switchBranch`, async () => {
         // reset rest branchCheckout spy call history
         rest.branchCheckout.resetHistory();
@@ -462,6 +517,27 @@ suite('extension', () => {
         // check if uri handler was called
         const call = uriHandler.handleUri.getCall(0);
         assert.strictEqual(call.args[0].toString(), externalUri.toString(), 'uri handler args should match');
+    });
+
+    test('uri callback does not authenticate', async () => {
+        const RealUriHandler = (uriHandlerModule.UriHandler as unknown as sinon.SinonStub)
+            .wrappedMethod as unknown as typeof uriHandlerModule.UriHandler;
+        const subscriptions: vscode.Disposable[] = [];
+        const getClient = sandbox.spy(async () => undefined);
+        const h = new RealUriHandler({
+            context: { subscriptions } as unknown as vscode.ExtensionContext,
+            rootUri: vscode.Uri.parse('vscode-test://root'),
+            auth: { getClient } as unknown as InstanceType<typeof authModule.Auth>
+        });
+        const uri = vscode.Uri.from({
+            scheme: vscode.env.uriScheme,
+            authority: `${PUBLISHER}.${NAME}`
+        });
+
+        await h.handleUri(uri);
+
+        assert.ok(getClient.notCalled, 'oauth callback uri should not request auth');
+        subscriptions.forEach((d) => d.dispose());
     });
 
     test('uri open - collision warning', async () => {


### PR DESCRIPTION
### What's Changed

- Show the PlayCanvas disconnected status in signed-out project windows.
- Start the existing external sign-in flow without the extra in-app prompt.
- De-dupe per-window auth validation/login and ignore OAuth callback URIs before auth.

### Testing

Manual tests: not run