### PR TITLE
test: add docker compose test runner

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,9 @@
+/.DS_Store
+/.git
+/.vscode-test
+/.vscode-storage
+/coverage
+/node_modules
+/out
+*.vsix
+**/node_modules

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,38 @@
+FROM node:22-bookworm
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        ca-certificates \
+        git \
+        libasound2 \
+        libatk-bridge2.0-0 \
+        libatk1.0-0 \
+        libcups2 \
+        libdrm2 \
+        libgbm1 \
+        libgtk-3-0 \
+        libnss3 \
+        libsecret-1-0 \
+        libx11-xcb1 \
+        libxcb1 \
+        libxcomposite1 \
+        libxdamage1 \
+        libxkbfile1 \
+        libxrandr2 \
+        libxshmfence1 \
+        libxss1 \
+        xauth \
+        xvfb \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /work
+
+COPY package.json package-lock.json ./
+COPY plugin ./plugin
+RUN npm ci
+
+COPY . .
+
+CMD ["bash", "-lc", "xvfb-run -a --server-args=\"-screen 0 1024x768x24\" npm test"]

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,0 +1,14 @@
+services:
+    tests:
+        build:
+            context: .
+        platform: ${TEST_DOCKER_PLATFORM:-linux/amd64}
+        init: true
+        tmpfs:
+            - /work/.vscode-storage
+            - /work/out
+        volumes:
+            - vscode-test:/work/.vscode-test
+
+volumes:
+    vscode-test:

--- a/src/test/suite/extension.test.ts
+++ b/src/test/suite/extension.test.ts
@@ -189,7 +189,7 @@ suite('extension', () => {
         // get consumed by the next test's first call.
         rest.resetFailures();
         // settle deferred queue / mutex between tests
-        await wait(process.env.CI ? 2000 : 50);
+        await wait(process.env.CI ? 500 : 50);
     });
 
     const assetCreate = async ({ name, content = '', parent }: { name: string; content?: string; parent?: number }) => {

--- a/src/test/suite/extension.test.ts
+++ b/src/test/suite/extension.test.ts
@@ -189,7 +189,7 @@ suite('extension', () => {
         // get consumed by the next test's first call.
         rest.resetFailures();
         // settle deferred queue / mutex between tests
-        await wait(process.env.CI ? 500 : 50);
+        await wait(process.env.CI ? 250 : 50);
     });
 
     const assetCreate = async ({ name, content = '', parent }: { name: string; content?: string; parent?: number }) => {


### PR DESCRIPTION
### What's Changed

- Add a Docker Compose service for running the full VS Code extension test suite in Linux under Xvfb.
- Cache the downloaded VS Code test install in a named Docker volume.
- Reduce the CI teardown drain from 2s to 250ms.

Manual tests: Docker Compose run verified locally.