### PR TITLE
feat: install playcanvas types at runtime

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,8 +21,8 @@
     "browser": "./out/browser.js",
     "scripts": {
         "build": "node ./scripts/build.mjs",
-        "compile": "tsc -p .",
-        "compile:plugin": "tsc -p ./plugin && node ./scripts/playcanvas-dts.mjs",
+        "compile": "tsc -p . && node ./scripts/playcanvas-dts.mjs",
+        "compile:plugin": "tsc -p ./plugin",
         "compile:web": "rollup -c",
         "lint": "prettier --check . && eslint .",
         "lint:fix": "prettier --write . && eslint --fix .",
@@ -30,7 +30,7 @@
         "test": "vscode-test",
         "test:web": "vscode-test-web --extensionDevelopmentPath=.",
         "watch": "tsc -watch -p ./",
-        "watch:plugin": "tsc -watch -p ./plugin && node ./scripts/playcanvas-dts.mjs",
+        "watch:plugin": "tsc -watch -p ./plugin",
         "watch:web": "rollup -c -w"
     },
     "contributes": {

--- a/plugin/package.json
+++ b/plugin/package.json
@@ -11,7 +11,7 @@
     "type": "commonjs",
     "main": "out/index.js",
     "files": [
-        "out"
+        "out/index.js.map"
     ],
     "dependencies": {
         "typescript": "*"

--- a/plugin/src/index.ts
+++ b/plugin/src/index.ts
@@ -1,15 +1,8 @@
-import fs from 'fs';
 import path from 'path';
 
 import type * as ts from 'typescript/lib/tsserverlibrary';
 
-const FILES = new Map([
-    // global pc namespace
-    ['.pc/globals.d.ts', fs.readFileSync(path.join(__dirname, 'playcanvas.d.ts'), 'utf8')],
-
-    // 'playcanvas' module declaration
-    ['.pc/module.d.ts', 'declare module "playcanvas" { export = pc; }\n']
-]);
+const FILES = ['.pc/globals.d.ts', '.pc/module.d.ts'];
 
 const PROJECT_REGEX = /playcanvas\.playcanvas\/\w+\/.+ \(\d+\)/;
 
@@ -36,15 +29,7 @@ const init = (modules: { typescript: typeof ts }): ts.server.PluginModule => {
         }
         log(info.project, `Initializing plugin ${projectDir}`);
 
-        // add virtual file paths
-        const paths: string[] = [];
-        for (const [name] of FILES) {
-            paths.push(ts.server.toNormalizedPath(path.join(projectDir, name)));
-        }
-
         const proxy = info.languageServiceHost;
-        const getScriptSnapshot = proxy.getScriptSnapshot.bind(proxy);
-        const readFile = proxy.readFile.bind(proxy);
         const getCompilationSettings = proxy.getCompilationSettings.bind(proxy);
 
         // project tsconfig wins over plugin defaults; cache by settings
@@ -59,26 +44,6 @@ const init = (modules: { typescript: typeof ts }): ts.server.PluginModule => {
             merged.lib = [...(compilerOptions.lib ?? []), ...(settings.lib ?? [])];
             cache = { settings, merged };
             return merged;
-        };
-
-        // intercept getScriptSnapshot to provide a snapshot for the virtual file
-        proxy.getScriptSnapshot = (fileName) => {
-            if (paths.includes(fileName)) {
-                log(info.project, `Providing snapshot for virtual file: ${fileName}`);
-                const rel = path.relative(projectDir, fileName).replace(/\\/g, '/');
-                return ts.ScriptSnapshot.fromString(FILES.get(rel)!);
-            }
-            return getScriptSnapshot(fileName);
-        };
-
-        // intercept readFile to provide content for the virtual file
-        proxy.readFile = (fileName, encoding) => {
-            if (paths.includes(fileName)) {
-                log(info.project, `Reading content for virtual file: ${fileName}`);
-                const rel = path.relative(projectDir, fileName).replace(/\\/g, '/');
-                return FILES.get(rel)!;
-            }
-            return readFile(fileName, encoding);
         };
 
         return info.languageService;
@@ -99,11 +64,12 @@ const init = (modules: { typescript: typeof ts }): ts.server.PluginModule => {
         // openClientFile registers ScriptInfo so ambient module declarations resolve.
         // the /.pc guard above prevents the re-entrant project creation this used to cause.
         const paths: string[] = [];
-        for (const [name, content] of FILES) {
+        for (const name of FILES) {
             const filePath = ts.server.toNormalizedPath(path.join(projectDir, name));
             if (!project.containsFile(filePath)) {
-                log(project, `registering virtual file: ${filePath}`);
-                project.projectService.openClientFile(filePath, content, ts.ScriptKind.TS);
+                // undefined content makes tsserver read the physical .pc file from disk
+                log(project, `registering type file: ${filePath}`);
+                project.projectService.openClientFile(filePath, undefined, ts.ScriptKind.TS);
             }
             paths.push(filePath);
         }

--- a/scripts/playcanvas-dts.mjs
+++ b/scripts/playcanvas-dts.mjs
@@ -1,4 +1,4 @@
 import fs from 'fs';
 
-await fs.promises.mkdir('plugin/out', { recursive: true });
-await fs.promises.copyFile('node_modules/playcanvas/build/playcanvas.d.ts', 'plugin/out/playcanvas.d.ts');
+await fs.promises.mkdir('out', { recursive: true });
+await fs.promises.copyFile('node_modules/playcanvas/build/playcanvas.d.ts', 'out/playcanvas.d.ts');

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -2,7 +2,7 @@ import http from 'http';
 
 import * as vscode from 'vscode';
 
-import { API_URL, COOKIE_NAME, NAME, PUBLISHER, HOME_URL, LOGIN_URL, PORT, WEB } from './config';
+import { API_URL, COOKIE_NAME, NAME, PUBLISHER, HOME_URL, LOGIN_URL, PLAYCANVAS_VERSION, PORT, WEB } from './config';
 import { AUTH_TIMEOUT_MS } from './connections/constants';
 import { Rest } from './connections/rest';
 import { tryCatch } from './utils/utils';
@@ -10,6 +10,23 @@ import { tryCatch } from './utils/utils';
 type Session = {
     accessToken: string;
     userId: number;
+};
+
+type EditorConfig = {
+    engineVersion: string;
+};
+
+const SESSION_ID_KEY = `${NAME}.sessionId`;
+const ENGINE_VERSION_KEY = `${NAME}.engineVersion`;
+const EDITOR_CONFIG_TTL_MS = 5 * 60 * 1000;
+
+export const parseEditorConfig = (text: string) => {
+    const accessToken = /["']accessToken["']\s*:\s*["']([^"']+)["']/.exec(text)?.[1];
+    const engineVersion =
+        /["']?engineVersions["']?\s*:\s*\{[\s\S]*?["']?current["']?\s*:\s*\{[\s\S]*?["']?version["']?\s*:\s*["']([^"']+)["']/.exec(
+            text
+        )?.[1];
+    return { accessToken, engineVersion };
 };
 
 class Auth {
@@ -23,6 +40,10 @@ class Auth {
 
     private _reload?: Promise<void>;
 
+    private _config?: { engineVersion: string; ts: number };
+
+    private _configReq?: Promise<EditorConfig>;
+
     constructor(context: vscode.ExtensionContext) {
         this._context = context;
     }
@@ -34,6 +55,7 @@ class Auth {
     async clearAccessToken() {
         this._clear();
         await this._context.secrets.delete(`${NAME}.accessToken`);
+        await this._context.secrets.delete(SESSION_ID_KEY);
     }
 
     private _clear() {
@@ -41,6 +63,75 @@ class Auth {
         this._validating.clear();
         this._login = undefined;
         this._reload = undefined;
+        this._configReq = undefined;
+    }
+
+    private async _cachedEngineVersion() {
+        if (this._config) {
+            return this._config.engineVersion;
+        }
+        const version = this._context.globalState?.get<string>(ENGINE_VERSION_KEY);
+        return version || PLAYCANVAS_VERSION;
+    }
+
+    private async _storeEngineVersion(engineVersion?: string) {
+        if (!engineVersion) {
+            return;
+        }
+        this._config = { engineVersion, ts: Date.now() };
+        await this._context.globalState?.update(ENGINE_VERSION_KEY, engineVersion);
+    }
+
+    private async _fetchEditorConfig(sessionId: string) {
+        const current = await this._cachedEngineVersion();
+        const ctrl = new AbortController();
+        const timer = setTimeout(() => ctrl.abort(), AUTH_TIMEOUT_MS);
+        const [fetchErr, res] = await tryCatch(
+            fetch(`${HOME_URL}/editor`, {
+                headers: {
+                    Cookie: `${COOKIE_NAME}=${sessionId}`
+                },
+                signal: ctrl.signal
+            }) as Promise<Response>
+        );
+        clearTimeout(timer);
+        if (fetchErr || !res.ok) {
+            return { engineVersion: current };
+        }
+
+        const [textErr, text] = await tryCatch(res.text() as Promise<string>);
+        if (textErr) {
+            return { engineVersion: current };
+        }
+
+        const { engineVersion } = parseEditorConfig(text);
+        await this._storeEngineVersion(engineVersion);
+        return { engineVersion: engineVersion || current };
+    }
+
+    async getEditorConfig() {
+        const cached = this._config;
+        if (cached && Date.now() - cached.ts < EDITOR_CONFIG_TTL_MS) {
+            return { engineVersion: cached.engineVersion };
+        }
+
+        const sessionId = await this._context.secrets.get(SESSION_ID_KEY);
+        if (!sessionId || WEB) {
+            return { engineVersion: await this._cachedEngineVersion() };
+        }
+
+        if (this._configReq) {
+            return this._configReq;
+        }
+
+        const task = this._fetchEditorConfig(sessionId);
+        this._configReq = task;
+        const [err, config] = await tryCatch(task);
+        this._configReq = undefined;
+        if (err) {
+            return { engineVersion: await this._cachedEngineVersion() };
+        }
+        return config;
     }
 
     async getClient(manual = false) {
@@ -194,8 +285,7 @@ class Auth {
                         return;
                     }
                     const text = await res3.text();
-                    const matches = /"accessToken":\s*"(\w+)"/.exec(text);
-                    const accessToken = matches?.[1];
+                    const { accessToken, engineVersion } = parseEditorConfig(text);
                     if (!accessToken) {
                         res.writeHead(500, { 'Content-Type': 'text/plain' });
                         res.end('Failed to parse access token.');
@@ -205,6 +295,8 @@ class Auth {
                         reject(new Error('Failed to parse access token.'));
                         return;
                     }
+                    await this._context.secrets.store(SESSION_ID_KEY, sessionId);
+                    await this._storeEngineVersion(engineVersion);
 
                     // resolve access token
                     clearTimeout(timeout);

--- a/src/config.ts
+++ b/src/config.ts
@@ -3,6 +3,7 @@ import packageJson from '../package.json';
 export const NAME = packageJson.name;
 export const PUBLISHER = packageJson.publisher.toLowerCase();
 export const VERSION = packageJson.version;
+export const PLAYCANVAS_VERSION = packageJson.devDependencies.playcanvas;
 
 export const DEBUG = process.env.NODE_ENV === 'development';
 export const ENV = process.env.ENV || 'prod';

--- a/src/disk.ts
+++ b/src/disk.ts
@@ -5,6 +5,7 @@ import * as vscode from 'vscode';
 import { NAME } from './config';
 import { progressNotification } from './notification';
 import type { ProjectManager } from './project-manager';
+import type { TypeFiles } from './type-installer';
 import type { EventMap } from './typings/event-map';
 import type { ShareDbTextOp } from './typings/sharedb';
 import { UndoManager } from './undo-manager';
@@ -73,7 +74,7 @@ const pathsRelated = (path1: string, path2: string): boolean => {
     return false;
 };
 
-class Disk extends Linker<{ folderUri: vscode.Uri; projectManager: ProjectManager }> {
+class Disk extends Linker<{ folderUri: vscode.Uri; projectManager: ProjectManager; types: TypeFiles }> {
     static IGNORE_FILE = '.pcignore';
 
     static TYPE_DIR = '.pc';
@@ -117,15 +118,12 @@ class Disk extends Linker<{ folderUri: vscode.Uri; projectManager: ProjectManage
 
     error = signal<Error | undefined>(undefined);
 
-    private _extensionUri: vscode.Uri;
+    private _types?: TypeFiles;
 
-    private _dts?: { globals: Uint8Array; module: Uint8Array };
-
-    constructor({ events, extensionUri }: { events: EventEmitter<EventMap>; extensionUri: vscode.Uri }) {
+    constructor({ events }: { events: EventEmitter<EventMap> }) {
         super();
 
         this._events = events;
-        this._extensionUri = extensionUri;
     }
 
     private _checkIgnoreUpdated(uri: vscode.Uri, deleted = false) {
@@ -183,24 +181,18 @@ class Disk extends Linker<{ folderUri: vscode.Uri; projectManager: ProjectManage
         }
     }
 
-    private async _writeTypeFiles(folderUri: vscode.Uri) {
-        if (!this._dts) {
-            const dtsUri = vscode.Uri.joinPath(
-                this._extensionUri,
-                'node_modules',
-                'playcanvas-plugin',
-                'out',
-                'playcanvas.d.ts'
-            );
-            const [err, content] = await tryCatch(vscode.workspace.fs.readFile(dtsUri) as Promise<Uint8Array>);
-            if (err) {
-                this._log.warn('failed to read playcanvas.d.ts', err);
-                return;
-            }
-            this._dts = {
-                globals: content,
-                module: buffer.from('declare module "playcanvas" { export = pc; }\n')
-            };
+    private async _sameFile(uri: vscode.Uri, content: Uint8Array) {
+        const [err, current] = await tryCatch(vscode.workspace.fs.readFile(uri) as Promise<Uint8Array>);
+        if (err) {
+            return false;
+        }
+        return hash(current) === hash(content);
+    }
+
+    private async _writeTypeFiles(folderUri: vscode.Uri, types = this._types) {
+        if (!types) {
+            this._log.warn('failed to write playcanvas types: no type files loaded');
+            return;
         }
 
         const dirUri = vscode.Uri.joinPath(folderUri, Disk.TYPE_DIR);
@@ -209,17 +201,27 @@ class Disk extends Linker<{ folderUri: vscode.Uri; projectManager: ProjectManage
 
         // global pc namespace types
         const globalsUri = vscode.Uri.joinPath(dirUri, 'globals.d.ts');
-        this._echo.set(`${globalsUri}:create`, '');
-        this._echo.set(`${globalsUri}:change`, hash(this._dts.globals));
-        await vscode.workspace.fs.writeFile(globalsUri, this._dts.globals);
+        const globalsChanged = !(await this._sameFile(globalsUri, types.globals));
+        if (globalsChanged) {
+            this._echo.set(`${globalsUri}:create`, '');
+            this._echo.set(`${globalsUri}:change`, hash(types.globals));
+            await vscode.workspace.fs.writeFile(globalsUri, types.globals);
+        }
 
         // 'playcanvas' module declaration (must be separate — script file referencing global pc)
         const moduleUri = vscode.Uri.joinPath(dirUri, 'module.d.ts');
-        this._echo.set(`${moduleUri}:create`, '');
-        this._echo.set(`${moduleUri}:change`, hash(this._dts.module));
-        await vscode.workspace.fs.writeFile(moduleUri, this._dts.module);
+        const moduleChanged = !(await this._sameFile(moduleUri, types.module));
+        if (moduleChanged) {
+            this._echo.set(`${moduleUri}:create`, '');
+            this._echo.set(`${moduleUri}:change`, hash(types.module));
+            await vscode.workspace.fs.writeFile(moduleUri, types.module);
+        }
 
-        this._log.debug('wrote type files to .pc/');
+        if (globalsChanged || moduleChanged) {
+            void tryCatch(vscode.commands.executeCommand('typescript.restartTsServer') as Promise<unknown>);
+        }
+
+        this._log.debug(`wrote type files to .pc/ (${types.version}${types.fallback ? ', fallback' : ''})`);
     }
 
     private _create(uri: vscode.Uri, type: 'file' | 'folder', content: Uint8Array) {
@@ -1422,7 +1424,15 @@ class Disk extends Linker<{ folderUri: vscode.Uri; projectManager: ProjectManage
         };
     }
 
-    async link({ folderUri, projectManager }: { folderUri: vscode.Uri; projectManager: ProjectManager }) {
+    async link({
+        folderUri,
+        projectManager,
+        types
+    }: {
+        folderUri: vscode.Uri;
+        projectManager: ProjectManager;
+        types: TypeFiles;
+    }) {
         if (this._folderUri !== undefined) {
             throw this.error.set(() => fail`manager already linked`);
         }
@@ -1501,7 +1511,7 @@ class Disk extends Linker<{ folderUri: vscode.Uri; projectManager: ProjectManage
         }
 
         // write type definition files to .pc/
-        await this._writeTypeFiles(folderUri);
+        await this._writeTypeFiles(folderUri, types);
 
         // remove old files deepest-first — siblings at each level parallelize
         const levels = new Map<number, vscode.Uri[]>();
@@ -1550,10 +1560,12 @@ class Disk extends Linker<{ folderUri: vscode.Uri; projectManager: ProjectManage
             this._opened.clear();
             this._ignoring = (_uri: vscode.Uri) => false;
             this._ignoreHash = '';
+            this._types = undefined;
         });
 
         this._folderUri = folderUri;
         this._projectManager = projectManager;
+        this._types = types;
 
         this._log.info(`linked to ${folderUri.toString()}`);
     }
@@ -1561,19 +1573,21 @@ class Disk extends Linker<{ folderUri: vscode.Uri; projectManager: ProjectManage
     async unlink() {
         const folderUri = this._folderUri;
         const projectManager = this._projectManager;
-        if (!folderUri || !projectManager) {
+        const types = this._types;
+        if (!folderUri || !projectManager || !types) {
             throw this.error.set(() => fail`unlink called before link`);
         }
         await super.unlink();
         this._folderUri = undefined;
         this._projectManager = undefined;
+        this._types = undefined;
         this._diskHash.clear();
         this._diskStat.clear();
         this._undos.forEach((m) => m.clear());
         this._undos.clear();
         void vscode.commands.executeCommand('setContext', 'playcanvas.active', false);
         this._log.info(`unlinked from ${folderUri.toString()}`);
-        return { folderUri, projectManager };
+        return { folderUri, projectManager, types };
     }
 }
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -26,6 +26,7 @@ import { ProjectManager } from './project-manager';
 import { CollabProvider } from './providers/collab-provider';
 import { DecorationProvider } from './providers/decoration-provider';
 import { closeSentry, setSentryCollaborators, setSentryProject, setSentryUser } from './sentry';
+import { TypeInstaller } from './type-installer';
 import type { EventMap } from './typings/event-map';
 import type { Project } from './typings/models';
 import { fail } from './utils/error';
@@ -246,9 +247,10 @@ export const activate = async (context: vscode.ExtensionContext) => {
     >();
 
     // disk
+    const typeInstaller = new TypeInstaller({ context });
+
     const disk = new Disk({
-        events,
-        extensionUri: context.extensionUri
+        events
     });
     effect(() => {
         const err = disk.error.get();
@@ -278,7 +280,12 @@ export const activate = async (context: vscode.ExtensionContext) => {
 
             // relink everything
             await projectManager.link(projectState);
-            await disk.link(diskState);
+            const config = await auth.getEditorConfig();
+            const types = await typeInstaller.install({
+                projectId: projectState.projectId,
+                version: config.engineVersion
+            });
+            await disk.link({ ...diskState, types });
             await decorationProvider.link(dirtyState);
             await collabProvider.link(collabState);
             await uriHandler.link(uriState);
@@ -718,11 +725,17 @@ export const activate = async (context: vscode.ExtensionContext) => {
         );
 
         const folderUri = vscode.Uri.joinPath(rootUri, projectToName(project));
+        const editorConfig = await auth.getEditorConfig();
+        const types = await typeInstaller.install({
+            projectId: project.id,
+            version: editorConfig.engineVersion
+        });
 
         // mount disk
         await disk.link({
             folderUri,
-            projectManager
+            projectManager,
+            types
         });
         context.subscriptions.push(
             new vscode.Disposable(() => {

--- a/src/test/mocks/auth.ts
+++ b/src/test/mocks/auth.ts
@@ -3,12 +3,14 @@ import type * as vscode from 'vscode';
 
 import { Auth } from '../../auth';
 
-import { accessToken } from './models';
+import { accessToken, engineVersion } from './models';
 
 class MockAuth extends Auth {
     getAccessToken: sinon.SinonSpy<[manual?: boolean, reload?: boolean], Promise<string>>;
 
     getStoredAccessToken: sinon.SinonSpy<[], Promise<string>>;
+
+    getEditorConfig: sinon.SinonSpy<[], Promise<{ engineVersion: string }>>;
 
     clearAccessToken: sinon.SinonSpy<[], Promise<void>>;
 
@@ -19,6 +21,7 @@ class MockAuth extends Auth {
 
         this.getAccessToken = sandbox.spy(async () => accessToken);
         this.getStoredAccessToken = sandbox.spy(async () => accessToken);
+        this.getEditorConfig = sandbox.spy(async () => ({ engineVersion }));
         this.clearAccessToken = sandbox.spy(async () => undefined);
         this.reset = sandbox.spy(async () => undefined);
     }

--- a/src/test/mocks/models.ts
+++ b/src/test/mocks/models.ts
@@ -2,6 +2,7 @@ import type { Asset, Branch, Project, User } from '../../typings/models';
 import { hash } from '../../utils/utils';
 
 export const accessToken = 'test-access-token';
+export const engineVersion = '2.18.0';
 
 export const user: User = {
     id: 1,

--- a/src/test/suite/extension.test.ts
+++ b/src/test/suite/extension.test.ts
@@ -12,6 +12,7 @@ import * as sharedbModule from '../../connections/sharedb';
 import * as uriHandlerModule from '../../handlers/uri-handler';
 import { Log } from '../../log';
 import * as sentryModule from '../../sentry';
+import * as typesModule from '../../type-installer';
 import type { Asset } from '../../typings/models';
 import * as buffer from '../../utils/buffer';
 import { Debouncer } from '../../utils/debouncer';
@@ -20,7 +21,17 @@ import { Mutex } from '../../utils/mutex';
 import { hash, tryCatch, withTimeout } from '../../utils/utils';
 import { MockAuth } from '../mocks/auth';
 import { MockMessenger } from '../mocks/messenger';
-import { assets, documents, branches, projectSettings, project, user, accessToken, uniqueId } from '../mocks/models';
+import {
+    assets,
+    documents,
+    branches,
+    projectSettings,
+    project,
+    user,
+    accessToken,
+    engineVersion,
+    uniqueId
+} from '../mocks/models';
 import { MockRelay } from '../mocks/relay';
 import { MockRest } from '../mocks/rest';
 import { MockShareDb } from '../mocks/sharedb';
@@ -284,6 +295,15 @@ const sharedb = new MockShareDb(sandbox, messenger);
 const relay = new MockRelay(sandbox);
 const rest = new MockRest(sandbox, messenger, sharedb);
 const uriHandler = new MockUriHandler(sandbox, rest);
+const typeFiles = {
+    globals: buffer.from('declare namespace pc { const VERSION: string; }\n'),
+    module: buffer.from('declare module "playcanvas" { export = pc; }\n'),
+    version: engineVersion,
+    fallback: false
+};
+const typeInstaller = {
+    install: sandbox.spy(async (_params: { projectId: number; version: string }) => typeFiles)
+};
 const assertOpsPromise = (key: string, expected: unknown[]) => {
     return new Promise<void>((resolve) => {
         const doc = sharedb.subscriptions.get(key);
@@ -309,6 +329,7 @@ sandbox.stub(sharedbModule, 'ShareDb').returns(sharedb);
 sandbox.stub(messengerModule, 'Messenger').returns(messenger);
 sandbox.stub(relayModule, 'Relay').returns(relay);
 sandbox.stub(uriHandlerModule, 'UriHandler').returns(uriHandler);
+sandbox.stub(typesModule, 'TypeInstaller').returns(typeInstaller as unknown as typesModule.TypeInstaller);
 
 // stub vscode methods
 const quickPickStub = sandbox
@@ -483,6 +504,23 @@ suite('extension', () => {
         const call2 = openTextDocumentSpy.getCall(0);
         assert.ok(call2, 'openTextDocument should have been called');
         assert.strictEqual(call2.args[0]?.toString(), uri.toString(), 'opened document uri should match');
+
+        assert.ok(typeInstaller.install.called, 'types installer should run');
+        const args = typeInstaller.install.getCall(0).args[0] as { version: string };
+        assert.strictEqual(args.version, engineVersion, 'version should match');
+    });
+
+    test('project load - playcanvas type files', async () => {
+        const folderUri = vscode.workspace.workspaceFolders?.[0]?.uri;
+        assert.ok(folderUri, 'workspace folder should exist');
+
+        const globalsUri = vscode.Uri.joinPath(folderUri, '.pc', 'globals.d.ts');
+        const moduleUri = vscode.Uri.joinPath(folderUri, '.pc', 'module.d.ts');
+        const globals = await assertResolves(vscode.workspace.fs.readFile(globalsUri), 'globals read');
+        const module = await assertResolves(vscode.workspace.fs.readFile(moduleUri), 'module read');
+
+        assert.strictEqual(buffer.toString(globals), buffer.toString(typeFiles.globals), 'globals should match');
+        assert.strictEqual(buffer.toString(module), buffer.toString(typeFiles.module), 'module should match');
     });
 
     test(`command ${NAME}.openProject`, async () => {
@@ -561,6 +599,19 @@ suite('extension', () => {
         assert.deepStrictEqual(tokens, [accessToken, accessToken], 'login callers should share token');
         assert.strictEqual(requestTokenStub.callCount, 1, 'external login should start once');
         assert.strictEqual(rest.id.callCount, 1, 'login token should be validated once');
+    });
+
+    test('auth parses editor config engine version', () => {
+        const parsed = authModule.parseEditorConfig(`
+            <script>
+                const config = {
+                    "accessToken": "${accessToken}",
+                    engineVersions: { current: { version: "${engineVersion}" } }
+                };
+            </script>
+        `);
+
+        assert.deepStrictEqual(parsed, { accessToken, engineVersion }, 'editor config should parse');
     });
 
     test(`command ${NAME}.switchBranch`, async () => {

--- a/src/type-installer.ts
+++ b/src/type-installer.ts
@@ -1,0 +1,245 @@
+import type * as childProcess from 'node:child_process';
+
+import * as vscode from 'vscode';
+
+import { ENV, PLAYCANVAS_VERSION, WEB } from './config';
+import { Log } from './log';
+import * as buffer from './utils/buffer';
+import { tryCatch, tryCatchSync } from './utils/utils';
+
+const MANIFEST = 'playcanvas-types.json';
+const MODULE_DTS = 'declare module "playcanvas" { export = pc; }\n';
+const INSTALL_TIMEOUT_MS = 2 * 60 * 1000;
+
+export type TypeFiles = {
+    globals: Uint8Array;
+    module: Uint8Array;
+    version: string;
+    fallback: boolean;
+};
+
+type Manifest = {
+    playcanvas?: string;
+    registry?: string;
+};
+
+type ChildProcess = typeof childProcess;
+
+const npm = () => (process.platform === 'win32' ? 'npm.cmd' : 'npm');
+
+const normalize = (version?: string) => (version || PLAYCANVAS_VERSION).replace(/^v/i, '');
+
+const run = async (proc: ChildProcess, cmd: string, args: string[], cwd: string) => {
+    return new Promise<string>((resolve, reject) => {
+        const child = proc.spawn(cmd, args, { cwd, windowsHide: true });
+        const chunks: string[] = [];
+        const timer = setTimeout(() => {
+            child.kill();
+            reject(new Error(`${cmd} ${args.join(' ')} timed out`));
+        }, INSTALL_TIMEOUT_MS);
+
+        child.stdout.on('data', (chunk: Uint8Array) => chunks.push(buffer.toString(chunk)));
+        child.stderr.on('data', (chunk: Uint8Array) => chunks.push(buffer.toString(chunk)));
+        child.on('error', (err) => {
+            clearTimeout(timer);
+            reject(err);
+        });
+        child.on('close', (code) => {
+            clearTimeout(timer);
+            if (code === 0) {
+                resolve(chunks.join(''));
+                return;
+            }
+            reject(new Error(`${cmd} ${args.join(' ')} failed with exit code ${code}: ${chunks.join('')}`));
+        });
+    });
+};
+
+class TypeInstaller {
+    private _log = new Log(this.constructor.name);
+
+    private _context: vscode.ExtensionContext;
+
+    private _fallback?: Uint8Array;
+
+    private _running = new Map<string, Promise<TypeFiles>>();
+
+    private _warned = new Set<string>();
+
+    constructor({ context }: { context: vscode.ExtensionContext }) {
+        this._context = context;
+    }
+
+    private _cache(projectId: number) {
+        const rootUri = WEB ? this._context.globalStorageUri : vscode.Uri.file(this._context.globalStorageUri.fsPath);
+        return vscode.Uri.joinPath(rootUri, 'types', `${ENV}-${projectId}`);
+    }
+
+    private async _manifest(cacheUri: vscode.Uri) {
+        const uri = vscode.Uri.joinPath(cacheUri, MANIFEST);
+        const [readErr, raw] = await tryCatch(vscode.workspace.fs.readFile(uri) as Promise<Uint8Array>);
+        if (readErr) {
+            return {};
+        }
+
+        const [parseErr, data] = tryCatchSync(() => JSON.parse(buffer.toString(raw)) as Manifest);
+        if (parseErr) {
+            return {};
+        }
+        return data;
+    }
+
+    private async _readInstalled(cacheUri: vscode.Uri, version: string, fallback = false) {
+        const uri = vscode.Uri.joinPath(cacheUri, 'node_modules', 'playcanvas', 'build', 'playcanvas.d.ts');
+        const [err, globals] = await tryCatch(vscode.workspace.fs.readFile(uri) as Promise<Uint8Array>);
+        if (err) {
+            return;
+        }
+        return {
+            globals,
+            module: buffer.from(MODULE_DTS),
+            version,
+            fallback
+        };
+    }
+
+    private async _readFallback() {
+        if (this._fallback) {
+            return this._fallback;
+        }
+
+        const uri = vscode.Uri.joinPath(this._context.extensionUri, 'out', 'playcanvas.d.ts');
+        const [err, globals] = await tryCatch(vscode.workspace.fs.readFile(uri) as Promise<Uint8Array>);
+        if (!err) {
+            this._fallback = globals;
+            return globals;
+        }
+
+        const devUri = vscode.Uri.joinPath(
+            this._context.extensionUri,
+            'node_modules',
+            'playcanvas',
+            'build',
+            'playcanvas.d.ts'
+        );
+        const [, devGlobals] = await tryCatch(vscode.workspace.fs.readFile(devUri) as Promise<Uint8Array>);
+        this._fallback = devGlobals ?? buffer.from('declare namespace pc {}\n');
+        return this._fallback;
+    }
+
+    private async _fallbackTypes(projectId: number, version: string, reason: string, cacheUri?: vscode.Uri) {
+        this._log.warn(`PlayCanvas types for ${version} could not be updated`, reason);
+        if (cacheUri) {
+            const manifest = await this._manifest(cacheUri);
+            const installed = await this._readInstalled(cacheUri, manifest.playcanvas ?? version, true);
+            if (installed) {
+                this._warn(projectId, version, `${reason}. Using cached PlayCanvas types.`);
+                return installed;
+            }
+        }
+
+        this._warn(projectId, version, `${reason}. Using bundled fallback types.`);
+        return {
+            globals: await this._readFallback(),
+            module: buffer.from(MODULE_DTS),
+            version: PLAYCANVAS_VERSION,
+            fallback: true
+        };
+    }
+
+    private _warn(projectId: number, version: string, message: string) {
+        const suffix = ' See the PlayCanvas output for details.';
+        const limit = 240 - suffix.length;
+        const detail = `${message.length > limit ? `${message.slice(0, limit)}...` : message}${suffix}`;
+        const key = `${projectId}:${version}:${detail}`;
+        if (this._warned.has(key)) {
+            return;
+        }
+        this._warned.add(key);
+        void vscode.window.showWarningMessage(`PlayCanvas types for ${version} could not be updated: ${detail}`);
+    }
+
+    private async _install(projectId: number, raw: string) {
+        const version = normalize(raw);
+        const cacheUri = this._cache(projectId);
+
+        this._log.info(`type cache uri=${cacheUri.toString()} scheme=${cacheUri.scheme} fsPath=${cacheUri.fsPath}`);
+        if (WEB) {
+            return this._fallbackTypes(projectId, version, 'npm is unavailable in web extension host', cacheUri);
+        }
+
+        await vscode.workspace.fs.createDirectory(cacheUri);
+        const manifest = await this._manifest(cacheUri);
+        if (manifest.playcanvas === version && manifest.registry === 'https://registry.npmjs.org/') {
+            const installed = await this._readInstalled(cacheUri, version);
+            if (installed) {
+                return installed;
+            }
+        }
+
+        const [importErr, proc] = await tryCatch(import(['node', 'child_process'].join(':')) as Promise<ChildProcess>);
+        if (importErr) {
+            return this._fallbackTypes(projectId, version, 'npm could not be loaded', cacheUri);
+        }
+
+        const cmd = npm();
+        const [npmErr] = await tryCatch(run(proc, cmd, ['--version'], cacheUri.fsPath));
+        if (npmErr) {
+            return this._fallbackTypes(projectId, version, 'npm was not found', cacheUri);
+        }
+
+        this._log.info(`installing playcanvas@${version} from https://registry.npmjs.org/ into ${cacheUri.fsPath}`);
+        const args = [
+            'install',
+            '--prefix',
+            cacheUri.fsPath,
+            '--registry=https://registry.npmjs.org/',
+            '--ignore-scripts',
+            '--no-audit',
+            '--no-fund',
+            '--package-lock=false',
+            '--save=false',
+            `playcanvas@${version}`
+        ];
+        const [installErr] = await tryCatch(run(proc, cmd, args, cacheUri.fsPath));
+        if (installErr) {
+            return this._fallbackTypes(projectId, version, installErr.message, cacheUri);
+        }
+
+        const installed = await this._readInstalled(cacheUri, version);
+        if (!installed) {
+            return this._fallbackTypes(
+                projectId,
+                version,
+                'installed package did not include playcanvas.d.ts',
+                cacheUri
+            );
+        }
+
+        const uri = vscode.Uri.joinPath(cacheUri, MANIFEST);
+        await vscode.workspace.fs.writeFile(
+            uri,
+            buffer.from(JSON.stringify({ playcanvas: version, registry: 'https://registry.npmjs.org/' }, undefined, 2))
+        );
+        return installed;
+    }
+
+    async install({ projectId, version }: { projectId: number; version: string }) {
+        const key = `${ENV}:${projectId}:${normalize(version)}`;
+        const running = this._running.get(key);
+        if (running) {
+            return running;
+        }
+
+        const task = this._install(projectId, version);
+        this._running.set(key, task);
+        const [err, types] = await tryCatch(task);
+        this._running.delete(key);
+        if (err) {
+            return this._fallbackTypes(projectId, normalize(version), err.message);
+        }
+        return types;
+    }
+}
+
+export { TypeInstaller };


### PR DESCRIPTION
### What's Changed

- Install PlayCanvas type files at runtime from the Editor engine version.
- Cache npm installs per environment/project and keep `.pc` output unchanged.
- Update TS plugin to register physical `.pc` type files instead of serving bundled DTS.

Manual tests: not run