### PR TITLE
fix: refresh access token on reconnect across sharedb/relay/messenger

### DIFF
--- a/src/auth.ts
+++ b/src/auth.ts
@@ -13,6 +13,7 @@ type Session = {
 };
 
 type EditorConfig = {
+    accessToken?: string;
     engineVersion: string;
 };
 
@@ -82,7 +83,7 @@ class Auth {
         await this._context.globalState?.update(ENGINE_VERSION_KEY, engineVersion);
     }
 
-    private async _fetchEditorConfig(sessionId: string) {
+    private async _fetchEditorConfig(sessionId: string): Promise<EditorConfig> {
         const current = await this._cachedEngineVersion();
         const ctrl = new AbortController();
         const timer = setTimeout(() => ctrl.abort(), AUTH_TIMEOUT_MS);
@@ -104,9 +105,12 @@ class Auth {
             return { engineVersion: current };
         }
 
-        const { engineVersion } = parseEditorConfig(text);
+        const { accessToken, engineVersion } = parseEditorConfig(text);
+        if (accessToken) {
+            await this._context.secrets.store(`${NAME}.accessToken`, accessToken);
+        }
         await this._storeEngineVersion(engineVersion);
-        return { engineVersion: engineVersion || current };
+        return { accessToken, engineVersion: engineVersion || current };
     }
 
     async getEditorConfig() {
@@ -404,6 +408,17 @@ class Auth {
             // validate token
             const session = await this._validateAccessToken(accessToken);
             accessToken = session?.accessToken;
+        }
+
+        // silent refresh via session cookie — editor-server returns the session's
+        // current accessToken, skipping OAuth when the session is still alive
+        if (!accessToken && !manual && !WEB) {
+            const sessionId = await this._context.secrets.get(SESSION_ID_KEY);
+            if (sessionId) {
+                const refreshed = await this._fetchEditorConfig(sessionId);
+                const session = await this._validateAccessToken(refreshed.accessToken);
+                accessToken = session?.accessToken;
+            }
         }
 
         if (!accessToken) {

--- a/src/connections/messenger.ts
+++ b/src/connections/messenger.ts
@@ -5,7 +5,7 @@ import { Log } from '../log';
 import { Deferred } from '../utils/deferred';
 import { EventEmitter } from '../utils/event-emitter';
 import { signal } from '../utils/signal';
-import { withTimeout } from '../utils/utils';
+import { tryCatch, withTimeout } from '../utils/utils';
 
 import {
     CONNECT_TIMEOUT_MS,
@@ -91,7 +91,7 @@ class Messenger extends EventEmitter<EventMap> {
 
     private _disconnecting = false;
 
-    private _getToken: (() => string) | null = null;
+    private _getToken: (() => Promise<string | undefined>) | null = null;
 
     private _lastPong = 0;
 
@@ -114,10 +114,10 @@ class Messenger extends EventEmitter<EventMap> {
         this.origin = origin;
     }
 
-    private _connect() {
+    private async _connect() {
         this._disconnecting = false;
 
-        const accessToken = this._getToken!();
+        const accessToken = await this._getToken!();
         const options = WEB
             ? undefined
             : {
@@ -311,11 +311,16 @@ class Messenger extends EventEmitter<EventMap> {
         const delay = Math.min(RECONNECT_BASE_MS * Math.pow(2, this._reconnectAttempt), RECONNECT_MAX_MS);
         this._log.info(`reconnecting in ${delay}ms (attempt ${this._reconnectAttempt + 1})`);
         this._reconnectAttempt++;
-        this._reconnectTimer = setTimeout(() => {
+        this._reconnectTimer = setTimeout(async () => {
             if (this._disconnecting) {
                 return;
             }
-            this._socket = this._connect();
+            const [err, socket] = await tryCatch(this._connect());
+            if (err) {
+                this._log.warn('failed to reconnect', err.message);
+                return;
+            }
+            this._socket = socket;
         }, delay);
     }
 
@@ -327,9 +332,9 @@ class Messenger extends EventEmitter<EventMap> {
         }
     }
 
-    async connect(getToken: () => string) {
+    async connect(getToken: () => Promise<string | undefined>) {
         this._getToken = getToken;
-        this._socket = this._connect();
+        this._socket = await this._connect();
         await withTimeout(this._active.promise, CONNECT_TIMEOUT_MS, 'Messenger connection timed out');
     }
 

--- a/src/connections/relay.ts
+++ b/src/connections/relay.ts
@@ -6,7 +6,7 @@ import { Deferred } from '../utils/deferred';
 import { fail } from '../utils/error';
 import { EventEmitter } from '../utils/event-emitter';
 import { signal } from '../utils/signal';
-import { withTimeout } from '../utils/utils';
+import { tryCatch, withTimeout } from '../utils/utils';
 
 import {
     AUTH_CLOSE_CODE,
@@ -40,7 +40,9 @@ class Relay extends EventEmitter<EventMap> {
 
     private _disconnecting = false;
 
-    private _getToken: (() => string) | null = null;
+    private _authRetried = false;
+
+    private _getToken: (() => Promise<string | undefined>) | null = null;
 
     private _lastPong = 0;
 
@@ -65,10 +67,10 @@ class Relay extends EventEmitter<EventMap> {
         this.origin = origin;
     }
 
-    private _connect() {
+    private async _connect() {
         this._disconnecting = false;
 
-        const accessToken = this._getToken!();
+        const accessToken = await this._getToken!();
         const options = WEB
             ? undefined
             : {
@@ -86,8 +88,8 @@ class Relay extends EventEmitter<EventMap> {
             this._authTimeout = null;
             const reason = `[${this.constructor.name}] invalid access token`;
             // TODO: figure out why this triggers 1006 not 3000
+            // error is set in the close handler so we can retry once with a fresh token first
             socket.close(3000, reason);
-            this.error.set(() => fail`${reason}`);
         }, 5000);
         socket.addEventListener('open', () => {
             this._log.debug('socket.open');
@@ -130,8 +132,14 @@ class Relay extends EventEmitter<EventMap> {
                 return;
             }
 
-            // skip reconnect on auth failure — retrying with same token won't help
+            // auth failure — retry once with a fresh token before giving up
             if (code === AUTH_CLOSE_CODE) {
+                if (this._authRetried) {
+                    this.error.set(() => fail`[${this.constructor.name}] invalid access token`);
+                    return;
+                }
+                this._authRetried = true;
+                this._scheduleReconnect();
                 return;
             }
 
@@ -145,6 +153,7 @@ class Relay extends EventEmitter<EventMap> {
     private _onauth(socket: WebSocket) {
         // reset backoff on successful auth
         this._reconnectAttempt = 0;
+        this._authRetried = false;
         this._lastPong = Date.now();
         this._pings.length = 0;
 
@@ -292,11 +301,16 @@ class Relay extends EventEmitter<EventMap> {
         const delay = Math.min(RECONNECT_BASE_MS * Math.pow(2, this._reconnectAttempt), RECONNECT_MAX_MS);
         this._log.info(`reconnecting in ${delay}ms (attempt ${this._reconnectAttempt + 1})`);
         this._reconnectAttempt++;
-        this._reconnectTimer = setTimeout(() => {
+        this._reconnectTimer = setTimeout(async () => {
             if (this._disconnecting) {
                 return;
             }
-            this._socket = this._connect();
+            const [err, socket] = await tryCatch(this._connect());
+            if (err) {
+                this.error.set(() => err);
+                return;
+            }
+            this._socket = socket;
         }, delay);
     }
 
@@ -308,9 +322,10 @@ class Relay extends EventEmitter<EventMap> {
         }
     }
 
-    async connect(getToken: () => string) {
+    async connect(getToken: () => Promise<string | undefined>) {
         this._getToken = getToken;
-        this._socket = this._connect();
+        this._authRetried = false;
+        this._socket = await this._connect();
         await withTimeout(this._active.promise, CONNECT_TIMEOUT_MS, 'Relay connection timed out');
     }
 

--- a/src/connections/sharedb.ts
+++ b/src/connections/sharedb.ts
@@ -54,7 +54,9 @@ class ShareDb extends EventEmitter<EventMap> {
 
     private _disconnecting = false;
 
-    private _getToken: (() => string) | null = null;
+    private _authRetried = false;
+
+    private _getToken: (() => Promise<string | undefined>) | null = null;
 
     private _lastPong = 0;
 
@@ -75,10 +77,10 @@ class ShareDb extends EventEmitter<EventMap> {
         this.origin = origin;
     }
 
-    private _connect() {
+    private async _connect() {
         this._disconnecting = false;
 
-        const accessToken = this._getToken!();
+        const accessToken = await this._getToken!();
         const options = WEB
             ? undefined
             : {
@@ -103,8 +105,8 @@ class ShareDb extends EventEmitter<EventMap> {
                 const json = JSON.parse(data.toString().slice(4));
                 if (!json.id) {
                     const reason = `[${this.constructor.name}] invalid access token`;
+                    // error is set in the close handler so we can retry once with a fresh token first
                     socket.close(3000, reason);
-                    this.error.set(() => fail`${reason}`);
                     return;
                 }
                 this._log.debug('socket.auth', json);
@@ -147,8 +149,14 @@ class ShareDb extends EventEmitter<EventMap> {
                 return;
             }
 
-            // skip reconnect on auth failure — retrying with same token won't help
+            // auth failure — retry once with a fresh token before giving up
             if (code === AUTH_CLOSE_CODE) {
+                if (this._authRetried) {
+                    this.error.set(() => fail`[${this.constructor.name}] invalid access token`);
+                    return;
+                }
+                this._authRetried = true;
+                this._scheduleReconnect();
                 return;
             }
 
@@ -162,6 +170,7 @@ class ShareDb extends EventEmitter<EventMap> {
     private async _onauth(socket: WebSocket) {
         // reset backoff on successful auth
         this._reconnectAttempt = 0;
+        this._authRetried = false;
         this._lastPong = Date.now();
 
         if (this._connection) {
@@ -367,11 +376,16 @@ class ShareDb extends EventEmitter<EventMap> {
         const delay = Math.min(RECONNECT_BASE_MS * Math.pow(2, this._reconnectAttempt), RECONNECT_MAX_MS);
         this._log.info(`reconnecting in ${delay}ms (attempt ${this._reconnectAttempt + 1})`);
         this._reconnectAttempt++;
-        this._reconnectTimer = setTimeout(() => {
+        this._reconnectTimer = setTimeout(async () => {
             if (this._disconnecting) {
                 return;
             }
-            this._socket = this._connect();
+            const [err, socket] = await tryCatch(this._connect());
+            if (err) {
+                this.error.set(() => err);
+                return;
+            }
+            this._socket = socket;
         }, delay);
     }
 
@@ -383,9 +397,10 @@ class ShareDb extends EventEmitter<EventMap> {
         }
     }
 
-    async connect(getToken: () => string) {
+    async connect(getToken: () => Promise<string | undefined>) {
         this._getToken = getToken;
-        this._socket = this._connect();
+        this._authRetried = false;
+        this._socket = await this._connect();
         await withTimeout(this._active.promise, CONNECT_TIMEOUT_MS, 'ShareDB connection timed out');
     }
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -623,7 +623,7 @@ export const activate = async (context: vscode.ExtensionContext) => {
 
         // connect sharedb, messenger, relay if not connected
         if (!sharedb.connected.get()) {
-            const [err] = await tryCatch(sharedb.connect(() => accessToken));
+            const [err] = await tryCatch(sharedb.connect(() => auth.getAccessToken()));
             if (err) {
                 sharedb.disconnect();
                 failure.set(() => ({ err, source: 'sharedb' }));
@@ -649,7 +649,7 @@ export const activate = async (context: vscode.ExtensionContext) => {
             );
         }
         if (!relay.connected.get()) {
-            const [err] = await tryCatch(relay.connect(() => accessToken));
+            const [err] = await tryCatch(relay.connect(() => auth.getAccessToken()));
             if (err) {
                 relay.disconnect();
                 failure.set(() => ({ err, source: 'relay' }));

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -636,7 +636,7 @@ export const activate = async (context: vscode.ExtensionContext) => {
             );
         }
         if (!messenger.connected.get()) {
-            const [err] = await tryCatch(messenger.connect(() => accessToken));
+            const [err] = await tryCatch(messenger.connect(() => auth.getAccessToken()));
             if (err) {
                 messenger.disconnect();
                 failure.set(() => ({ err, source: 'messenger' }));

--- a/src/test/mocks/messenger.ts
+++ b/src/test/mocks/messenger.ts
@@ -3,7 +3,7 @@ import type sinon from 'sinon';
 import { Messenger } from '../../connections/messenger';
 
 class MockMessenger extends Messenger {
-    connect: sinon.SinonSpy<[() => string], Promise<void>>;
+    connect: sinon.SinonSpy<[() => Promise<string | undefined>], Promise<void>>;
 
     disconnect: sinon.SinonSpy<[], void>;
 
@@ -19,7 +19,7 @@ class MockMessenger extends Messenger {
             origin: ''
         });
 
-        this.connect = sandbox.spy(async (_getToken: () => string) => {
+        this.connect = sandbox.spy(async (_getToken: () => Promise<string | undefined>) => {
             this.connected.set(() => true);
         });
         this.disconnect = sandbox.spy(() => {

--- a/src/test/mocks/relay.ts
+++ b/src/test/mocks/relay.ts
@@ -3,7 +3,7 @@ import type sinon from 'sinon';
 import { Relay } from '../../connections/relay';
 
 class MockRelay extends Relay {
-    connect: sinon.SinonSpy<[() => string], Promise<void>>;
+    connect: sinon.SinonSpy<[() => Promise<string | undefined>], Promise<void>>;
 
     disconnect: sinon.SinonSpy<[], void>;
 
@@ -19,7 +19,7 @@ class MockRelay extends Relay {
             origin: ''
         });
 
-        this.connect = sandbox.spy(async (_getToken: () => string) => {
+        this.connect = sandbox.spy(async (_getToken: () => Promise<string | undefined>) => {
             this.connected.set(() => true);
         });
         this.disconnect = sandbox.spy(() => {

--- a/src/test/mocks/sharedb.ts
+++ b/src/test/mocks/sharedb.ts
@@ -315,7 +315,7 @@ class MockDoc extends Doc {
 class MockShareDb extends ShareDb {
     subscriptions = new Map<string, MockDoc>();
 
-    connect: sinon.SinonSpy<[() => string], Promise<void>>;
+    connect: sinon.SinonSpy<[() => Promise<string | undefined>], Promise<void>>;
 
     disconnect: sinon.SinonSpy<[], void>;
 
@@ -406,7 +406,7 @@ class MockShareDb extends ShareDb {
     constructor(sandbox: sinon.SinonSandbox, messenger: MockMessenger) {
         super({ url: '', origin: '' });
 
-        this.connect = sandbox.spy(async (_getToken: () => string) => {
+        this.connect = sandbox.spy(async (_getToken: () => Promise<string | undefined>) => {
             this.connected.set(() => true);
         });
         this.disconnect = sandbox.spy(() => {


### PR DESCRIPTION
## Summary
Previously, `sharedb.connect`, `relay.connect`, and `messenger.connect` were all called with `() => accessToken` — a closure capturing the token at link time. Every reconnect reused the **same captured token forever**, regardless of whether it had been revoked or rotated server-side. Combined with each connection's own auth-failure handling, this produced three flavours of the same bug:

- **ShareDB**: on server-replied `auth{id:null}`, client closes 3000 and `AUTH_CLOSE_CODE` short-circuits reconnect → presence dies silently.
- **Relay**: client's 5s handshake timeout closes 3000 and `AUTH_CLOSE_CODE` short-circuits reconnect → presence dies silently. (Note: a *server* token rejection actually returns HTTP 500/401 at upgrade → close code 1006, so the 3000 path was mostly catching transient handshake slowness. The 1006 path still reconnected, but with the same stale token.)
- **Messenger**: server just calls `socket.close()` with no code on auth failure → client reconnects forever, but with the same stale token, never recovering.

### Backend token reality
Tokens aren't refresh-token-style and don't have a TTL on the underlying `access` collection row. They're *served by editor-server* (`editor.ts:318`) from `sessions.access_token`, where the session has a 15-day sliding TTL. A new login (anywhere) mints a new token and points the session at it; logout deletes the access row. So the extension's token becomes invalid when the user logged out somewhere else, or when their session rotated.

### Fix
- Change `_getToken` across all three connections from `() => string` to `() => Promise<string | undefined>`, and pass `() => auth.getAccessToken()` from `extension.ts`. Every reconnect now re-validates the stored token against the server.
- **Silent refresh in `auth.getAccessToken()`**: between validation failure and OAuth fallback, re-fetch `${HOME_URL}/editor` with the stored session cookie. Editor-server returns the session's current accessToken in the rendered HTML — `_fetchEditorConfig` already fetched this for `engineVersion` and was discarding the token. We now parse and store both. This handles the rotated-by-fresh-login case without dragging the user through OAuth.
- For ShareDB and Relay: track an `_authRetried` flag and on the first AUTH_CLOSE_CODE, schedule a reconnect rather than giving up; reset on successful auth. Surface the `error` signal only if the *retry* fails — a successful refresh stays silent.
- For Messenger: no retry-once flag needed; it already reconnects with backoff. The token-refresh change alone is the fix.

### Refresh fallback order
1. Cached token validates against server → use it (cheapest)
2. Otherwise, fetch editor HTML with session cookie → store/use the served accessToken (silent, works while session is alive)
3. Otherwise, full OAuth flow (last resort)

Fixes #307

## Test plan
- [x] Normal login still works (no regression on the happy path).
- [x] Trigger a rotated token (log in from a browser): VS Code's stored token validates fails, session-cookie refresh picks up the new token from editor-server, connections reconnect silently — no OAuth popup.
- [x] Full logout-everywhere: validation fails *and* session-cookie refresh fails (editor-server returns a redirect, no accessToken in HTML); falls through to OAuth.
- [x] ShareDB-specific: server returns `auth{id:null}` → close 3000 → retry-once with refreshed token → succeeds.
- [x] Relay-specific: 5s handshake stalls → close 3000 → retry-once.
- [x] Messenger-specific: server closes socket on bad token → normal reconnect with fresh token → succeeds.
- [x] If retry *also* fails for sharedb/relay: the `error` signal fires.

## Notes
No new automated test — the existing `MockRelay`/`MockShareDb`/`MockMessenger` only stub `connect` as a sinon spy and don't simulate the WebSocket auth-handshake lifecycle.

Backend cross-check (`monorepo/services/{relay-server,collab-server,messenger,editor-server,login-server}` and `shared-libs/lib/auth.js`) confirms:
- `access` collection has no TTL; tokens are revoked explicitly via logout.
- `sessions` collection has a 15-day TTL on the `expires` field (sliding window).
- Editor-server `/editor` returns `accessToken: req.self.accessToken` derived from the session cookie — same refresh-route the extension can use.
- relay-server: auth at HTTP upgrade via cookie/Bearer header → bad token returns HTTP 500/401 → close code 1006 (NOT 3000).
- collab-server: in-band `auth` message → server replies `auth{id: null}` on failure → client emits code 3000.
- messenger: in-band `authenticate` message → server `socket.close()` with no code on failure.