### PR TITLE
fix: guard failed save desync

### DIFF
--- a/src/commands.ts
+++ b/src/commands.ts
@@ -195,6 +195,13 @@ export const registerProjectCommands = ({
                     return;
                 }
 
+                if (projectManager.unsafeFiles().length) {
+                    void vscode.window.showWarningMessage(
+                        'PlayCanvas changes are not saved. Try again when saving finishes.'
+                    );
+                    return;
+                }
+
                 reload.set(() => ({ projectManager }));
             });
             if (err) {
@@ -210,8 +217,15 @@ export const registerProjectCommands = ({
                     return;
                 }
 
-                const { branchId } = cache.get(state.projectId) ?? {};
-                if (!branchId) {
+                const { branchId, projectManager } = cache.get(state.projectId) ?? {};
+                if (!branchId || !projectManager) {
+                    return;
+                }
+
+                if (projectManager.unsafeFiles().length) {
+                    void vscode.window.showWarningMessage(
+                        'PlayCanvas changes are not saved. Try again when saving finishes.'
+                    );
                     return;
                 }
 

--- a/src/disk.ts
+++ b/src/disk.ts
@@ -104,6 +104,8 @@ class Disk extends Linker<{ folderUri: vscode.Uri; projectManager: ProjectManage
 
     private _saving = new Set<string>();
 
+    private _blocked = new Set<string>();
+
     private _undos = new Map<string, UndoManager>();
 
     private _readMutex = new Mutex<void>(pathsRelated, (err) => this._log.warn('readMutex error', err));
@@ -659,10 +661,15 @@ class Disk extends Linker<{ folderUri: vscode.Uri; projectManager: ProjectManage
                         this._log.warn(`dirty applyEdit failed for ${doc.uri}`);
                     }
                 } else {
-                    // content matches -- replace first char with itself to mark dirty without visible change
-                    const edit = new vscode.WorkspaceEdit();
-                    edit.replace(doc.uri, new vscode.Range(0, 0, 0, 1), current.charAt(0));
-                    await vscode.workspace.applyEdit(edit);
+                    // content matches -- make a reversible edit to mark dirty without final text change
+                    const pos = doc.positionAt(0);
+                    const add = new vscode.WorkspaceEdit();
+                    add.insert(doc.uri, pos, ' ');
+                    if (await vscode.workspace.applyEdit(add)) {
+                        const remove = new vscode.WorkspaceEdit();
+                        remove.delete(doc.uri, new vscode.Range(pos, doc.positionAt(1)));
+                        await vscode.workspace.applyEdit(remove);
+                    }
                 }
             });
             this._locks.delete(`${doc.uri}`);
@@ -708,6 +715,41 @@ class Disk extends Linker<{ folderUri: vscode.Uri; projectManager: ProjectManage
             });
     }
 
+    private _revertBlockedEdit(document: vscode.TextDocument) {
+        const key = `${document.uri}`;
+        return this._writeMutex.atomic([key], async () => {
+            if (this._locks.has(key)) {
+                return;
+            }
+
+            const [, bytes] = await tryCatch(
+                Promise.resolve(vscode.workspace.fs.readFile(document.uri) as Promise<Uint8Array>)
+            );
+            const expected = bytes ? norm(buffer.toString(bytes)) : '';
+            const current = document.getText();
+            if (current === expected) {
+                return;
+            }
+
+            const { prefix, suffix } = diff(current, expected);
+            const edit = new vscode.WorkspaceEdit();
+            edit.replace(
+                document.uri,
+                new vscode.Range(document.positionAt(prefix), document.positionAt(current.length - suffix)),
+                expected.substring(prefix, expected.length - suffix)
+            );
+
+            this._locks.add(key);
+            this._blocked.add(key);
+            const [err, applied] = await tryCatch(Promise.resolve(vscode.workspace.applyEdit(edit)));
+            this._blocked.delete(key);
+            this._locks.delete(key);
+            if (err || !applied) {
+                this._log.warn(`blocked edit revert failed for ${document.uri}`);
+            }
+        });
+    }
+
     private _watchEvents(folderUri: vscode.Uri) {
         const assetFileCreate = this._events.on('asset:file:create', async (path, type, content) => {
             const uri = vscode.Uri.joinPath(folderUri, path);
@@ -737,6 +779,14 @@ class Disk extends Linker<{ folderUri: vscode.Uri; projectManager: ProjectManage
             this._checkIgnoreUpdated(uri);
             await this._save(uri);
         });
+        const assetFileFailed = this._events.on('asset:file:failed', async (path) => {
+            const uri = vscode.Uri.joinPath(folderUri, path);
+            const doc = vscode.workspace.textDocuments.find((d) => d.uri.toString() === uri.toString());
+            if (!doc || !this._opened.has(uri.path) || doc.isDirty) {
+                return;
+            }
+            await this._dirty(doc);
+        });
         const assetFileSubscribed = this._events.on('asset:file:subscribed', async (path, content, dirty) => {
             const uri = vscode.Uri.joinPath(folderUri, path);
             await this._subscribed(uri, path, content, dirty);
@@ -747,6 +797,7 @@ class Disk extends Linker<{ folderUri: vscode.Uri; projectManager: ProjectManage
             this._events.off('asset:file:rename', assetFileRename);
             this._events.off('asset:file:delete', assetFileDelete);
             this._events.off('asset:file:save', assetFileSave);
+            this._events.off('asset:file:failed', assetFileFailed);
             this._events.off('asset:file:subscribed', assetFileSubscribed);
         };
     }
@@ -921,6 +972,7 @@ class Disk extends Linker<{ folderUri: vscode.Uri; projectManager: ProjectManage
             this._diskHash.delete(document.uri.path);
             this._diskStat.delete(document.uri.path);
             this._saving.delete(document.uri.path);
+            this._blocked.delete(`${document.uri}`);
             this._events.emit('asset:doc:close', path);
         });
 
@@ -939,12 +991,22 @@ class Disk extends Linker<{ folderUri: vscode.Uri; projectManager: ProjectManage
             // check if file is in memory
             const path = relativePath(document.uri, folderUri);
             const file = projectManager.files.get(path);
-            if (!file || file.type !== 'file') {
+            if ((!file || file.type !== 'file') && projectManager.loading(path)) {
+                if (!this._blocked.has(`${document.uri}`)) {
+                    if (!this._locks.has(`${document.uri}`)) {
+                        void this._revertBlockedEdit(document);
+                    }
+                    void vscode.window.showWarningMessage('PlayCanvas file is still loading. Try again in a moment.');
+                }
                 return;
             }
 
             // check if locked (from remote update)
             if (this._locks.has(`${document.uri}`)) {
+                return;
+            }
+
+            if (!file || file.type !== 'file') {
                 return;
             }
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -266,6 +266,10 @@ export const activate = async (context: vscode.ExtensionContext) => {
             void vscode.window.showWarningMessage('Dropping reload request to avoid overlapping reloads');
             return false;
         }
+        if (projectManager.unsafeFiles().length) {
+            void vscode.window.showWarningMessage('PlayCanvas changes are not saved. Try again when saving finishes.');
+            return false;
+        }
         reloading = true;
         const [err] = await tryCatch(async () => {
             // unlink everything
@@ -759,8 +763,29 @@ export const activate = async (context: vscode.ExtensionContext) => {
                 desyncStatusItem.show();
             } else {
                 desyncStatusItem.hide();
+                desyncStatusItem.command = `${NAME}.reloadProject`;
+                desyncStatusItem.tooltip = 'PlayCanvas project is out of sync — click to reload';
                 return;
             }
+
+            if (projectManager.saveFailed()) {
+                desyncStatusItem.command = `${NAME}.reportIssue`;
+                desyncStatusItem.tooltip = 'PlayCanvas could not save changes — click to report';
+                void vscode.window
+                    .showWarningMessage('PlayCanvas could not save changes.', 'Report Issue')
+                    .then((choice) => {
+                        if (choice === 'Report Issue') {
+                            void vscode.commands.executeCommand(
+                                `${NAME}.reportIssue`,
+                                'PlayCanvas could not save changes'
+                            );
+                        }
+                    });
+                return;
+            }
+
+            desyncStatusItem.command = `${NAME}.reloadProject`;
+            desyncStatusItem.tooltip = 'PlayCanvas project is out of sync — click to reload';
             void vscode.window
                 .showWarningMessage(
                     'PlayCanvas project is out of sync. Reload to recover.',

--- a/src/project-manager.ts
+++ b/src/project-manager.ts
@@ -55,7 +55,7 @@ class ProjectManager extends Linker<{ projectId: number; branchId: string }> {
 
     private static readonly SAVE_RETRY_DELAY_MS = 2 * 1000;
 
-    private static readonly SAVE_ACK_TIMEOUT_MS = 2 * 1000;
+    private static readonly SAVE_ACK_TIMEOUT_MS = 5 * 1000;
 
     private static readonly FLUSH_TIMEOUT_MS = 5 * 1000;
 

--- a/src/project-manager.ts
+++ b/src/project-manager.ts
@@ -55,13 +55,17 @@ class ProjectManager extends Linker<{ projectId: number; branchId: string }> {
 
     private static readonly SAVE_RETRY_DELAY_MS = 2 * 1000;
 
+    private static readonly SAVE_ACK_TIMEOUT_MS = 2 * 1000;
+
     private static readonly FLUSH_TIMEOUT_MS = 5 * 1000;
 
-    private _saveRetries = new Map<number, { timeout?: NodeJS.Timeout; attempt: number }>();
+    private _saveAttempts = new Map<number, { ack?: NodeJS.Timeout; retry?: NodeJS.Timeout; attempt: number }>();
 
     private _saveInflight = new Set<number>();
 
     private _savePending = new Set<number>();
+
+    private _saveFailed = new Set<number>();
 
     private _events: EventEmitter<EventMap>;
 
@@ -84,6 +88,8 @@ class ProjectManager extends Linker<{ projectId: number; branchId: string }> {
     private _idUniqueId: Bimap<number, number> = new Bimap<number, number>();
 
     private _subscribing = new Map<number, Promise<(VirtualFile & { type: 'file' }) | undefined>>();
+
+    private _subscribeFailed = new Set<number>();
 
     private _queued = new Set<string>();
 
@@ -131,6 +137,9 @@ class ProjectManager extends Linker<{ projectId: number; branchId: string }> {
     // recovers automatically after a transient stall instead of staying stuck.
     private _heal() {
         if (!this.desync.get() || !this._sharedb.connected.get()) {
+            return;
+        }
+        if (this._saveFailed.size > 0) {
             return;
         }
         for (const file of this._files.values()) {
@@ -372,19 +381,84 @@ class ProjectManager extends Linker<{ projectId: number; branchId: string }> {
         return { skip: false, changed: false };
     }
 
+    private _savePath(uniqueId: number) {
+        if (!this._assets.has(uniqueId)) {
+            return undefined;
+        }
+        return this._assetPath(uniqueId);
+    }
+
+    private _clearSaveAttempt(uniqueId: number) {
+        const entry = this._saveAttempts.get(uniqueId);
+        clearTimeout(entry?.ack);
+        clearTimeout(entry?.retry);
+        this._saveAttempts.delete(uniqueId);
+    }
+
+    private _clearSaveFailure(uniqueId: number) {
+        if (!this._saveFailed.delete(uniqueId)) {
+            return;
+        }
+        this._heal();
+    }
+
+    private _failSave(uniqueId: number) {
+        const path = this._savePath(uniqueId);
+        if (path) {
+            const file = this._files.get(path);
+            if (file && file.type !== 'folder') {
+                file.dirty = true;
+                this._events.emit('asset:file:dirty', path, true);
+                this._events.emit('asset:file:failed', path);
+            }
+        }
+        this._saveFailed.add(uniqueId);
+        this.desync.set(() => true);
+    }
+
+    private _sendSave(uniqueId: number) {
+        const entry = this._saveAttempts.get(uniqueId) ?? { attempt: 0 };
+        clearTimeout(entry.ack);
+        const ack = setTimeout(() => {
+            const current = this._saveAttempts.get(uniqueId);
+            if (current?.ack !== ack) {
+                return;
+            }
+            current.ack = undefined;
+            this._saveInflight.delete(uniqueId);
+            this._verifySave('error', uniqueId);
+        }, ProjectManager.SAVE_ACK_TIMEOUT_MS);
+        entry.ack = ack;
+        this._saveAttempts.set(uniqueId, entry);
+
+        void tryCatch(this._sharedb.sendRaw(`doc:save:${uniqueId}`)).then(([err]) => {
+            if (!err) {
+                return;
+            }
+            const current = this._saveAttempts.get(uniqueId);
+            clearTimeout(current?.ack);
+            if (current) {
+                current.ack = undefined;
+            }
+            this._saveInflight.delete(uniqueId);
+            this._log.warn(`failed to send save for document ${uniqueId}: ${err.message}`);
+            this._verifySave('error', uniqueId);
+        });
+    }
+
     private _verifySave(state: 'success' | 'error', uniqueId: number) {
         if (state === 'success') {
-            const entry = this._saveRetries.get(uniqueId);
-            clearTimeout(entry?.timeout);
-            this._saveRetries.delete(uniqueId);
+            this._clearSaveAttempt(uniqueId);
             return true;
         }
 
         this._log.warn(`failed to save document ${uniqueId}: ${state}`);
 
         // skip if already retrying this doc
-        const entry = this._saveRetries.get(uniqueId);
-        if (entry?.timeout) {
+        const entry = this._saveAttempts.get(uniqueId) ?? { attempt: 0 };
+        clearTimeout(entry.ack);
+        entry.ack = undefined;
+        if (entry.retry) {
             return false;
         }
 
@@ -392,15 +466,17 @@ class ProjectManager extends Linker<{ projectId: number; branchId: string }> {
         const attempt = (entry?.attempt ?? 0) + 1;
         if (attempt > ProjectManager.SAVE_MAX_RETRIES) {
             this._log.error(`giving up saving document ${uniqueId} after ${ProjectManager.SAVE_MAX_RETRIES} retries`);
-            this._saveRetries.delete(uniqueId);
+            this._clearSaveAttempt(uniqueId);
+            this._savePending.delete(uniqueId);
+            this._failSave(uniqueId);
             return false;
         }
 
         // schedule retry
-        const timeout = setTimeout(async () => {
-            const e = this._saveRetries.get(uniqueId);
+        const retry = setTimeout(async () => {
+            const e = this._saveAttempts.get(uniqueId);
             if (e) {
-                e.timeout = undefined;
+                e.retry = undefined;
             }
 
             // bail out if project was unlinked while waiting
@@ -409,18 +485,26 @@ class ProjectManager extends Linker<{ projectId: number; branchId: string }> {
             }
 
             // re-open the document on the server via doc:reconnect
-            await this._sharedb.sendRaw(`doc:reconnect:${uniqueId}`);
+            const [err] = await tryCatch(this._sharedb.sendRaw(`doc:reconnect:${uniqueId}`));
+            if (err) {
+                this._log.warn(`failed to reconnect document ${uniqueId}: ${err.message}`);
+                this._verifySave('error', uniqueId);
+                return;
+            }
 
             // re-check after await — unlink may have happened during sendRaw
             if (this._projectId === undefined) {
                 return;
             }
 
-            this._sharedb.sendRaw(`doc:save:${uniqueId}`);
+            this._saveInflight.add(uniqueId);
+            this._sendSave(uniqueId);
             this._log.debug(`retried save for document ${uniqueId} (attempt ${attempt})`);
         }, ProjectManager.SAVE_RETRY_DELAY_MS);
 
-        this._saveRetries.set(uniqueId, { timeout, attempt });
+        entry.retry = retry;
+        entry.attempt = attempt;
+        this._saveAttempts.set(uniqueId, entry);
         return false;
     }
 
@@ -430,6 +514,18 @@ class ProjectManager extends Linker<{ projectId: number; branchId: string }> {
         }
         this._savePending.delete(uniqueId);
         this.save(path);
+    }
+
+    private _finishSave(uniqueId: number, path: string) {
+        this._saveInflight.delete(uniqueId);
+        this._clearSaveAttempt(uniqueId);
+        this._drainSaves(uniqueId, path);
+    }
+
+    private _failSubscribe(uniqueId: number, path: string, msg: string) {
+        this._subscribeFailed.add(uniqueId);
+        this.desync.set(() => true);
+        this._log.warn(`${msg} for ${path}`);
     }
 
     private _watchSharedb() {
@@ -448,14 +544,6 @@ class ProjectManager extends Linker<{ projectId: number; branchId: string }> {
             }
 
             const path = this._assetPath(uniqueId);
-            const file = this._files.get(path);
-            if (!file || file.type !== 'file') {
-                return;
-            }
-
-            // mark as clean (sharedb content now synced with S3)
-            file.dirty = false;
-            this._events.emit('asset:file:save', path);
             this._drainSaves(uniqueId, path);
         });
         return () => {
@@ -777,16 +865,23 @@ class ProjectManager extends Linker<{ projectId: number; branchId: string }> {
                         // NOTE: only mark clean if local content matches the saved hash,
                         // NOTE: otherwise local unsaved changes would be silently discarded
                         const localHash = hash(file.doc.text);
-                        if (fileTo?.hash === localHash) {
-                            file.dirty = false;
+                        const dirty = fileTo?.hash !== localHash;
+                        const wasDirty = file.dirty;
+                        file.dirty = dirty;
+                        this._finishSave(uniqueId, path);
+                        if (!dirty) {
+                            this._clearSaveFailure(uniqueId);
+                            this._events.emit('asset:file:save', path);
+                        } else if (!wasDirty) {
+                            this._events.emit('asset:file:dirty', path, true);
                         }
                     } else {
                         // stub: no doc to compare, mark clean on remote save
                         file.dirty = false;
+                        this._finishSave(uniqueId, path);
+                        this._clearSaveFailure(uniqueId);
+                        this._events.emit('asset:file:save', path);
                     }
-
-                    // add events for VS Code to clear dirty indicator
-                    this._events.emit('asset:file:save', this._assetPath(uniqueId));
                     break;
                 }
             }
@@ -1168,7 +1263,7 @@ class ProjectManager extends Linker<{ projectId: number; branchId: string }> {
 
         // coalesce: if a save is already in-flight, mark pending and let the
         // ack drive the follow-up (Code Editor save.ts:159-162)
-        if (this._saveInflight.has(file.uniqueId)) {
+        if (this._saveInflight.has(file.uniqueId) || this._saveAttempts.has(file.uniqueId)) {
             this._savePending.add(file.uniqueId);
             return;
         }
@@ -1187,7 +1282,7 @@ class ProjectManager extends Linker<{ projectId: number; branchId: string }> {
                 this._drainSaves(file.uniqueId, path);
                 return;
             }
-            this._sharedb.sendRaw(`doc:save:${file.uniqueId}`);
+            this._sendSave(file.uniqueId);
             this._log.debug(`saved file ${path}`);
         });
     }
@@ -1208,6 +1303,34 @@ class ProjectManager extends Linker<{ projectId: number; branchId: string }> {
         const path = this._assetPath(uniqueId);
         const file = this._files.get(path);
         return file?.uniqueId === uniqueId;
+    }
+
+    loading(path: string) {
+        const file = this._files.get(path);
+        return file?.type === 'stub';
+    }
+
+    saveFailed() {
+        return this._saveFailed.size > 0;
+    }
+
+    unsafeFiles() {
+        const paths: string[] = [];
+        for (const [path, file] of this._files) {
+            if (file.type === 'folder') {
+                continue;
+            }
+            if (
+                file.dirty ||
+                this._saveInflight.has(file.uniqueId) ||
+                this._savePending.has(file.uniqueId) ||
+                this._saveAttempts.has(file.uniqueId) ||
+                this._saveFailed.has(file.uniqueId)
+            ) {
+                paths.push(path);
+            }
+        }
+        return paths;
     }
 
     async subscribe(path: string) {
@@ -1233,15 +1356,19 @@ class ProjectManager extends Linker<{ projectId: number; branchId: string }> {
 
         const pending = this._doSubscribe(path, file.uniqueId);
         this._subscribing.set(file.uniqueId, pending);
-        const result = await pending;
+        const [err, result] = await tryCatch(pending);
         this._subscribing.delete(file.uniqueId);
+        if (err) {
+            this._failSubscribe(file.uniqueId, path, err.message);
+            return undefined;
+        }
         return result;
     }
 
     private async _doSubscribe(path: string, uniqueId: number) {
         const doc = await this._sharedb.subscribe('documents', `${uniqueId}`);
         if (!doc) {
-            this._log.error(fail`failed to subscribe to document ${uniqueId}`);
+            this._failSubscribe(uniqueId, path, `failed to subscribe to document ${uniqueId}`);
             return undefined;
         }
 
@@ -1255,7 +1382,7 @@ class ProjectManager extends Linker<{ projectId: number; branchId: string }> {
         // null data after hard reset — clean up and skip until reload
         if (doc.data === null) {
             await this._sharedb.unsubscribe('documents', `${uniqueId}`);
-            this._log.debug(`subscribe skipped ${path} (null data, pending reload)`);
+            this._failSubscribe(uniqueId, path, 'subscribe skipped (null data, pending reload)');
             return undefined;
         }
 
@@ -1279,6 +1406,7 @@ class ProjectManager extends Linker<{ projectId: number; branchId: string }> {
         // resolve current path after await (may have changed due to rename)
         const current = this._assetPath(uniqueId);
         this._files.set(current, promoted);
+        this._subscribeFailed.delete(uniqueId);
 
         // wire op handler (same as _addFile)
         otdoc.on('op', (op, prev) => {
@@ -1510,15 +1638,20 @@ class ProjectManager extends Linker<{ projectId: number; branchId: string }> {
             unwatchMessenger();
             unwatchReconnect();
 
-            this._saveRetries.forEach(({ timeout }) => clearTimeout(timeout));
-            this._saveRetries.clear();
+            this._saveAttempts.forEach(({ ack, retry }) => {
+                clearTimeout(ack);
+                clearTimeout(retry);
+            });
+            this._saveAttempts.clear();
             this._saveInflight.clear();
             this._savePending.clear();
+            this._saveFailed.clear();
 
             this._files.clear();
             this._assets.clear();
             this._idUniqueId.clear();
             this._subscribing.clear();
+            this._subscribeFailed.clear();
             this._queued.clear();
 
             this.collisions.clear();

--- a/src/test/mocks/sharedb.ts
+++ b/src/test/mocks/sharedb.ts
@@ -8,6 +8,7 @@ import type sinon from 'sinon';
 import { ShareDb } from '../../connections/sharedb';
 import type { Asset } from '../../typings/models';
 import type { ShareDbOp, ShareDbTextOp } from '../../typings/sharedb';
+import { hash } from '../../utils/utils';
 
 import type { MockMessenger } from './messenger';
 import { projectSettings, assets, documents } from './models';
@@ -336,10 +337,12 @@ class MockShareDb extends ShareDb {
 
     closedDocuments = new Set<number>();
 
+    documentSubscribeDelay = 0;
+
     // FIFO of save responses to inject per uniqueId. empty queue → emit 'success'
     // (today's default). drives ProjectManager._verifySave's retry path
     // (src/project-manager.ts:399-422), which re-sends doc:reconnect + doc:save.
-    saveResponses = new Map<number, ('success' | 'error')[]>();
+    saveResponses = new Map<number, ('success' | 'error' | 'timeout')[]>();
 
     failNextSave(uniqueId: number, count = 1) {
         const q = this.saveResponses.get(uniqueId) ?? [];
@@ -410,6 +413,9 @@ class MockShareDb extends ShareDb {
             this.connected.set(() => false);
         });
         this.subscribe = sandbox.spy(async (type: string, key: string) => {
+            if (type === 'documents' && this.documentSubscribeDelay > 0) {
+                await new Promise((resolve) => setTimeout(resolve, this.documentSubscribeDelay));
+            }
             const doc = new MockDoc(sandbox, type, key);
             this.subscriptions.set(`${type}:${key}`, doc);
             return doc;
@@ -436,6 +442,7 @@ class MockShareDb extends ShareDb {
             this.fsCascadeDeletes = false;
             this.fsProductionMoveOps = false;
             this.closedDocuments.clear();
+            this.documentSubscribeDelay = 0;
         };
         this.sendRaw = sandbox.spy(async (data: Parameters<WebSocket['send']>[0]) => {
             // check for fs operations
@@ -487,7 +494,30 @@ class MockShareDb extends ShareDb {
                 const id = parseInt(raw, 10);
                 const q = this.saveResponses.get(id);
                 const state = q?.shift() ?? 'success';
+                if (state === 'timeout') {
+                    return;
+                }
                 this.emit('doc:save', state, id);
+                if (state === 'success') {
+                    const asset = assets.get(id);
+                    if (!asset?.file) {
+                        return;
+                    }
+                    const next = hash(documents.get(id) ?? '');
+                    if (asset.file.hash === next) {
+                        return;
+                    }
+                    const doc = this.subscriptions.get(`assets:${id}`);
+                    const file = {
+                        filename: asset.file.filename,
+                        hash: next
+                    };
+                    if (doc) {
+                        doc.submitOp([{ p: ['file'], od: asset.file, oi: file }], { source: 'remote' });
+                    } else {
+                        asset.file = file;
+                    }
+                }
                 return;
             }
             if (`${data}`.startsWith('doc:reconnect:')) {

--- a/src/test/suite/extension.test.ts
+++ b/src/test/suite/extension.test.ts
@@ -11,7 +11,6 @@ import * as restModule from '../../connections/rest';
 import * as sharedbModule from '../../connections/sharedb';
 import * as uriHandlerModule from '../../handlers/uri-handler';
 import { Log } from '../../log';
-import { ProjectManager } from '../../project-manager';
 import * as sentryModule from '../../sentry';
 import * as typesModule from '../../type-installer';
 import type { Asset } from '../../typings/models';
@@ -42,15 +41,9 @@ const sandbox = sinon.createSandbox();
 const guardSandbox = sinon.createSandbox();
 const DEFAULT_TIMEOUT = 2500;
 const RETRY_TIMEOUT = 4000;
+const SAVE_RETRY_TIMEOUT = 8000;
+const SAVE_FAILURE_TIMEOUT = 15000;
 const WATCHER_TIMEOUT = 1000;
-const saveTuning = ProjectManager as unknown as {
-    SAVE_MAX_RETRIES: number;
-    SAVE_RETRY_DELAY_MS: number;
-    SAVE_ACK_TIMEOUT_MS: number;
-};
-saveTuning.SAVE_MAX_RETRIES = 2;
-saveTuning.SAVE_RETRY_DELAY_MS = 50;
-saveTuning.SAVE_ACK_TIMEOUT_MS = 50;
 
 const createRecordChannel = <T extends { settled: Promise<void> }>() => {
     const records: T[] = [];
@@ -2007,7 +2000,9 @@ suite('extension', () => {
         assert.strictEqual(saveCalls.length, 0, 'should not send redundant doc:save to server');
     });
 
-    test('file save - matching asset hash clears failed save state', async () => {
+    test('file save - matching asset hash clears failed save state', async function () {
+        this.timeout(SAVE_FAILURE_TIMEOUT);
+
         const folderUri = vscode.workspace.workspaceFolders?.[0]?.uri;
         assert.ok(folderUri, 'workspace folder should exist');
 
@@ -2023,13 +2018,13 @@ suite('extension', () => {
         await vscode.workspace.applyEdit(edit);
         await waitForIdle('failed save edit');
 
-        sharedb.failNextSave(asset.uniqueId, 3);
+        sharedb.failNextSave(asset.uniqueId, 6);
         warningMessageStub.resetHistory();
         const failed = waitForEmit(
             'asset:file:dirty',
             (args) => args[0] === asset.name,
             'save failure dirty',
-            RETRY_TIMEOUT
+            SAVE_FAILURE_TIMEOUT
         );
         await tdoc.save();
         await failed;
@@ -3212,7 +3207,9 @@ suite('extension', () => {
         );
     });
 
-    test('save retry runs when doc:save ack is missing', async () => {
+    test('save retry runs when doc:save ack is missing', async function () {
+        this.timeout(SAVE_RETRY_TIMEOUT);
+
         const folderUri = vscode.workspace.workspaceFolders?.[0]?.uri;
         assert.ok(folderUri, 'workspace folder should exist');
 
@@ -3231,7 +3228,7 @@ suite('extension', () => {
             'doc:save',
             (args) => args[0] === 'success' && args[1] === asset.uniqueId,
             'doc save timeout retry',
-            RETRY_TIMEOUT
+            SAVE_RETRY_TIMEOUT
         );
         await tdoc.save();
         await saved;

--- a/src/test/suite/extension.test.ts
+++ b/src/test/suite/extension.test.ts
@@ -41,7 +41,7 @@ const sandbox = sinon.createSandbox();
 const guardSandbox = sinon.createSandbox();
 const DEFAULT_TIMEOUT = 2500;
 const RETRY_TIMEOUT = 4000;
-const SAVE_RETRY_TIMEOUT = 8000;
+const SAVE_RETRY_TIMEOUT = 12000;
 const SAVE_FAILURE_TIMEOUT = 15000;
 const WATCHER_TIMEOUT = 1000;
 

--- a/src/test/suite/extension.test.ts
+++ b/src/test/suite/extension.test.ts
@@ -11,6 +11,7 @@ import * as restModule from '../../connections/rest';
 import * as sharedbModule from '../../connections/sharedb';
 import * as uriHandlerModule from '../../handlers/uri-handler';
 import { Log } from '../../log';
+import { ProjectManager } from '../../project-manager';
 import * as sentryModule from '../../sentry';
 import * as typesModule from '../../type-installer';
 import type { Asset } from '../../typings/models';
@@ -42,6 +43,14 @@ const guardSandbox = sinon.createSandbox();
 const DEFAULT_TIMEOUT = 2500;
 const RETRY_TIMEOUT = 4000;
 const WATCHER_TIMEOUT = 1000;
+const saveTuning = ProjectManager as unknown as {
+    SAVE_MAX_RETRIES: number;
+    SAVE_RETRY_DELAY_MS: number;
+    SAVE_ACK_TIMEOUT_MS: number;
+};
+saveTuning.SAVE_MAX_RETRIES = 2;
+saveTuning.SAVE_RETRY_DELAY_MS = 50;
+saveTuning.SAVE_ACK_TIMEOUT_MS = 50;
 
 const createRecordChannel = <T extends { settled: Promise<void> }>() => {
     const records: T[] = [];
@@ -434,6 +443,33 @@ const assetCreate = async ({
     const asset = assets.get(res.uniqueId);
     assert.ok(asset, `asset ${res.uniqueId} should exist`);
     return asset;
+};
+
+const markSaved = (asset: Asset, text = documents.get(asset.uniqueId) ?? '') => {
+    if (!asset.file) {
+        return;
+    }
+    const next = hash(text);
+    if (asset.file.hash === next) {
+        return;
+    }
+    const file = {
+        filename: asset.file.filename,
+        hash: next
+    };
+    const doc = sharedb.subscriptions.get(`assets:${asset.uniqueId}`);
+    if (doc) {
+        doc.submitOp([{ p: ['file'], od: asset.file, oi: file }], { source: 'remote' });
+    } else {
+        asset.file = file;
+    }
+};
+
+const markAllSaved = async () => {
+    for (const asset of assets.values()) {
+        markSaved(asset);
+    }
+    await waitForIdle('mark all saved');
 };
 
 const ensurePcignore = async () => {
@@ -1534,6 +1570,66 @@ suite('extension', () => {
         assert.strictEqual(saveCalls.length, 0, 'should not send doc:save for external closed file change');
     });
 
+    test('file open - typing before subscribe reverts without OT submit', async () => {
+        const folderUri = vscode.workspace.workspaceFolders?.[0]?.uri;
+        assert.ok(folderUri, 'workspace folder should exist');
+
+        const asset = await assetCreate({ name: 'blocked_subscribe_edit.js', content: '// ORIG\n' });
+        const uri = vscode.Uri.joinPath(folderUri, asset.name);
+        const original = '// ORIG\n';
+
+        await markAllSaved();
+        const reloaded = waitForEmit('asset:file:create', (args) => args[0] === asset.name, 'blocked subscribe reload');
+        await assertResolves(vscode.commands.executeCommand(`${NAME}.reloadProject`) as Promise<unknown>, 'reload');
+        await reloaded;
+        await waitForIdle('blocked subscribe reload settle');
+        await waitForFileContent(uri, original, 'blocked subscribe file');
+
+        sharedb.documentSubscribeDelay = 1000;
+        warningMessageStub.resetHistory();
+        const subscribed = waitForEmit(
+            'asset:file:subscribed',
+            (args) => args[0] === asset.name,
+            'delayed subscribe',
+            RETRY_TIMEOUT
+        );
+        const opened = waitForEmit('asset:doc:open', (args) => args[0] === asset.name, 'document open');
+
+        const tdoc = await vscode.workspace.openTextDocument(uri);
+        await opened;
+
+        let changed = false;
+        const reverted = new Promise<void>((resolve) => {
+            const disposable = vscode.workspace.onDidChangeTextDocument((e) => {
+                if (e.document.uri.toString() !== uri.toString()) {
+                    return;
+                }
+                if (e.document.getText().startsWith('X')) {
+                    changed = true;
+                    return;
+                }
+                if (changed && e.document.getText() === original) {
+                    disposable.dispose();
+                    resolve();
+                }
+            });
+        });
+
+        const edit = new vscode.WorkspaceEdit();
+        edit.insert(uri, new vscode.Position(0, 0), 'X');
+        assert.strictEqual(await vscode.workspace.applyEdit(edit), true, 'blocked edit should apply before revert');
+        await assertResolves(reverted, 'blocked edit revert');
+        await vscode.window.showTextDocument(tdoc);
+        await subscribed;
+        await waitForIdle('blocked edit settle');
+
+        const doc = sharedb.subscriptions.get(`documents:${asset.uniqueId}`);
+        assert.ok(doc, 'document should be subscribed after delay');
+        assert.strictEqual(tdoc.getText(), original, 'blocked edit should be reverted to disk content');
+        assert.strictEqual(doc.submitOp.callCount, 0, 'blocked edit should not submit OT');
+        assert.ok(warningMessageStub.calledWith(sinon.match(/still loading/i)), 'loading warning should be shown');
+    });
+
     test('file close - discard after first-keystroke does not roll back doc', async () => {
         // regression #278: first onChange after open fires with isDirty=false
         // (transient), so external=true was a false positive. _dirtyReload then
@@ -1911,6 +2007,64 @@ suite('extension', () => {
         assert.strictEqual(saveCalls.length, 0, 'should not send redundant doc:save to server');
     });
 
+    test('file save - matching asset hash clears failed save state', async () => {
+        const folderUri = vscode.workspace.workspaceFolders?.[0]?.uri;
+        assert.ok(folderUri, 'workspace folder should exist');
+
+        await markAllSaved();
+
+        const asset = await assetCreate({ name: 'save_failed_then_hash.js', content: '// ORIG\n' });
+        const uri = vscode.Uri.joinPath(folderUri, asset.name);
+        const tdoc = await vscode.workspace.openTextDocument(uri);
+        await vscode.window.showTextDocument(tdoc);
+
+        const edit = new vscode.WorkspaceEdit();
+        edit.insert(uri, new vscode.Position(0, 0), '// EDIT\n');
+        await vscode.workspace.applyEdit(edit);
+        await waitForIdle('failed save edit');
+
+        sharedb.failNextSave(asset.uniqueId, 3);
+        warningMessageStub.resetHistory();
+        const failed = waitForEmit(
+            'asset:file:dirty',
+            (args) => args[0] === asset.name,
+            'save failure dirty',
+            RETRY_TIMEOUT
+        );
+        await tdoc.save();
+        await failed;
+        await waitForIdle('failed save settle');
+
+        assert.strictEqual(tdoc.isDirty, true, 'failed save should re-dirty the open document');
+        assert.ok(
+            warningMessageStub.calledWith(sinon.match(/could not save/i)),
+            'save failure warning should be shown'
+        );
+
+        warningMessageStub.resetHistory();
+        await assertResolves(
+            vscode.commands.executeCommand(`${NAME}.reloadProject`) as Promise<unknown>,
+            'reload block'
+        );
+        assert.ok(
+            warningMessageStub.calledWith(sinon.match(/changes are not saved/i)),
+            'reload should be blocked while save failed'
+        );
+
+        const saved = waitForEmit('asset:file:save', (args) => args[0] === asset.name, 'matching hash save');
+        markSaved(asset, tdoc.getText());
+        await saved;
+        await waitForIdle('matching hash settle');
+
+        warningMessageStub.resetHistory();
+        rest.branchCheckout.resetHistory();
+        await assertResolves(
+            vscode.commands.executeCommand(`${NAME}.switchBranch`) as Promise<unknown>,
+            'switch branch'
+        );
+        assert.strictEqual(rest.branchCheckout.callCount, 1, 'switch branch should be unblocked after matching hash');
+    });
+
     test('file save - remote op reverts to s3 hash', async () => {
         const folderUri = vscode.workspace.workspaceFolders?.[0]?.uri;
         assert.ok(folderUri, 'workspace folder should exist');
@@ -2272,8 +2426,9 @@ suite('extension', () => {
         const gitDir = vscode.Uri.joinPath(folderUri, '.git');
         await assertResolves(vscode.workspace.fs.createDirectory(gitDir), 'fs.createDirectory');
 
-        const watcher = watchFile(folderUri, '.git/HEAD', 'create').promise;
-        const headUri = vscode.Uri.joinPath(gitDir, 'HEAD');
+        const head = `HEAD_${Date.now()}`;
+        const watcher = watchFile(folderUri, `.git/${head}`, 'create').promise;
+        const headUri = vscode.Uri.joinPath(gitDir, head);
         await assertResolves(
             vscode.workspace.fs.writeFile(headUri, buffer.from('ref: refs/heads/main\n')),
             'fs.writeFile'
@@ -2281,9 +2436,9 @@ suite('extension', () => {
         await assertResolves(watcher, 'watcher.create');
 
         assert.strictEqual(
-            Array.from(assets.values()).find((a) => a.name === 'HEAD'),
+            Array.from(assets.values()).find((a) => a.name === head),
             undefined,
-            '.git/HEAD should not exist as asset'
+            `.git/${head} should not exist as asset`
         );
         assert.strictEqual(
             Array.from(assets.values()).find((a) => a.name === '.git'),
@@ -2295,6 +2450,8 @@ suite('extension', () => {
     test('vcs exclusion - .git survives re-link cleanup', async () => {
         const folderUri = vscode.workspace.workspaceFolders?.[0]?.uri;
         assert.ok(folderUri, 'workspace folder should exist');
+
+        await markAllSaved();
 
         // ensure .git/ and a child file exist on disk before reload
         const gitDir = vscode.Uri.joinPath(folderUri, '.git');
@@ -3053,6 +3210,37 @@ suite('extension', () => {
             warningMessageStub.calledWith(sinon.match(/out of sync/i)),
             'desync toast must fire after submit rejection'
         );
+    });
+
+    test('save retry runs when doc:save ack is missing', async () => {
+        const folderUri = vscode.workspace.workspaceFolders?.[0]?.uri;
+        assert.ok(folderUri, 'workspace folder should exist');
+
+        const asset = await assetCreate({ name: 'save_missing_ack.js', content: '// ORIG\n' });
+        const uri = vscode.Uri.joinPath(folderUri, asset.name);
+        const tdoc = await vscode.workspace.openTextDocument(uri);
+        await vscode.window.showTextDocument(tdoc);
+
+        const edit = new vscode.WorkspaceEdit();
+        edit.insert(uri, new vscode.Position(0, 0), '// EDIT\n');
+        await vscode.workspace.applyEdit(edit);
+
+        sharedb.saveResponses.set(asset.uniqueId, ['timeout', 'success']);
+        sharedb.sendRaw.resetHistory();
+        const saved = waitForEmit(
+            'doc:save',
+            (args) => args[0] === 'success' && args[1] === asset.uniqueId,
+            'doc save timeout retry',
+            RETRY_TIMEOUT
+        );
+        await tdoc.save();
+        await saved;
+
+        const calls = sharedb.sendRaw.getCalls().map((c) => `${c.args[0]}`);
+        const docSaves = calls.filter((c) => c === `doc:save:${asset.uniqueId}`);
+        const reconnects = calls.filter((c) => c === `doc:reconnect:${asset.uniqueId}`);
+        assert.strictEqual(docSaves.length, 2, 'expected timed-out doc:save + retry doc:save');
+        assert.strictEqual(reconnects.length, 1, 'expected one doc:reconnect after missing ack');
     });
 
     test('multi-edit batch offsets cumulate correctly', async () => {

--- a/src/typings/event-map.d.ts
+++ b/src/typings/event-map.d.ts
@@ -11,6 +11,7 @@ export type EventMap = {
     'asset:file:rename': [string, string];
     'asset:file:save': [string];
     'asset:file:dirty': [string, boolean];
+    'asset:file:failed': [string];
     'asset:file:subscribed': [string, string, boolean];
 
     'asset:doc:open': [string];


### PR DESCRIPTION
Fixes #248

### What's Changed

- Treat asset file hashes as the durable clean signal; save acks only clear in-flight attempts.
- Add save ack timeout, retry, and failure tracking that keeps unsafe files dirty and blocks reload/switch until a matching asset hash arrives.
- Block stub-backed pre-subscribe edits by reverting the attempted buffer edit and warning the user.
- Keep collaboration live while save is in-flight; only unsafe project lifecycle actions are blocked.

Before/after examples:

| Case | Before | After |
| --- | --- | --- |
| `doc:save:success` only | Could mark file clean before asset hash | Stays dirty until asset hash matches |
| Missing `doc:save` ack | Save attempt could hang without recovery | Timeout retries, then marks desync |
| Save failure after retries | Reload/switch could proceed unsafely | Reload/switch are blocked |
| Typing during stub subscribe | Edit could be dropped before ShareDB | Edit is reverted with a loading warning |
| Collaborator edits during save | Save ack could clear newer dirty text | Dirty remains and follow-up save coalesces |

Manual tests: not run