### PR TITLE
chore: update playcanvas engine patch

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -43,7 +43,7 @@
                 "eslint-plugin-prettier": "5.5.5",
                 "globals": "17.5.0",
                 "jsonc-eslint-parser": "2.4.2",
-                "playcanvas": "2.18.0",
+                "playcanvas": "2.18.1",
                 "prettier": "3.8.3",
                 "rollup": "4.60.2",
                 "rollup-plugin-polyfill-node": "0.13.0",
@@ -6795,9 +6795,9 @@
             }
         },
         "node_modules/playcanvas": {
-            "version": "2.18.0",
-            "resolved": "https://registry.npmjs.org/playcanvas/-/playcanvas-2.18.0.tgz",
-            "integrity": "sha512-UufnnYsYuTCQaeFvYiSjUrDTcX7jNfy8cOydAoAySK323nLVi+8CL+lzFcWUvB5J2LRoT2oYJnPby37/6O084A==",
+            "version": "2.18.1",
+            "resolved": "https://registry.npmjs.org/playcanvas/-/playcanvas-2.18.1.tgz",
+            "integrity": "sha512-R+60EWFgPwgwqvnzP81sZbRfwJdL8EG5MLV+vJ+aeG6+Djt4IvpfJAHzYKRHak0I4oYtCCZwdLBygFboLBMCWQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {

--- a/package.json
+++ b/package.json
@@ -191,7 +191,7 @@
         "eslint-plugin-prettier": "5.5.5",
         "globals": "17.5.0",
         "jsonc-eslint-parser": "2.4.2",
-        "playcanvas": "2.18.0",
+        "playcanvas": "2.18.1",
         "prettier": "3.8.3",
         "rollup": "4.60.2",
         "rollup-plugin-polyfill-node": "0.13.0",


### PR DESCRIPTION
### What's Changed

- Update PlayCanvas from 2.18.0 to 2.18.1.
- Refresh npm lockfile metadata for the engine package.

### Manual Tests

- not run
