### PR TITLE
fix: guard dirty resync

### DIFF
--- a/src/commands.ts
+++ b/src/commands.ts
@@ -7,6 +7,7 @@ import { NAME, VERSION, ENV } from './config';
 import type { Rest } from './connections/rest';
 import { UriHandler } from './handlers/uri-handler';
 import { Log } from './log';
+import { UNSAFE_CHANGES_MESSAGE } from './messages';
 import type { Metrics } from './metrics';
 import type { ProjectManager } from './project-manager';
 import { addAttachment, captureIssue, getLastSentryEventId } from './sentry';
@@ -170,6 +171,14 @@ export const registerProjectCommands = ({
     reload: ReturnType<typeof signal<{ projectManager: ProjectManager } | undefined>>;
     failure: ReturnType<typeof signal<{ err: Error; source?: string } | undefined>>;
 }) => {
+    const unsafe = (projectManager?: ProjectManager) => {
+        if (!projectManager?.unsafeFiles().length) {
+            return false;
+        }
+        void vscode.window.showWarningMessage(UNSAFE_CHANGES_MESSAGE);
+        return true;
+    };
+
     context.subscriptions.push(
         vscode.commands.registerCommand(`${NAME}.openProject`, async () => {
             const [err] = await tryCatch(async () => {
@@ -194,6 +203,9 @@ export const registerProjectCommands = ({
                 if (!projectManager) {
                     return;
                 }
+                if (unsafe(projectManager)) {
+                    return;
+                }
 
                 reload.set(() => ({ projectManager }));
             });
@@ -210,8 +222,11 @@ export const registerProjectCommands = ({
                     return;
                 }
 
-                const { branchId } = cache.get(state.projectId) ?? {};
-                if (!branchId) {
+                const { branchId, projectManager } = cache.get(state.projectId) ?? {};
+                if (!branchId || !projectManager) {
+                    return;
+                }
+                if (unsafe(projectManager)) {
                     return;
                 }
 

--- a/src/disk.ts
+++ b/src/disk.ts
@@ -3,6 +3,7 @@ import { type as ottext } from 'ot-text';
 import * as vscode from 'vscode';
 
 import { NAME } from './config';
+import { OUT_OF_SYNC_FILE_MESSAGE } from './messages';
 import { progressNotification } from './notification';
 import type { ProjectManager } from './project-manager';
 import type { TypeFiles } from './type-installer';
@@ -156,6 +157,19 @@ class Disk extends Linker<{ folderUri: vscode.Uri; projectManager: ProjectManage
             });
     }
 
+    private _syncBlocked(uri: vscode.Uri) {
+        const folderUri = this._folderUri;
+        const pm = this._projectManager;
+        if (!folderUri || !pm) {
+            return false;
+        }
+        return pm.syncBlocked(relativePath(uri, folderUri));
+    }
+
+    private _warnSyncBlocked() {
+        void vscode.window.showWarningMessage(OUT_OF_SYNC_FILE_MESSAGE);
+    }
+
     private _parseIgnoreText(text: string, folderUri: vscode.Uri, h = hash(text)) {
         this._ignoreHash = h;
 
@@ -227,6 +241,9 @@ class Disk extends Linker<{ folderUri: vscode.Uri; projectManager: ProjectManage
     private _create(uri: vscode.Uri, type: 'file' | 'folder', content: Uint8Array) {
         return this._writeMutex.atomic([`${uri}`], async () => {
             if (this._ignoring(uri)) {
+                return;
+            }
+            if (this._syncBlocked(uri)) {
                 return;
             }
 
@@ -311,6 +328,10 @@ class Disk extends Linker<{ folderUri: vscode.Uri; projectManager: ProjectManage
         const snapshot = norm(content);
         return this._writeMutex.atomic([`${uri}`], async () => {
             if (this._ignoring(uri)) {
+                return;
+            }
+            if (this._syncBlocked(uri)) {
+                this._log.warn(`sync.remote.blocked ${uri}`);
                 return;
             }
 
@@ -446,6 +467,9 @@ class Disk extends Linker<{ folderUri: vscode.Uri; projectManager: ProjectManage
             if (this._ignoring(uri)) {
                 return;
             }
+            if (this._syncBlocked(uri)) {
+                return;
+            }
 
             // check local echo by seeing if file exists
             const exists = await fileExists(uri);
@@ -473,6 +497,9 @@ class Disk extends Linker<{ folderUri: vscode.Uri; projectManager: ProjectManage
             if (this._ignoring(oldUri)) {
                 return;
             }
+            if (this._syncBlocked(oldUri) || this._syncBlocked(newUri)) {
+                return;
+            }
 
             // check local echo by seeing if old file exists
             const oldExists = await fileExists(oldUri);
@@ -498,6 +525,9 @@ class Disk extends Linker<{ folderUri: vscode.Uri; projectManager: ProjectManage
     private _save(uri: vscode.Uri) {
         return this._writeMutex.atomic([`${uri}`], async () => {
             if (this._ignoring(uri)) {
+                return;
+            }
+            if (this._syncBlocked(uri)) {
                 return;
             }
 
@@ -531,9 +561,6 @@ class Disk extends Linker<{ folderUri: vscode.Uri; projectManager: ProjectManage
     }
 
     private async _subscribed(uri: vscode.Uri, path: string, content: string, dirty: boolean) {
-        // undo inverses reference pre-reload OT history — clear so undo can't resurrect missing content
-        this._undos.get(uri.path)?.clear();
-
         if (this._opened.has(uri.path)) {
             // reconcile buffer with live ShareDB doc after subscribe
             await this._writeMutex.atomic([`${uri}`], async () => {
@@ -551,25 +578,43 @@ class Disk extends Linker<{ folderUri: vscode.Uri; projectManager: ProjectManage
                     const doc = await vscode.workspace.openTextDocument(uri);
                     const bufferText = norm(doc.getText());
 
-                    // server is authoritative — apply live ShareDB doc to buffer on any divergence
-                    if (file.doc.text !== bufferText) {
-                        const { prefix, suffix } = diff(bufferText, file.doc.text);
-                        const edit = new vscode.WorkspaceEdit();
-                        edit.replace(
-                            uri,
-                            new vscode.Range(doc.positionAt(prefix), doc.positionAt(bufferText.length - suffix)),
-                            file.doc.text.substring(prefix, file.doc.text.length - suffix)
-                        );
-                        const applied = await vscode.workspace.applyEdit(edit);
-                        if (!applied) {
-                            this._log.warn(`subscribe.resync applyEdit failed for ${uri}`);
-                        }
-                        this._log.info(`subscribe.resync ${uri}`);
+                    if (file.doc.text === bufferText) {
+                        pm.unblockSync(path);
+                        this._undos.get(uri.path)?.clear();
+                        return;
                     }
+
+                    if (doc.isDirty || file.dirty || file.doc.pending || pm.syncBlocked(path)) {
+                        pm.blockSync(path);
+                        this._log.warn(`subscribe.resync.blocked ${uri}`);
+                        return;
+                    }
+
+                    // undo inverses reference pre-reload OT history — clear before applying server snapshot
+                    this._undos.get(uri.path)?.clear();
+
+                    // server is authoritative — apply live ShareDB doc to clean buffers only
+                    const { prefix, suffix } = diff(bufferText, file.doc.text);
+                    const edit = new vscode.WorkspaceEdit();
+                    edit.replace(
+                        uri,
+                        new vscode.Range(doc.positionAt(prefix), doc.positionAt(bufferText.length - suffix)),
+                        file.doc.text.substring(prefix, file.doc.text.length - suffix)
+                    );
+                    const applied = await vscode.workspace.applyEdit(edit);
+                    if (!applied) {
+                        this._log.warn(`subscribe.resync applyEdit failed for ${uri}`);
+                    }
+                    this._log.info(`subscribe.resync ${uri}`);
                 });
                 this._locks.delete(`${uri}`);
             });
         } else {
+            if (this._syncBlocked(uri)) {
+                this._log.warn(`subscribe.resync.blocked ${uri}`);
+                return;
+            }
+
             // sync server snapshot to disk for closed files — server is authoritative
             const buf = buffer.from(norm(content));
             const key = `${uri}`;
@@ -635,6 +680,9 @@ class Disk extends Linker<{ folderUri: vscode.Uri; projectManager: ProjectManage
             const path = relativePath(doc.uri, folderUri);
             const file = pm.files.get(path);
             if (!file || file.type !== 'file') {
+                return;
+            }
+            if (pm.syncBlocked(path)) {
                 return;
             }
 
@@ -840,6 +888,10 @@ class Disk extends Linker<{ folderUri: vscode.Uri; projectManager: ProjectManage
             const path = relativePath(uri, folderUri);
             const mgr = this._undos.get(uri.path);
             const file = projectManager.files.get(path);
+            if (projectManager.syncBlocked(path)) {
+                this._warnSyncBlocked();
+                return;
+            }
             if (!mgr?.canUndo || !file || file.type !== 'file') {
                 return;
             }
@@ -863,6 +915,10 @@ class Disk extends Linker<{ folderUri: vscode.Uri; projectManager: ProjectManage
             const path = relativePath(uri, folderUri);
             const mgr = this._undos.get(uri.path);
             const file = projectManager.files.get(path);
+            if (projectManager.syncBlocked(path)) {
+                this._warnSyncBlocked();
+                return;
+            }
             if (!mgr?.canRedo || !file || file.type !== 'file') {
                 return;
             }
@@ -938,6 +994,10 @@ class Disk extends Linker<{ folderUri: vscode.Uri; projectManager: ProjectManage
 
             // check if file is in memory
             const path = relativePath(document.uri, folderUri);
+            if (projectManager.syncBlocked(path)) {
+                this._warnSyncBlocked();
+                return;
+            }
             const file = projectManager.files.get(path);
             if (!file || file.type !== 'file') {
                 return;
@@ -1017,6 +1077,11 @@ class Disk extends Linker<{ folderUri: vscode.Uri; projectManager: ProjectManage
 
             // check if file is in memory
             const path = relativePath(document.uri, folderUri);
+            if (projectManager.syncBlocked(path)) {
+                this._saving.delete(document.uri.path);
+                this._warnSyncBlocked();
+                return;
+            }
             const file = projectManager.files.get(path);
             if (!file || file.type !== 'file') {
                 return;
@@ -1053,6 +1118,10 @@ class Disk extends Linker<{ folderUri: vscode.Uri; projectManager: ProjectManage
             this._saving.delete(document.uri.path);
 
             const path = relativePath(document.uri, folderUri);
+            if (projectManager.syncBlocked(path)) {
+                this._warnSyncBlocked();
+                return;
+            }
             const file = projectManager.files.get(path);
             if (!file || file.type !== 'file') {
                 return;
@@ -1130,6 +1199,11 @@ class Disk extends Linker<{ folderUri: vscode.Uri; projectManager: ProjectManage
                                 // batch create/delete of same file into rename
                                 const path1 = relativePath(op1.uri, folderUri);
                                 const path2 = relativePath(op2.uri, folderUri);
+                                if (projectManager.syncBlocked(path1) || projectManager.syncBlocked(path2)) {
+                                    this._warnSyncBlocked();
+                                    i++;
+                                    continue;
+                                }
                                 const [folder1, name1] = parsePath(path1);
                                 const [folder2, name2] = parsePath(path2);
                                 if (name1 === name2 || folder1 === folder2) {
@@ -1157,6 +1231,10 @@ class Disk extends Linker<{ folderUri: vscode.Uri; projectManager: ProjectManage
                         switch (op.action) {
                             case 'create': {
                                 const path = relativePath(op.uri, folderUri);
+                                if (projectManager.syncBlocked(path)) {
+                                    this._warnSyncBlocked();
+                                    break;
+                                }
                                 this._readMutex.atomic([path], async () => {
                                     const type = await op.type;
                                     const content = await op.content;
@@ -1213,6 +1291,10 @@ class Disk extends Linker<{ folderUri: vscode.Uri; projectManager: ProjectManage
                             }
                             case 'change': {
                                 const path = relativePath(op.uri, folderUri);
+                                if (projectManager.syncBlocked(path)) {
+                                    this._warnSyncBlocked();
+                                    break;
+                                }
                                 this._readMutex.atomic([path], async () => {
                                     const content = await op.content;
                                     if (!content) {
@@ -1272,6 +1354,10 @@ class Disk extends Linker<{ folderUri: vscode.Uri; projectManager: ProjectManage
                             }
                             case 'delete': {
                                 const path = relativePath(op.uri, folderUri);
+                                if (projectManager.syncBlocked(path)) {
+                                    this._warnSyncBlocked();
+                                    break;
+                                }
                                 this._readMutex.atomic([path], async () => {
                                     const type = await op.type;
                                     if (!type) {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -20,6 +20,7 @@ import { ShareDb } from './connections/sharedb';
 import { Disk } from './disk';
 import { UriHandler } from './handlers/uri-handler';
 import { Log } from './log';
+import { UNSAFE_CHANGES_MESSAGE } from './messages';
 import { Metrics } from './metrics';
 import { simpleNotification } from './notification';
 import { ProjectManager } from './project-manager';
@@ -266,6 +267,10 @@ export const activate = async (context: vscode.ExtensionContext) => {
             void vscode.window.showWarningMessage('Dropping reload request to avoid overlapping reloads');
             return false;
         }
+        if (projectManager.unsafeFiles().length) {
+            void vscode.window.showWarningMessage(UNSAFE_CHANGES_MESSAGE);
+            return false;
+        }
         reloading = true;
         const [err] = await tryCatch(async () => {
             // unlink everything
@@ -460,6 +465,10 @@ export const activate = async (context: vscode.ExtensionContext) => {
                 return;
             }
             if (branchId !== branch_id) {
+                return;
+            }
+            if (projectManager.unsafeFiles().length) {
+                void vscode.window.showWarningMessage(UNSAFE_CHANGES_MESSAGE);
                 return;
             }
 

--- a/src/messages.ts
+++ b/src/messages.ts
@@ -1,0 +1,4 @@
+export const OUT_OF_SYNC_FILE_MESSAGE =
+    'PlayCanvas file is out of sync. Reload the project after preserving local changes.';
+
+export const UNSAFE_CHANGES_MESSAGE = 'PlayCanvas changes are not saved. Try again when saving finishes.';

--- a/src/project-manager.ts
+++ b/src/project-manager.ts
@@ -87,6 +87,8 @@ class ProjectManager extends Linker<{ projectId: number; branchId: string }> {
 
     private _queued = new Set<string>();
 
+    private _syncBlocked = new Set<string>();
+
     collisions: CollisionManager;
 
     error = signal<Error | undefined>(undefined);
@@ -126,11 +128,56 @@ class ProjectManager extends Linker<{ projectId: number; branchId: string }> {
         return this._files;
     }
 
+    blockSync(path: string) {
+        this._syncBlocked.add(path);
+
+        const file = this._files.get(path);
+        if (file && file.type !== 'folder') {
+            file.dirty = true;
+            this._events.emit('asset:file:dirty', path, true);
+
+            this._savePending.delete(file.uniqueId);
+            this._saveInflight.delete(file.uniqueId);
+
+            const retry = this._saveRetries.get(file.uniqueId);
+            clearTimeout(retry?.timeout);
+            this._saveRetries.delete(file.uniqueId);
+        }
+
+        this.desync.set(() => true);
+    }
+
+    unblockSync(path: string) {
+        if (!this._syncBlocked.delete(path)) {
+            return;
+        }
+        this._heal();
+    }
+
+    syncBlocked(path: string) {
+        return this._syncBlocked.has(path);
+    }
+
+    unsafeFiles() {
+        const paths = new Set(this._syncBlocked);
+        for (const [path, file] of this._files) {
+            if (file.type === 'file' && (file.dirty || file.doc.pending)) {
+                paths.add(path);
+            } else if (file.type === 'stub' && file.dirty) {
+                paths.add(path);
+            }
+        }
+        return [...paths];
+    }
+
     // called when any doc's pending queue drains. clears desync once the connection
     // is healthy and no other doc has outstanding ops — so the toast/status-bar
     // recovers automatically after a transient stall instead of staying stuck.
     private _heal() {
         if (!this.desync.get() || !this._sharedb.connected.get()) {
+            return;
+        }
+        if (this._syncBlocked.size) {
             return;
         }
         for (const file of this._files.values()) {
@@ -276,15 +323,20 @@ class ProjectManager extends Linker<{ projectId: number; branchId: string }> {
         // shareDB -> vscode (source filtering is internal to OTDocument)
         otdoc.on('op', (op, prev) => {
             const path = this._assetPath(uniqueId);
+            const blocked = this.syncBlocked(path);
 
             // compute dirty: does doc content still differ from last S3 save?
             // if asset metadata is missing, defaults to dirty (undefined !== hash)
             const asset = this._assets.get(uniqueId);
-            const dirty = asset?.file?.hash !== hash(otdoc.text);
+            const dirty = blocked || asset?.file?.hash !== hash(otdoc.text);
             file.dirty = dirty;
 
             // update must run before save so buffer is written before indicator clears
             this._events.emit('asset:file:update', path, op as ShareDbTextOp, otdoc.text, prev);
+            if (blocked) {
+                this._events.emit('asset:file:dirty', path, true);
+                return;
+            }
             if (!dirty) {
                 this._events.emit('asset:file:save', path);
             }
@@ -443,11 +495,26 @@ class ProjectManager extends Linker<{ projectId: number; branchId: string }> {
             // arrive with an empty _saveInflight — harmless
             this._saveInflight.delete(uniqueId);
 
+            const path = this._assetPath(uniqueId);
+            if (this.syncBlocked(path)) {
+                this._savePending.delete(uniqueId);
+
+                const retry = this._saveRetries.get(uniqueId);
+                clearTimeout(retry?.timeout);
+                this._saveRetries.delete(uniqueId);
+
+                const file = this._files.get(path);
+                if (file && file.type !== 'folder') {
+                    file.dirty = true;
+                    this._events.emit('asset:file:dirty', path, true);
+                }
+                return;
+            }
+
             if (!this._verifySave(state, uniqueId)) {
                 return;
             }
 
-            const path = this._assetPath(uniqueId);
             const file = this._files.get(path);
             if (!file || file.type !== 'file') {
                 return;
@@ -772,6 +839,11 @@ class ProjectManager extends Linker<{ projectId: number; branchId: string }> {
                     if (!file || file.type === 'folder') {
                         return;
                     }
+                    if (this.syncBlocked(path)) {
+                        file.dirty = true;
+                        this._events.emit('asset:file:dirty', path, true);
+                        break;
+                    }
 
                     if (file.type === 'file') {
                         // NOTE: only mark clean if local content matches the saved hash,
@@ -860,6 +932,9 @@ class ProjectManager extends Linker<{ projectId: number; branchId: string }> {
     async create(path: string, type: 'folder' | 'file', content?: Uint8Array) {
         if (!this._projectId || !this._branchId) {
             throw this.error.set(() => fail`project not loaded`);
+        }
+        if (this.syncBlocked(path)) {
+            return;
         }
 
         const [parentPath, name] = parsePath(path);
@@ -959,6 +1034,10 @@ class ProjectManager extends Linker<{ projectId: number; branchId: string }> {
     }
 
     async delete(path: string, type: 'file' | 'folder') {
+        if (this.syncBlocked(path)) {
+            return;
+        }
+
         // check if file exists
         const file = this._files.get(path);
         if (!file || (file.type === 'stub' ? 'file' : file.type) !== type) {
@@ -1002,6 +1081,9 @@ class ProjectManager extends Linker<{ projectId: number; branchId: string }> {
     async rename(oldPath: string, newPath: string) {
         if (!this._projectId || !this._branchId) {
             throw this.error.set(() => fail`project not loaded`);
+        }
+        if (this.syncBlocked(oldPath) || this.syncBlocked(newPath)) {
+            return;
         }
 
         // skip if paths are identical
@@ -1115,6 +1197,10 @@ class ProjectManager extends Linker<{ projectId: number; branchId: string }> {
     }
 
     async write(path: string, content: Uint8Array) {
+        if (this.syncBlocked(path)) {
+            return;
+        }
+
         let file = this._files.get(path);
         if (!file || file.type === 'folder') {
             return;
@@ -1155,6 +1241,10 @@ class ProjectManager extends Linker<{ projectId: number; branchId: string }> {
     }
 
     save(path: string) {
+        if (this.syncBlocked(path)) {
+            return;
+        }
+
         // check if file is in memory
         const file = this._files.get(path);
         if (!file || file.type !== 'file') {
@@ -1283,10 +1373,15 @@ class ProjectManager extends Linker<{ projectId: number; branchId: string }> {
         // wire op handler (same as _addFile)
         otdoc.on('op', (op, prev) => {
             const p = this._assetPath(uniqueId);
+            const blocked = this.syncBlocked(p);
             const a = this._assets.get(uniqueId);
-            const d = a?.file?.hash !== hash(otdoc.text);
+            const d = blocked || a?.file?.hash !== hash(otdoc.text);
             promoted.dirty = d;
             this._events.emit('asset:file:update', p, op as ShareDbTextOp, otdoc.text, prev);
+            if (blocked) {
+                this._events.emit('asset:file:dirty', p, true);
+                return;
+            }
             if (!d) {
                 this._events.emit('asset:file:save', p);
             }
@@ -1520,6 +1615,7 @@ class ProjectManager extends Linker<{ projectId: number; branchId: string }> {
             this._idUniqueId.clear();
             this._subscribing.clear();
             this._queued.clear();
+            this._syncBlocked.clear();
 
             this.collisions.clear();
         });

--- a/src/test/suite/extension.test.ts
+++ b/src/test/suite/extension.test.ts
@@ -11,6 +11,7 @@ import * as restModule from '../../connections/rest';
 import * as sharedbModule from '../../connections/sharedb';
 import * as uriHandlerModule from '../../handlers/uri-handler';
 import { Log } from '../../log';
+import { UNSAFE_CHANGES_MESSAGE } from '../../messages';
 import * as sentryModule from '../../sentry';
 import * as typesModule from '../../type-installer';
 import type { Asset } from '../../typings/models';
@@ -445,6 +446,21 @@ const ensurePcignore = async () => {
         return existing;
     }
     return assetCreate({ name: '.pcignore', content: 'ignored*.js\n' });
+};
+
+const markAllSaved = async () => {
+    for (const asset of assets.values()) {
+        const text = documents.get(asset.uniqueId);
+        if (!asset.file || text === undefined) {
+            continue;
+        }
+
+        const file = { ...asset.file, hash: hash(text) };
+        const doc = sharedb.subscriptions.get(`assets:${asset.uniqueId}`);
+        doc?.submitOp([{ p: ['file'], od: asset.file, oi: file }], { source: 'remote' });
+        sharedb.emit('doc:save', 'success', asset.uniqueId);
+    }
+    await waitForIdle('mark all saved');
 };
 
 suite('extension', () => {
@@ -2295,6 +2311,7 @@ suite('extension', () => {
     test('vcs exclusion - .git survives re-link cleanup', async () => {
         const folderUri = vscode.workspace.workspaceFolders?.[0]?.uri;
         assert.ok(folderUri, 'workspace folder should exist');
+        await markAllSaved();
 
         // ensure .git/ and a child file exist on disk before reload
         const gitDir = vscode.Uri.joinPath(folderUri, '.git');
@@ -2990,7 +3007,7 @@ suite('extension', () => {
         const tdoc = await vscode.workspace.openTextDocument(uri);
         await vscode.window.showTextDocument(tdoc);
 
-        // local edit so undo has something to revert
+        // local edit so undo has something to revert, then save so reload is safe
         const localOp = assertOpsPromise(`documents:${asset.uniqueId}`, [['// LOCAL\n']]);
         const localSettled = waitForApplyEdit(uri, 2, 'undo reload first dirty reload');
         const edit = new vscode.WorkspaceEdit();
@@ -3000,6 +3017,15 @@ suite('extension', () => {
         await localSettled;
         await waitForIdle('undo reload local edit settle');
         assert.strictEqual(tdoc.getText(), '// LOCAL\n// ORIG\n');
+
+        const saved = waitForEmit(
+            'doc:save',
+            (args) => args[0] === 'success' && args[1] === asset.uniqueId,
+            'undo reload save'
+        );
+        await tdoc.save();
+        await saved;
+        await waitForIdle('undo reload save settle');
 
         // server ingestSnapshot replaces buffer; undo must drop its inverses
         const doc = sharedb.subscriptions.get(`documents:${asset.uniqueId}`);
@@ -3191,6 +3217,120 @@ suite('extension', () => {
         const reconnects = calls.filter((c) => c === `doc:reconnect:${asset.uniqueId}`);
         assert.strictEqual(docSaves.length, 2, 'expected initial doc:save + retry doc:save');
         assert.strictEqual(reconnects.length, 1, 'expected one doc:reconnect during retry');
+    });
+
+    test('lifecycle commands blocked while changes are unsafe', async () => {
+        const folderUri = vscode.workspace.workspaceFolders?.[0]?.uri;
+        assert.ok(folderUri, 'workspace folder should exist');
+        await markAllSaved();
+
+        const asset = await assetCreate({ name: 'unsafe_lifecycle.js', content: '// ORIG\n' });
+        const uri = vscode.Uri.joinPath(folderUri, asset.name);
+        await vscode.workspace.openTextDocument(uri);
+
+        const edit = new vscode.WorkspaceEdit();
+        edit.insert(uri, new vscode.Position(0, 0), '// DIRTY\n');
+        await vscode.workspace.applyEdit(edit);
+        await waitForIdle('unsafe lifecycle dirty settle');
+
+        warningMessageStub.resetHistory();
+        await assertResolves(vscode.commands.executeCommand(`${NAME}.reloadProject`), `${NAME}.reloadProject`);
+        assert.ok(
+            warningMessageStub.calledWith(UNSAFE_CHANGES_MESSAGE),
+            'reloadProject should warn and refuse unsafe files'
+        );
+
+        warningMessageStub.resetHistory();
+        rest.branchCheckout.resetHistory();
+        await assertResolves(vscode.commands.executeCommand(`${NAME}.switchBranch`), `${NAME}.switchBranch`);
+        assert.ok(
+            warningMessageStub.calledWith(UNSAFE_CHANGES_MESSAGE),
+            'switchBranch should warn and refuse unsafe files'
+        );
+        assert.strictEqual(rest.branchCheckout.callCount, 0, 'switchBranch should not checkout while unsafe');
+    });
+
+    test('dirty sharedb reload preserves buffer and blocks follow-up sync', async () => {
+        const folderUri = vscode.workspace.workspaceFolders?.[0]?.uri;
+        assert.ok(folderUri, 'workspace folder should exist');
+
+        const asset = await assetCreate({ name: 'dirty_reload_blocked.js', content: '// ORIG\n' });
+        const uri = vscode.Uri.joinPath(folderUri, asset.name);
+        const tdoc = await vscode.workspace.openTextDocument(uri);
+
+        const localOp = assertOpsPromise(`documents:${asset.uniqueId}`, [['// LOCAL\n']]);
+        const edit = new vscode.WorkspaceEdit();
+        edit.insert(uri, new vscode.Position(0, 0), '// LOCAL\n');
+        await vscode.workspace.applyEdit(edit);
+        await assertResolves(localOp, 'dirty reload local op');
+        await waitForIdle('dirty reload local settle');
+
+        const local = tdoc.getText();
+        const doc = sharedb.subscriptions.get(`documents:${asset.uniqueId}`);
+        assert.ok(doc, 'sharedb doc should exist');
+
+        warningMessageStub.resetHistory();
+        const blocked = waitForEmit('asset:file:dirty', (args) => args[0] === asset.name, 'dirty reload blocked');
+        const server = '// SERVER SNAPSHOT\n';
+        doc.reload(server);
+        documents.set(asset.uniqueId, server);
+        await blocked;
+        await waitForIdle('dirty reload blocked settle');
+
+        assert.strictEqual(tdoc.getText(), local, 'dirty buffer should not be replaced by server snapshot');
+
+        warningMessageStub.resetHistory();
+        doc.submitOp.resetHistory();
+        sharedb.sendRaw.resetHistory();
+
+        const followup = new vscode.WorkspaceEdit();
+        followup.insert(uri, new vscode.Position(0, 0), '// FOLLOWUP\n');
+        await vscode.workspace.applyEdit(followup);
+        await waitForIdle('blocked followup edit');
+
+        assert.strictEqual(doc.submitOp.callCount, 0, 'blocked file should not submit follow-up ops');
+
+        await tdoc.save();
+        await waitForIdle('blocked followup save');
+        const saves = sharedb.sendRaw.getCalls().filter((c) => `${c.args[0]}`.startsWith('doc:save:'));
+        assert.strictEqual(saves.length, 0, 'blocked file should not send doc:save');
+        assert.ok(
+            warningMessageStub.calledWith(sinon.match(/file is out of sync/i)),
+            'blocked follow-up edit or save should warn'
+        );
+    });
+
+    test('pending sharedb reload preserves buffer', async () => {
+        const folderUri = vscode.workspace.workspaceFolders?.[0]?.uri;
+        assert.ok(folderUri, 'workspace folder should exist');
+
+        const asset = await assetCreate({ name: 'pending_reload_blocked.js', content: '// ORIG\n' });
+        const uri = vscode.Uri.joinPath(folderUri, asset.name);
+        const tdoc = await vscode.workspace.openTextDocument(uri);
+
+        const doc = sharedb.subscriptions.get(`documents:${asset.uniqueId}`);
+        assert.ok(doc, 'sharedb doc should exist');
+        doc._latency = 1000;
+
+        const edit = new vscode.WorkspaceEdit();
+        edit.insert(uri, new vscode.Position(0, 0), '// PENDING\n');
+        await vscode.workspace.applyEdit(edit);
+        await waitForIdle('pending reload local settle');
+        assert.strictEqual(doc.hasPending(), true, 'local op should still be pending');
+
+        const local = tdoc.getText();
+        const blocked = waitForEmit('asset:file:dirty', (args) => args[0] === asset.name, 'pending reload blocked');
+        const server = '// SERVER SNAPSHOT\n';
+        doc.reload(server);
+        documents.set(asset.uniqueId, server);
+        await blocked;
+        await waitForIdle('pending reload blocked settle');
+
+        assert.strictEqual(tdoc.getText(), local, 'pending buffer should not be replaced by server snapshot');
+
+        await new Promise((resolve) => setTimeout(resolve, 1050));
+        await waitForIdle('pending reload latency settle');
+        assert.strictEqual(tdoc.getText(), local, 'pending buffer should stay preserved after op callback');
     });
 
     test('rest assetCreate failure surfaces error to user', async () => {


### PR DESCRIPTION
Fixes #248

### What's Changed

- Preserve open dirty or pending buffers when ShareDB reloads during `subscribe.resync`.
- Mark unsafe files dirty, block their sync path, and keep the project desynced until recovery.
- Suppress follow-up edits, saves, undo/redo, disk watcher changes, and remote disk writes for blocked files.
- Block reload and branch switching while dirty, pending, or blocked files exist.
- Centralize the new user-facing warning copy in `messages.ts`.

Before/after examples:

| Case | Before | After |
| --- | --- | --- |
| Dirty open buffer during `subscribe.resync` | Could be replaced by the server snapshot | Local buffer is preserved and sync is blocked |
| Pending local op during reload | Server snapshot could hide unacked local text | File is marked unsafe and project desync stays visible |
| Follow-up edit on blocked file | Could submit more OT ops against diverged state | Edit is preserved locally but not submitted |
| Saving a blocked file | Could send `doc:save` for unsafe content | Save is suppressed with an out-of-sync warning |
| Reload or branch switch with unsafe files | Could proceed while local text was unresolved | Command is refused until saving/recovery completes |

Manual tests: not run