### PR TITLE
fix: coalesce concurrent creates for the same path

### DIFF
--- a/src/project-manager.ts
+++ b/src/project-manager.ts
@@ -962,7 +962,7 @@ class ProjectManager extends Linker<{ projectId: number; branchId: string }> {
             return inflight;
         }
 
-        const pending = this._doCreate(path, type, content);
+        const pending = this._createOnce(path, type, content);
         this._creating.set(path, pending);
         const [err] = await tryCatch(pending);
         this._creating.delete(path);
@@ -971,7 +971,7 @@ class ProjectManager extends Linker<{ projectId: number; branchId: string }> {
         }
     }
 
-    private async _doCreate(path: string, type: 'folder' | 'file', content?: Uint8Array) {
+    private async _createOnce(path: string, type: 'folder' | 'file', content?: Uint8Array) {
         if (!this._projectId || !this._branchId) {
             throw this.error.set(() => fail`project not loaded`);
         }

--- a/src/project-manager.ts
+++ b/src/project-manager.ts
@@ -89,6 +89,8 @@ class ProjectManager extends Linker<{ projectId: number; branchId: string }> {
 
     private _subscribing = new Map<number, Promise<(VirtualFile & { type: 'file' }) | undefined>>();
 
+    private _creating = new Map<string, Promise<void>>();
+
     private _subscribeFailed = new Set<number>();
 
     private _queued = new Set<string>();
@@ -953,6 +955,23 @@ class ProjectManager extends Linker<{ projectId: number; branchId: string }> {
     }
 
     async create(path: string, type: 'folder' | 'file', content?: Uint8Array) {
+        // coalesce concurrent creates for the same path so siblings under a not-yet-acked
+        // folder don't each fire a duplicate REST and produce "parent folder is not found"
+        const inflight = this._creating.get(path);
+        if (inflight) {
+            return inflight;
+        }
+
+        const pending = this._doCreate(path, type, content);
+        this._creating.set(path, pending);
+        const [err] = await tryCatch(pending);
+        this._creating.delete(path);
+        if (err) {
+            throw err;
+        }
+    }
+
+    private async _doCreate(path: string, type: 'folder' | 'file', content?: Uint8Array) {
         if (!this._projectId || !this._branchId) {
             throw this.error.set(() => fail`project not loaded`);
         }


### PR DESCRIPTION
## Summary
When a bulk filesystem change lands (e.g. `git pull` adds a tree of new files), the disk watcher's ancestor-ensure loop runs concurrently for each leaf event. Multiple sibling events all observe the same ancestor missing, all call `projectManager.create(ancestorPath, 'folder')`, and the duplicate REST calls produce HTTP 400 `parent folder is not found`. The optimistic `_files.set` happens after REST returns, so the existing "already exists" early-return doesn't dedupe in-flight calls.

Add a `_creating: Map<path, Promise>` coalescer in `ProjectManager.create` that mirrors the existing `_subscribing` pattern — concurrent callers for the same path share one in-flight promise. No change in `disk.ts`: the ancestor loop already routes through `create()`.

Fixes #306

## Test plan
- [x] Existing `'folder create - copy tree local to remote'` integration test still passes (serial ancestor path).
- [x] In a checked-out project, run `git pull` (or similar) that adds a nested folder tree of new files; confirm Sentry / output log no longer shows `HTTP 400 parent folder is not found`.
- [x] Single-file create still works (no regression on the normal path).

## Notes
A deterministic integration test for the concurrent race would require either exposing `projectManager` for direct invocation or relying on VS Code watcher batching timing across multiple `fs.writeFile` calls — the latter is flaky. The fix mirrors `_subscribing` (already covered by `'auth dedupes concurrent login'`-style tests), so confidence comes from the pattern parity rather than a new test.