### PR TITLE
test: improve backend mock fidelity

### DIFF
--- a/src/test/mocks/models.ts
+++ b/src/test/mocks/models.ts
@@ -75,3 +75,18 @@ export const uniqueId = (function* () {
         yield id++;
     }
 })();
+
+export const assetItemId = (function* () {
+    let id = 1000;
+    while (true) {
+        yield id++;
+    }
+})();
+
+export const nextAssetIds = (distinct = false) => {
+    const id = uniqueId.next().value;
+    return {
+        uniqueId: id,
+        itemId: distinct ? assetItemId.next().value : id
+    };
+};

--- a/src/test/mocks/rest.ts
+++ b/src/test/mocks/rest.ts
@@ -7,7 +7,7 @@ import type { Asset, Branch, Project, User } from '../../typings/models';
 import { hash } from '../../utils/utils';
 
 import type { MockMessenger } from './messenger';
-import { user, project, assets, branches, documents, accessToken, uniqueId } from './models';
+import { user, project, assets, branches, documents, accessToken, nextAssetIds, projectSettings } from './models';
 import type { MockShareDb } from './sharedb';
 
 class MockRest extends Rest {
@@ -43,6 +43,18 @@ class MockRest extends Rest {
 
     assetFile: sinon.SinonSpy<[number, string, string], Promise<ArrayBuffer>>;
 
+    delayAssetFiles = false;
+
+    assetFileDelay = 0;
+
+    emitBranchSwitch = false;
+
+    branchSwitchDelay = 0;
+
+    distinctAssetIds = false;
+
+    assetEndpointsUseItemIds = false;
+
     // FIFO of errors to throw on the next N calls of a given method. mirrors a final
     // post-retry failure from src/connections/rest.ts (MAX_RETRIES=3) — exercises the
     // ProjectManager error/guard path without simulating the retry loop itself.
@@ -69,6 +81,12 @@ class MockRest extends Rest {
 
     resetFailures() {
         this._failures.clear();
+        this.delayAssetFiles = false;
+        this.assetFileDelay = 0;
+        this.emitBranchSwitch = false;
+        this.branchSwitchDelay = 0;
+        this.distinctAssetIds = false;
+        this.assetEndpointsUseItemIds = false;
     }
 
     private _maybeFail(method: string) {
@@ -76,6 +94,13 @@ class MockRest extends Rest {
         if (err) {
             throw err;
         }
+    }
+
+    private _asset(id: number) {
+        if (this.assetEndpointsUseItemIds) {
+            return Array.from(assets.values()).find((asset) => parseInt(asset.item_id, 10) === id);
+        }
+        return assets.get(id) ?? Array.from(assets.values()).find((asset) => parseInt(asset.item_id, 10) === id);
     }
 
     constructor(sandbox: sinon.SinonSandbox, messenger: MockMessenger, sharedb: MockShareDb) {
@@ -111,7 +136,20 @@ class MockRest extends Rest {
         });
         this.branchCheckout = sandbox.spy(async (branchId: string) => {
             this._maybeFail('branchCheckout');
-            return branches.get(branchId)!;
+            const branch = branches.get(branchId)!;
+            if (this.emitBranchSwitch) {
+                projectSettings.branch = branch.id;
+                setTimeout(() => {
+                    messenger.emit('branch.switch', {
+                        data: {
+                            branch_id: branch.id,
+                            project_id: branch.projectId,
+                            name: branch.name
+                        }
+                    });
+                }, this.branchSwitchDelay);
+            }
+            return branch;
         });
         this.assetCreate = sandbox.spy(
             async (
@@ -130,34 +168,37 @@ class MockRest extends Rest {
                 // calculate path
                 let path: number[] = [];
                 if (data.parent) {
-                    const asset = assets.get(data.parent);
+                    const asset = this._asset(data.parent);
                     if (!asset) {
                         throw new Error(`parent asset with ID ${data.parent} not found`);
                     }
-                    path = asset.path.concat(data.parent);
+                    path = asset.path.concat(parseInt(asset.item_id, 10));
                 }
 
                 // add new asset to assets map
-                const id = uniqueId.next().value;
+                const ids = nextAssetIds(this.distinctAssetIds);
                 const document = data.file ? await data.file.text() : '';
+                const file =
+                    data.type === 'folder'
+                        ? undefined
+                        : {
+                              filename: data.filename || data.name,
+                              hash: hash(document)
+                          };
                 const asset: Asset = {
-                    uniqueId: id,
-                    item_id: `${id}`,
-                    file:
-                        data.type === 'folder'
-                            ? undefined
-                            : {
-                                  filename: data.filename || data.name,
-                                  hash: hash(document)
-                              },
+                    uniqueId: ids.uniqueId,
+                    item_id: `${ids.itemId}`,
+                    file: this.delayAssetFiles ? undefined : file,
                     type: data.type,
                     path,
                     name: data.name
                 };
-                assets.set(id, asset);
+                assets.set(asset.uniqueId, asset);
 
                 // add document to documents map
-                documents.set(asset.uniqueId, document);
+                if (!this.delayAssetFiles) {
+                    documents.set(asset.uniqueId, document);
+                }
 
                 // call messenger assetCreated signal
                 messenger.emit('asset.new', {
@@ -171,18 +212,30 @@ class MockRest extends Rest {
                     }
                 });
 
+                if (this.delayAssetFiles && file) {
+                    setTimeout(() => {
+                        documents.set(asset.uniqueId, document);
+                        const doc = sharedb.subscriptions.get(`assets:${asset.uniqueId}`);
+                        if (doc) {
+                            doc.submitOp([{ p: ['file'], od: null, oi: file }], { source: 'remote' });
+                        } else {
+                            asset.file = file;
+                        }
+                    }, this.assetFileDelay);
+                }
+
                 return asset;
             }
         );
         this.assetRename = sandbox.spy(async (_projectId: number, _branchId: string, assetId: number, name: string) => {
             this._maybeFail('assetRename');
             // find asset and document
-            const asset = assets.get(assetId);
+            const asset = this._asset(assetId);
             assert(asset, `asset with ID ${assetId} not found`);
 
             // rename asset
             asset.name = name;
-            assets.set(assetId, asset);
+            assets.set(asset.uniqueId, asset);
 
             // fire sharedb op on document
             const doc = sharedb.subscriptions.get(`assets:${asset.uniqueId}`);
@@ -202,7 +255,8 @@ class MockRest extends Rest {
         });
         this.assetFile = sandbox.spy(async (assetId: number, _branchId: string, _filename: string) => {
             this._maybeFail('assetFile');
-            const content = documents.get(assetId) ?? '';
+            const asset = this._asset(assetId);
+            const content = documents.get(asset?.uniqueId ?? assetId) ?? '';
             return new TextEncoder().encode(content).buffer;
         });
     }

--- a/src/test/mocks/sharedb.ts
+++ b/src/test/mocks/sharedb.ts
@@ -6,6 +6,7 @@ import type { Snapshot, Callback, ShareDBSourceOptions, DocEventMap, Error } fro
 import type sinon from 'sinon';
 
 import { ShareDb } from '../../connections/sharedb';
+import type { Asset } from '../../typings/models';
 import type { ShareDbOp, ShareDbTextOp } from '../../typings/sharedb';
 
 import type { MockMessenger } from './messenger';
@@ -246,7 +247,8 @@ class MockDoc extends Doc {
             events.emit('load');
         };
         this.destroy = sandbox.spy(() => {
-            return;
+            this.subscribed = false;
+            events.emit('destroy');
         });
         this.pause = sandbox.spy(() => {
             return;
@@ -256,6 +258,13 @@ class MockDoc extends Doc {
         });
         this.hasPending = () => this._pending > 0;
         this.hasWritePending = () => this._pending > 0;
+        this.whenNothingPending = (callback: () => void) => {
+            if (this._pending === 0) {
+                callback();
+                return;
+            }
+            events.once('no write pending', callback);
+        };
         this.submitOp = sandbox.spy((op: unknown, options?: { source: string }, callback?: (err?: Error) => void) => {
             this._pending++;
             const apply = () => {
@@ -321,6 +330,12 @@ class MockShareDb extends ShareDb {
 
     resetAdversarial!: () => void;
 
+    fsCascadeDeletes = false;
+
+    fsProductionMoveOps = false;
+
+    closedDocuments = new Set<number>();
+
     // FIFO of save responses to inject per uniqueId. empty queue → emit 'success'
     // (today's default). drives ProjectManager._verifySave's retry path
     // (src/project-manager.ts:399-422), which re-sends doc:reconnect + doc:save.
@@ -332,6 +347,57 @@ class MockShareDb extends ShareDb {
             q.push('error');
         }
         this.saveResponses.set(uniqueId, q);
+    }
+
+    private _collectDeletes(ids: number[]) {
+        const deleted = new Set(ids);
+        if (!this.fsCascadeDeletes) {
+            return deleted;
+        }
+
+        const itemIds = new Set(
+            ids
+                .map((id) => assets.get(id)?.item_id)
+                .filter((id): id is string => id !== undefined)
+                .map((id) => parseInt(id, 10))
+        );
+        for (const asset of assets.values()) {
+            if (asset.path.some((id) => itemIds.has(id))) {
+                deleted.add(asset.uniqueId);
+            }
+        }
+        return deleted;
+    }
+
+    private _folderPath(to: number) {
+        if (to === 0) {
+            return [];
+        }
+        const parent = assets.get(to);
+        return parent ? parent.path.concat(parseInt(parent.item_id, 10)) : [];
+    }
+
+    private _moveOp(asset: Asset, from: number[], to: number[]) {
+        if (this.fsProductionMoveOps) {
+            return [{ p: ['path'], od: from, oi: to }];
+        }
+        if (from.length === 0 && to.length === 1) {
+            return [{ p: ['path'], li: to[0] }];
+        }
+        if (from.length === 1 && to.length === 0) {
+            return [{ p: ['path'], ld: from[0] }];
+        }
+        if (from.length === 1 && to.length === 1) {
+            return [{ p: ['path'], ld: from[0], li: to[0] }];
+        }
+        asset.path = to;
+        return [];
+    }
+
+    private _reconnectDocument(id: number) {
+        this.closedDocuments.delete(id);
+        const doc = this.subscriptions.get(`documents:${id}`);
+        doc?.reload(documents.get(id) ?? '');
     }
 
     constructor(sandbox: sinon.SinonSandbox, messenger: MockMessenger) {
@@ -352,6 +418,7 @@ class MockShareDb extends ShareDb {
             return Promise.all(subscriptions.map(([type, key]) => this.subscribe(type, key)));
         });
         this.unsubscribe = sandbox.spy(async (type: string, key: string) => {
+            this.subscriptions.get(`${type}:${key}`)?.destroy();
             this.subscriptions.delete(`${type}:${key}`);
         });
         this.bulkUnsubscribe = sandbox.spy(async (subscriptions: [string, string][]) => {
@@ -366,6 +433,9 @@ class MockShareDb extends ShareDb {
                 doc._rejectNext = null;
             }
             this.saveResponses.clear();
+            this.fsCascadeDeletes = false;
+            this.fsProductionMoveOps = false;
+            this.closedDocuments.clear();
         };
         this.sendRaw = sandbox.spy(async (data: Parameters<WebSocket['send']>[0]) => {
             // check for fs operations
@@ -377,13 +447,14 @@ class MockShareDb extends ShareDb {
 
                 // handle delete operation
                 if (json.op === 'delete') {
-                    for (const id of json.ids) {
+                    const ids = this._collectDeletes(json.ids);
+                    for (const id of ids) {
                         assets.delete(id);
                         documents.delete(id);
                     }
                     messenger.emit('assets.delete', {
                         data: {
-                            assets: json.ids.map((id) => id.toString())
+                            assets: Array.from(ids).map((id) => id.toString())
                         }
                     });
                     return;
@@ -395,21 +466,13 @@ class MockShareDb extends ShareDb {
                         const asset = assets.get(id);
                         if (asset) {
                             const path = asset.path.slice();
-                            asset.path = json.to === 0 ? [] : [json.to];
+                            const next = this._folderPath(json.to);
+                            const op = this._moveOp(asset, path, next);
                             const doc = this.subscriptions.get(`assets:${id}`);
-                            if (doc) {
-                                if (path.length === 0 && asset.path.length === 1) {
-                                    // moved into folder
-                                    doc.submitOp([{ p: ['path'], li: asset.path[0] }], { source: 'remote' });
-                                } else if (path.length === 1 && asset.path.length === 0) {
-                                    // moved out of folder
-                                    doc.submitOp([{ p: ['path'], ld: path[0] }], { source: 'remote' });
-                                } else if (path.length === 1 && asset.path.length === 1) {
-                                    // moved between folders
-                                    doc.submitOp([{ p: ['path'], ld: path[0], li: asset.path[0] }], {
-                                        source: 'remote'
-                                    });
-                                }
+                            if (doc && op.length) {
+                                doc.submitOp(op, { source: 'remote' });
+                            } else {
+                                asset.path = next;
                             }
                         }
                     }
@@ -425,6 +488,20 @@ class MockShareDb extends ShareDb {
                 const q = this.saveResponses.get(id);
                 const state = q?.shift() ?? 'success';
                 this.emit('doc:save', state, id);
+                return;
+            }
+            if (`${data}`.startsWith('doc:reconnect:')) {
+                const id = parseInt(data.toString().slice(14), 10);
+                if (!isNaN(id)) {
+                    this._reconnectDocument(id);
+                }
+                return;
+            }
+            if (`${data}`.startsWith('close:document:')) {
+                const id = parseInt(data.toString().slice(15), 10);
+                if (!isNaN(id)) {
+                    this.closedDocuments.add(id);
+                }
                 return;
             }
             return;


### PR DESCRIPTION
### What's Changed

- Improve backend mock fidelity for delayed asset file readiness, branch switch messages, distinct asset IDs, and item-id endpoint lookup.
- Add ShareDB mock hooks for pending callbacks, close/reconnect document messages, cascade deletes, and production-shaped move ops.

Manual tests: not run
