### PR TITLE
fix: bind OAuth callback to a dynamic port

### DIFF
--- a/src/auth.ts
+++ b/src/auth.ts
@@ -2,7 +2,7 @@ import http from 'http';
 
 import * as vscode from 'vscode';
 
-import { API_URL, COOKIE_NAME, NAME, PUBLISHER, HOME_URL, LOGIN_URL, PLAYCANVAS_VERSION, PORT, WEB } from './config';
+import { API_URL, COOKIE_NAME, NAME, PUBLISHER, HOME_URL, LOGIN_URL, PLAYCANVAS_VERSION, WEB } from './config';
 import { AUTH_TIMEOUT_MS } from './connections/constants';
 import { Rest } from './connections/rest';
 import { tryCatch } from './utils/utils';
@@ -234,7 +234,7 @@ class Auth {
             }, AUTH_TIMEOUT_MS);
             const server = http.createServer(async (req, res) => {
                 if (req.url?.startsWith('/auth/callback')) {
-                    const url = new URL(req.url, `http://localhost:${PORT}`);
+                    const url = new URL(req.url, 'http://localhost');
                     const query = url.searchParams;
                     const code = query.get('code');
 
@@ -315,11 +315,17 @@ class Auth {
                 }
             });
             server
-                .listen(PORT, () => {
+                .listen(0, () => {
+                    const { port } = server.address() as { port: number };
                     const oauthUri = vscode.Uri.parse(LOGIN_URL).with({
-                        query: `came_from=http://localhost:${PORT}/auth/callback`
+                        query: `came_from=http://localhost:${port}/auth/callback`
                     });
-                    void vscode.env.openExternal(oauthUri);
+                    void vscode.env.openExternal(oauthUri).then((opened) => {
+                        if (opened) return;
+                        clearTimeout(timeout);
+                        server.close();
+                        reject(new Error('Authentication cancelled.'));
+                    });
                 })
                 .on('error', (err) => {
                     clearTimeout(timeout);

--- a/src/config.ts
+++ b/src/config.ts
@@ -7,7 +7,6 @@ export const PLAYCANVAS_VERSION = packageJson.devDependencies.playcanvas;
 
 export const DEBUG = process.env.NODE_ENV === 'development';
 export const ENV = process.env.ENV || 'prod';
-export const PORT = parseInt(process.env.PORT || '61000', 10);
 export const WEB = process.env.PLATFORM === 'web';
 export const ROOT_FOLDER = process.env.ROOT_FOLDER || '';
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -101,6 +101,17 @@ export const activate = async (context: vscode.ExtensionContext) => {
             return;
         }
 
+        // user-initiated cancel — surface as warning + retry, not an error
+        if (err.message === 'Authentication cancelled.') {
+            const login = 'Log in';
+            void vscode.window.showWarningMessage(err.message, login).then((choice) => {
+                if (choice === login) {
+                    void vscode.commands.executeCommand(`${NAME}.login`);
+                }
+            });
+            return;
+        }
+
         // log to output channel (also reports to sentry)
         log.error(err);
 


### PR DESCRIPTION
## Summary
- Bind the local OAuth callback HTTP server to port `0` and use the OS-assigned port for `came_from`. The previous fixed `61000` failed with `EACCES` / `EADDRINUSE` whenever the port was already held (parallel login from another VS Code window, leaked listener from a previous lifecycle, unrelated process).
- When the user cancels the "open external URL" prompt, close the server immediately and surface the failure as a yellow warning with a **Log in** button — instead of waiting out the 2-min auth timeout and routing through `handleError` as a red "PlayCanvas Error" toast + Sentry report.

Fixes #305

## Test plan
- [x] Login completes successfully end-to-end on a fresh window.
- [x] Run two VS Code windows; trigger `playcanvas.login` in both — both reach the browser instead of one failing with `EADDRINUSE`.
- [x] Cancel the "Allow … to open external URL?" prompt → warning toast with **Log in** appears (no red error, no Sentry event), and clicking **Log in** re-enters the OAuth flow.