### PR TITLE
Adopt @playcanvas/eslint-config v3 (/typescript)

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,99 +1,25 @@
-import eslint from '@eslint/js';
+import typescriptConfig from '@playcanvas/eslint-config/typescript';
 import { defineConfig } from 'eslint/config';
-import eslintConfigPrettier from 'eslint-config-prettier/flat';
-import pluginImport from 'eslint-plugin-import';
-import * as pluginPackageJson from 'eslint-plugin-package-json';
-import globals from 'globals';
-import jsoncEslintParser from 'jsonc-eslint-parser';
-import tseslint from 'typescript-eslint';
-
-const ignoreConfig = {
-    ignores: ['**/node_modules', '**/out', '.vscode-test*/**', '.vscode-storage/**']
-};
-
-const baseConfig = {
-    rules: {
-        curly: 'error',
-        'import/order': [
-            'error',
-            {
-                alphabetize: { order: 'asc', caseInsensitive: true },
-                'newlines-between': 'always',
-                groups: ['builtin', 'external', 'internal', 'parent', 'sibling', 'index', 'object']
-            }
-        ],
-        '@typescript-eslint/no-invalid-void-type': 'off',
-        '@typescript-eslint/consistent-type-definitions': ['error', 'type'],
-        '@typescript-eslint/no-unused-vars': [
-            'error',
-            {
-                argsIgnorePattern: '^_',
-                varsIgnorePattern: '^_',
-                caughtErrorsIgnorePattern: '^_'
-            }
-        ]
-    },
-    settings: {
-        'import/resolver': {
-            typescript: true
-        }
-    }
-};
-
-const tsFilesConfig = {
-    files: ['**/*.{js,mjs,ts}'],
-    plugins: {
-        '@typescript-eslint': tseslint.plugin
-    },
-    languageOptions: {
-        parser: tseslint.parser,
-        ecmaVersion: 2022,
-        sourceType: 'module',
-        globals: globals.node
-    },
-    rules: {
-        '@typescript-eslint/consistent-type-imports': 'error',
-        '@typescript-eslint/no-dynamic-delete': 'off',
-        '@typescript-eslint/no-non-null-assertion': 'off'
-    }
-};
-
-const packageJsonRules = {
-    ...pluginPackageJson.configs.recommended.rules,
-    'package-json/require-exports': 'off',
-    'package-json/require-sideEffects': 'off'
-};
-
-const packageJsonConfig = {
-    files: ['**/package.json', '**/package-lock.json'],
-    languageOptions: {
-        parser: jsoncEslintParser
-    },
-    plugins: {
-        'package-json': pluginPackageJson
-    },
-    rules: packageJsonRules
-};
-
-const rootPackageJsonConfig = {
-    files: ['package.json'],
-    rules: {
-        'package-json/require-files': 'off'
-    }
-};
 
 export default defineConfig(
-    eslint.configs.recommended,
-    tseslint.configs.recommended,
-    tseslint.configs.strict,
-    tseslint.configs.stylistic,
-    pluginImport.flatConfigs.recommended,
-    ignoreConfig,
-    baseConfig,
-    tsFilesConfig,
-    packageJsonConfig,
-    rootPackageJsonConfig,
+    ...typescriptConfig,
 
-    // last: disable ESLint formatting rules that conflict with Prettier (Prettier runs separately)
-    eslintConfigPrettier
+    {
+        ignores: ['**/node_modules', '**/out', '.vscode-test*/**', '.vscode-storage/**']
+    },
+
+    // this extension's package.json intentionally omits these fields
+    {
+        files: ['**/package.json', '**/package-lock.json'],
+        rules: {
+            'package-json/require-exports': 'off',
+            'package-json/require-sideEffects': 'off'
+        }
+    },
+    {
+        files: ['package.json'],
+        rules: {
+            'package-json/require-files': 'off'
+        }
+    }
 );

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,8 +18,7 @@
                 "ws": "^8.18.3"
             },
             "devDependencies": {
-                "@eslint/js": "9.39.4",
-                "@playcanvas/eslint-config": "3.0.0-beta.3",
+                "@playcanvas/eslint-config": "3.0.0-beta.5",
                 "@rollup/plugin-commonjs": "29.0.2",
                 "@rollup/plugin-json": "6.1.0",
                 "@rollup/plugin-node-resolve": "16.0.3",
@@ -37,19 +36,12 @@
                 "@vscode/test-web": "0.0.80",
                 "dotenv": "17.4.2",
                 "eslint": "9.39.4",
-                "eslint-config-prettier": "10.1.8",
-                "eslint-import-resolver-typescript": "4.4.4",
-                "eslint-plugin-import": "2.32.0",
-                "eslint-plugin-package-json": "0.91.1",
-                "globals": "17.5.0",
-                "jsonc-eslint-parser": "2.4.2",
                 "playcanvas": "2.18.1",
                 "prettier": "3.8.3",
                 "rollup": "4.60.2",
                 "rollup-plugin-polyfill-node": "0.13.0",
                 "sinon": "21.1.2",
-                "typescript": "6.0.3",
-                "typescript-eslint": "8.59.0"
+                "typescript": "6.0.3"
             },
             "engines": {
                 "vscode": "^1.98.0"
@@ -474,9 +466,9 @@
             }
         },
         "node_modules/@eslint/config-array/node_modules/brace-expansion": {
-            "version": "1.1.12",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-            "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+            "version": "1.1.15",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
+            "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -548,9 +540,9 @@
             }
         },
         "node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
-            "version": "1.1.12",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-            "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+            "version": "1.1.15",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
+            "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -811,6 +803,13 @@
                 "@tybys/wasm-util": "^0.10.0"
             }
         },
+        "node_modules/@package-json/types": {
+            "version": "0.0.12",
+            "resolved": "https://registry.npmjs.org/@package-json/types/-/types-0.0.12.tgz",
+            "integrity": "sha512-uu43FGU34B5VM9mCNjXCwLaGHYjXdNincqKLaraaCW+7S2+SmiBg1Nv8bPnmschrIfZmfKNY9f3fC376MRrObw==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/@pkgjs/parseargs": {
             "version": "0.11.0",
             "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
@@ -823,16 +822,16 @@
             }
         },
         "node_modules/@playcanvas/eslint-config": {
-            "version": "3.0.0-beta.3",
-            "resolved": "https://registry.npmjs.org/@playcanvas/eslint-config/-/eslint-config-3.0.0-beta.3.tgz",
-            "integrity": "sha512-LvF4rr/bAlC1OE9zXwfRII9wnM6vycUuccfDu2EOeTXeutdRSxXwJaIzqcFUZ8PmVFYk1DGJp6YSsnWUo0N4ww==",
+            "version": "3.0.0-beta.5",
+            "resolved": "https://registry.npmjs.org/@playcanvas/eslint-config/-/eslint-config-3.0.0-beta.5.tgz",
+            "integrity": "sha512-ItIq14McE3GlFjJkO3oPeqw2MHcKCoZnoWuNTv8B7dftE9lVftTi5TCBIBLG6/wxB6EaS6rK1zoIFoNpSazXwA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@eslint/js": "^9.39.0",
                 "eslint-config-prettier": "^10.1.8",
                 "eslint-import-resolver-typescript": "^4.4.4",
-                "eslint-plugin-import": "^2.32.0",
+                "eslint-plugin-import-x": "^4.16.2",
                 "eslint-plugin-jsdoc": "^61.1.11",
                 "eslint-plugin-jsx-a11y": "^6.10.2",
                 "eslint-plugin-package-json": "^0.59.1",
@@ -841,7 +840,7 @@
                 "eslint-plugin-regexp": "^2.10.0",
                 "globals": "^16.5.0",
                 "jsonc-eslint-parser": "^2.4.1",
-                "typescript-eslint": "^8.46.2"
+                "typescript-eslint": "^8.60.1"
             },
             "peerDependencies": {
                 "eslint": ">= 9",
@@ -1537,7 +1536,9 @@
             "resolved": "https://registry.npmjs.org/@rtsao/scc/-/scc-1.1.0.tgz",
             "integrity": "sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==",
             "dev": true,
-            "license": "MIT"
+            "license": "MIT",
+            "optional": true,
+            "peer": true
         },
         "node_modules/@sentry-internal/browser-utils": {
             "version": "10.49.0",
@@ -1997,7 +1998,9 @@
             "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
             "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
             "dev": true,
-            "license": "MIT"
+            "license": "MIT",
+            "optional": true,
+            "peer": true
         },
         "node_modules/@types/mocha": {
             "version": "10.0.10",
@@ -2107,17 +2110,17 @@
             }
         },
         "node_modules/@typescript-eslint/eslint-plugin": {
-            "version": "8.59.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.59.0.tgz",
-            "integrity": "sha512-HyAZtpdkgZwpq8Sz3FSUvCR4c+ScbuWa9AksK2Jweub7w4M3yTz4O11AqVJzLYjy/B9ZWPyc81I+mOdJU/bDQw==",
+            "version": "8.60.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.60.1.tgz",
+            "integrity": "sha512-JQ4S5GB0tfjO8BuJ4fcX+HodkzJjYBV+7OJ+wLygaX7OGQ7FudyHL4NSCA6ob+w3Yn+5MkKIozOwQhXeM7opVg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@eslint-community/regexpp": "^4.12.2",
-                "@typescript-eslint/scope-manager": "8.59.0",
-                "@typescript-eslint/type-utils": "8.59.0",
-                "@typescript-eslint/utils": "8.59.0",
-                "@typescript-eslint/visitor-keys": "8.59.0",
+                "@typescript-eslint/scope-manager": "8.60.1",
+                "@typescript-eslint/type-utils": "8.60.1",
+                "@typescript-eslint/utils": "8.60.1",
+                "@typescript-eslint/visitor-keys": "8.60.1",
                 "ignore": "^7.0.5",
                 "natural-compare": "^1.4.0",
                 "ts-api-utils": "^2.5.0"
@@ -2130,22 +2133,22 @@
                 "url": "https://opencollective.com/typescript-eslint"
             },
             "peerDependencies": {
-                "@typescript-eslint/parser": "^8.59.0",
+                "@typescript-eslint/parser": "^8.60.1",
                 "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
                 "typescript": ">=4.8.4 <6.1.0"
             }
         },
         "node_modules/@typescript-eslint/parser": {
-            "version": "8.59.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.59.0.tgz",
-            "integrity": "sha512-TI1XGwKbDpo9tRW8UDIXCOeLk55qe9ZFGs8MTKU6/M08HWTw52DD/IYhfQtOEhEdPhLMT26Ka/x7p70nd3dzDg==",
+            "version": "8.60.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.60.1.tgz",
+            "integrity": "sha512-A0M6ua6H252bVjPvvtSgl2QA4+ET9S5Mtkb2GDyTxIhH/C4qDItT7RQNO5PhMC6NXGYXOR9dIalcDDgBKT7oFA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/scope-manager": "8.59.0",
-                "@typescript-eslint/types": "8.59.0",
-                "@typescript-eslint/typescript-estree": "8.59.0",
-                "@typescript-eslint/visitor-keys": "8.59.0",
+                "@typescript-eslint/scope-manager": "8.60.1",
+                "@typescript-eslint/types": "8.60.1",
+                "@typescript-eslint/typescript-estree": "8.60.1",
+                "@typescript-eslint/visitor-keys": "8.60.1",
                 "debug": "^4.4.3"
             },
             "engines": {
@@ -2161,14 +2164,14 @@
             }
         },
         "node_modules/@typescript-eslint/project-service": {
-            "version": "8.59.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.59.0.tgz",
-            "integrity": "sha512-Lw5ITrR5s5TbC19YSvlr63ZfLaJoU6vtKTHyB0GQOpX0W7d5/Ir6vUahWi/8Sps/nOukZQ0IB3SmlxZnjaKVnw==",
+            "version": "8.60.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.60.1.tgz",
+            "integrity": "sha512-eXkTH2bxmXlqD1RnOPmLZ9ZM9D3VwSx04JOwBnP9RQ+yUA5a2Mu7SfW8uaV2Aon53NJzZlZYuX7tn91Izf+xaw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/tsconfig-utils": "^8.59.0",
-                "@typescript-eslint/types": "^8.59.0",
+                "@typescript-eslint/tsconfig-utils": "^8.60.1",
+                "@typescript-eslint/types": "^8.60.1",
                 "debug": "^4.4.3"
             },
             "engines": {
@@ -2183,14 +2186,14 @@
             }
         },
         "node_modules/@typescript-eslint/scope-manager": {
-            "version": "8.59.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.59.0.tgz",
-            "integrity": "sha512-UzR16Ut8IpA3Mc4DbgAShlPPkVm8xXMWafXxB0BocaVRHs8ZGakAxGRskF7FId3sdk9lgGD73GSFaWmWFDE4dg==",
+            "version": "8.60.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.60.1.tgz",
+            "integrity": "sha512-gvI5OQoptnxQnchOirukCuQ55svJSTuD/4k5+pC267xyBtYry748R9/c3tYUzb/iE6RZfllRz2lVulLCHkTm4w==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/types": "8.59.0",
-                "@typescript-eslint/visitor-keys": "8.59.0"
+                "@typescript-eslint/types": "8.60.1",
+                "@typescript-eslint/visitor-keys": "8.60.1"
             },
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -2201,9 +2204,9 @@
             }
         },
         "node_modules/@typescript-eslint/tsconfig-utils": {
-            "version": "8.59.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.59.0.tgz",
-            "integrity": "sha512-91Sbl3s4Kb3SybliIY6muFBmHVv+pYXfybC4Oolp3dvk8BvIE3wOPc+403CWIT7mJNkfQRGtdqghzs2+Z91Tqg==",
+            "version": "8.60.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.60.1.tgz",
+            "integrity": "sha512-nh8w4qAteiKuZu3pSSzG/yGKpw0OlkrKnzFmbVRenKaD4qc+7i1GrmZaLVkr8rk4uipiPGMOW4YsM6WmKZ5CvA==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -2218,15 +2221,15 @@
             }
         },
         "node_modules/@typescript-eslint/type-utils": {
-            "version": "8.59.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.59.0.tgz",
-            "integrity": "sha512-3TRiZaQSltGqGeNrJzzr1+8YcEobKH9rHnqIp/1psfKFmhRQDNMGP5hBufanYTGznwShzVLs3Mz+gDN7HkWfXg==",
+            "version": "8.60.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.60.1.tgz",
+            "integrity": "sha512-sdwTrpjosW7ANQYJ39ZBF1ZyEMEGVB2UsikrserVM/30a/F1dTLnu9bGxEdosugyu5caigjLrR2qiD11asjI1A==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/types": "8.59.0",
-                "@typescript-eslint/typescript-estree": "8.59.0",
-                "@typescript-eslint/utils": "8.59.0",
+                "@typescript-eslint/types": "8.60.1",
+                "@typescript-eslint/typescript-estree": "8.60.1",
+                "@typescript-eslint/utils": "8.60.1",
                 "debug": "^4.4.3",
                 "ts-api-utils": "^2.5.0"
             },
@@ -2243,9 +2246,9 @@
             }
         },
         "node_modules/@typescript-eslint/types": {
-            "version": "8.59.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.59.0.tgz",
-            "integrity": "sha512-nLzdsT1gdOgFxxxwrlNVUBzSNBEEHJ86bblmk4QAS6stfig7rcJzWKqCyxFy3YRRHXDWEkb2NralA1nOYkkm/A==",
+            "version": "8.60.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.60.1.tgz",
+            "integrity": "sha512-4h0tY8ppCkdCzcrl2YM5M3my0xsE1Tf8om3owEu5oPWmXwkKRmk0j0LGDzYBGUcAlesEbxBhazqu/K4cu3Ug7w==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -2257,16 +2260,16 @@
             }
         },
         "node_modules/@typescript-eslint/typescript-estree": {
-            "version": "8.59.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.59.0.tgz",
-            "integrity": "sha512-O9Re9P1BmBLFJyikRbQpLku/QA3/AueZNO9WePLBwQrvkixTmDe8u76B6CYUAITRl/rHawggEqUGn5QIkVRLMw==",
+            "version": "8.60.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.60.1.tgz",
+            "integrity": "sha512-alpRkfG8hlVE5kdJW2GkfgDgXxold3e8e4l6EnmhRmRLbekgAPCCGDVD++sABy9FcgPFroq+uFcCSM1vR57Cew==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/project-service": "8.59.0",
-                "@typescript-eslint/tsconfig-utils": "8.59.0",
-                "@typescript-eslint/types": "8.59.0",
-                "@typescript-eslint/visitor-keys": "8.59.0",
+                "@typescript-eslint/project-service": "8.60.1",
+                "@typescript-eslint/tsconfig-utils": "8.60.1",
+                "@typescript-eslint/types": "8.60.1",
+                "@typescript-eslint/visitor-keys": "8.60.1",
                 "debug": "^4.4.3",
                 "minimatch": "^10.2.2",
                 "semver": "^7.7.3",
@@ -2295,9 +2298,9 @@
             }
         },
         "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-            "version": "5.0.5",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-            "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+            "version": "5.0.6",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+            "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -2324,16 +2327,16 @@
             }
         },
         "node_modules/@typescript-eslint/utils": {
-            "version": "8.59.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.59.0.tgz",
-            "integrity": "sha512-I1R/K7V07XsMJ12Oaxg/O9GfrysGTmCRhvZJBv0RE0NcULMzjqVpR5kRRQjHsz3J/bElU7HwCO7zkqL+MSUz+g==",
+            "version": "8.60.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.60.1.tgz",
+            "integrity": "sha512-h2MPBLoNtjc3qZWfY3Tl51yPorQ2McHn8pJfcMNTcIvrrZrr90Ykffit0yjrPFWQcRcUxzH20+6OcVdW4yHtUg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.9.1",
-                "@typescript-eslint/scope-manager": "8.59.0",
-                "@typescript-eslint/types": "8.59.0",
-                "@typescript-eslint/typescript-estree": "8.59.0"
+                "@typescript-eslint/scope-manager": "8.60.1",
+                "@typescript-eslint/types": "8.60.1",
+                "@typescript-eslint/typescript-estree": "8.60.1"
             },
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -2348,13 +2351,13 @@
             }
         },
         "node_modules/@typescript-eslint/visitor-keys": {
-            "version": "8.59.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.59.0.tgz",
-            "integrity": "sha512-/uejZt4dSere1bx12WLlPfv8GktzcaDtuJ7s42/HEZ5zGj9oxRaD4bj7qwSunXkf+pbAhFt2zjpHYUiT5lHf0Q==",
+            "version": "8.60.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.60.1.tgz",
+            "integrity": "sha512-EbGRQg4FhrmwLodl+t3JNAnXHWVr9Vp+Zl1QBZVPY4ByfkzIT8cX3K6QWODHtkIZqqJVEWvhHSx3v5PDHsaQag==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/types": "8.59.0",
+                "@typescript-eslint/types": "8.60.1",
                 "eslint-visitor-keys": "^5.0.0"
             },
             "engines": {
@@ -2856,9 +2859,9 @@
             }
         },
         "node_modules/anymatch/node_modules/picomatch": {
-            "version": "2.3.1",
-            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-            "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+            "version": "2.3.2",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+            "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -2962,6 +2965,8 @@
             "integrity": "sha512-F/TKATkzseUExPlfvmwQKGITM3DGTK+vkAsCZoDc5daVygbJBnjEUCbgkAvVFsgfXfX4YIqZ/27G3k3tdXrTxQ==",
             "dev": true,
             "license": "MIT",
+            "optional": true,
+            "peer": true,
             "dependencies": {
                 "call-bind": "^1.0.8",
                 "call-bound": "^1.0.4",
@@ -3329,9 +3334,9 @@
             }
         },
         "node_modules/brace-expansion": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-            "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
+            "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -4571,6 +4576,8 @@
             "integrity": "sha512-WFj2isz22JahUv+B788TlO3N6zL3nNJGU8CcZbPZvVEkBPaJdCV4vy5wyghty5ROFbCRnm132v8BScu5/1BQ8g==",
             "dev": true,
             "license": "MIT",
+            "optional": true,
+            "peer": true,
             "dependencies": {
                 "debug": "^3.2.7",
                 "is-core-module": "^2.13.0",
@@ -4583,6 +4590,8 @@
             "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
             "dev": true,
             "license": "MIT",
+            "optional": true,
+            "peer": true,
             "dependencies": {
                 "ms": "^2.1.1"
             }
@@ -4628,6 +4637,8 @@
             "integrity": "sha512-L8jSWTze7K2mTg0vos/RuLRS5soomksDPoJLXIslC7c8Wmut3bx7CPpJijDcBZtxQ5lrbUdM+s0OlNbz0DCDNw==",
             "dev": true,
             "license": "MIT",
+            "optional": true,
+            "peer": true,
             "dependencies": {
                 "debug": "^3.2.7"
             },
@@ -4646,6 +4657,8 @@
             "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
             "dev": true,
             "license": "MIT",
+            "optional": true,
+            "peer": true,
             "dependencies": {
                 "ms": "^2.1.1"
             }
@@ -4656,6 +4669,8 @@
             "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
             "dev": true,
             "license": "MIT",
+            "optional": true,
+            "peer": true,
             "dependencies": {
                 "@rtsao/scc": "^1.1.0",
                 "array-includes": "^3.1.9",
@@ -4684,12 +4699,52 @@
                 "eslint": "^2 || ^3 || ^4 || ^5 || ^6 || ^7.2.0 || ^8 || ^9"
             }
         },
+        "node_modules/eslint-plugin-import-x": {
+            "version": "4.16.2",
+            "resolved": "https://registry.npmjs.org/eslint-plugin-import-x/-/eslint-plugin-import-x-4.16.2.tgz",
+            "integrity": "sha512-rM9K8UBHcWKpzQzStn1YRN2T5NvdeIfSVoKu/lKF41znQXHAUcBbYXe5wd6GNjZjTrP7viQ49n1D83x/2gYgIw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@package-json/types": "^0.0.12",
+                "@typescript-eslint/types": "^8.56.0",
+                "comment-parser": "^1.4.1",
+                "debug": "^4.4.1",
+                "eslint-import-context": "^0.1.9",
+                "is-glob": "^4.0.3",
+                "minimatch": "^9.0.3 || ^10.1.2",
+                "semver": "^7.7.2",
+                "stable-hash-x": "^0.2.0",
+                "unrs-resolver": "^1.9.2"
+            },
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/eslint-plugin-import-x"
+            },
+            "peerDependencies": {
+                "@typescript-eslint/utils": "^8.56.0",
+                "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+                "eslint-import-resolver-node": "*"
+            },
+            "peerDependenciesMeta": {
+                "@typescript-eslint/utils": {
+                    "optional": true
+                },
+                "eslint-import-resolver-node": {
+                    "optional": true
+                }
+            }
+        },
         "node_modules/eslint-plugin-import/node_modules/brace-expansion": {
             "version": "1.1.14",
             "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
             "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
             "dev": true,
             "license": "MIT",
+            "optional": true,
+            "peer": true,
             "dependencies": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -4701,6 +4756,8 @@
             "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
             "dev": true,
             "license": "MIT",
+            "optional": true,
+            "peer": true,
             "dependencies": {
                 "ms": "^2.1.1"
             }
@@ -4711,6 +4768,8 @@
             "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
             "dev": true,
             "license": "ISC",
+            "optional": true,
+            "peer": true,
             "dependencies": {
                 "brace-expansion": "^1.1.7"
             },
@@ -4724,6 +4783,8 @@
             "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
             "dev": true,
             "license": "ISC",
+            "optional": true,
+            "peer": true,
             "bin": {
                 "semver": "bin/semver.js"
             }
@@ -4851,32 +4912,6 @@
             },
             "engines": {
                 "node": "*"
-            }
-        },
-        "node_modules/eslint-plugin-package-json": {
-            "version": "0.91.1",
-            "resolved": "https://registry.npmjs.org/eslint-plugin-package-json/-/eslint-plugin-package-json-0.91.1.tgz",
-            "integrity": "sha512-rxmCAcuTvDqrtywsmVHcFxEZdJUTByetAelAZiAcjMqo0BS1090KbjTeyEOiEdpEqxwa83c+xHCjFoZX9OKEcA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@altano/repository-tools": "^2.0.1",
-                "change-case": "^5.4.4",
-                "detect-indent": "^7.0.2",
-                "detect-newline": "^4.0.1",
-                "eslint-fix-utils": "~0.4.1",
-                "package-json-validator": "^1.3.1",
-                "semver": "^7.7.3",
-                "sort-object-keys": "^2.0.0",
-                "sort-package-json": "^3.4.0",
-                "validate-npm-package-name": "^7.0.0"
-            },
-            "engines": {
-                "node": "^20.19.0 || >=22.12.0"
-            },
-            "peerDependencies": {
-                "eslint": ">=8.0.0",
-                "jsonc-eslint-parser": ">=2.0.0"
             }
         },
         "node_modules/eslint-plugin-react": {
@@ -5305,9 +5340,9 @@
             }
         },
         "node_modules/flatted": {
-            "version": "3.4.1",
-            "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.1.tgz",
-            "integrity": "sha512-IxfVbRFVlV8V/yRaGzk0UVIcsKKHMSfYw66T/u4nTwlWteQePsxe//LjudR1AMX4tZW3WFCh3Zqa/sjlqpbURQ==",
+            "version": "3.4.2",
+            "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+            "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
             "dev": true,
             "license": "ISC"
         },
@@ -5582,19 +5617,6 @@
             },
             "engines": {
                 "node": ">= 6"
-            }
-        },
-        "node_modules/globals": {
-            "version": "17.5.0",
-            "resolved": "https://registry.npmjs.org/globals/-/globals-17.5.0.tgz",
-            "integrity": "sha512-qoV+HK2yFl/366t2/Cb3+xxPUo5BuMynomoDmiaZBIdbs+0pYbjfZU+twLhGKp4uCZ/+NbtpVepH5bGCxRyy2g==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=18"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/globalthis": {
@@ -6688,6 +6710,8 @@
             "integrity": "sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==",
             "dev": true,
             "license": "MIT",
+            "optional": true,
+            "peer": true,
             "dependencies": {
                 "minimist": "^1.2.0"
             },
@@ -7002,9 +7026,9 @@
             }
         },
         "node_modules/lodash": {
-            "version": "4.17.23",
-            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
-            "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
+            "version": "4.18.1",
+            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+            "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
             "license": "MIT"
         },
         "node_modules/lodash.merge": {
@@ -7196,9 +7220,9 @@
             "optional": true
         },
         "node_modules/mocha": {
-            "version": "11.7.5",
-            "resolved": "https://registry.npmjs.org/mocha/-/mocha-11.7.5.tgz",
-            "integrity": "sha512-mTT6RgopEYABzXWFx+GcJ+ZQ32kp4fMf0xvpZIIfSq9Z8lC/++MtcCnQ9t5FP2veYEP95FIYSvW+U9fV4xrlig==",
+            "version": "11.7.6",
+            "resolved": "https://registry.npmjs.org/mocha/-/mocha-11.7.6.tgz",
+            "integrity": "sha512-nS9xOGbw2I3cjCpxwZAEJ9xK9lmJ08vEkQvLtz4du9ZrF9UrjRpeJGiIgl2Z+Qs++pmB4ecDe48Fwsh+j+j7xA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -7546,6 +7570,8 @@
             "integrity": "sha512-+Lhy3TQTuzXI5hevh8sBGqbmurHbbIjAi0Z4S63nthVLmLxfbj4T54a4CfZrXIrt9iP4mVAPYMo/v99taj3wjQ==",
             "dev": true,
             "license": "MIT",
+            "optional": true,
+            "peer": true,
             "dependencies": {
                 "call-bind": "^1.0.7",
                 "define-properties": "^1.2.1",
@@ -7814,21 +7840,6 @@
             "dev": true,
             "license": "BlueOak-1.0.0"
         },
-        "node_modules/package-json-validator": {
-            "version": "1.4.0",
-            "resolved": "https://registry.npmjs.org/package-json-validator/-/package-json-validator-1.4.0.tgz",
-            "integrity": "sha512-Nb1qg9Z7Om/r3kw3gZfKbFvFC6e0Cj38Zc5NS2LCogxqbUCbFLTjlvRKk/9doMvaAyrzUVwrR0si/opLru4CHw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "semver": "^7.7.2",
-                "validate-npm-package-license": "^3.0.4",
-                "validate-npm-package-name": "^7.0.0"
-            },
-            "engines": {
-                "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
-            }
-        },
         "node_modules/pako": {
             "version": "0.2.9",
             "resolved": "https://registry.npmjs.org/pako/-/pako-0.2.9.tgz",
@@ -7931,9 +7942,9 @@
             }
         },
         "node_modules/path-to-regexp": {
-            "version": "8.3.0",
-            "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.3.0.tgz",
-            "integrity": "sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA==",
+            "version": "8.4.2",
+            "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+            "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
             "dev": true,
             "license": "MIT",
             "funding": {
@@ -7961,9 +7972,9 @@
             "license": "ISC"
         },
         "node_modules/picomatch": {
-            "version": "4.0.3",
-            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-            "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+            "version": "4.0.4",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+            "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -8292,9 +8303,9 @@
             }
         },
         "node_modules/readdirp/node_modules/picomatch": {
-            "version": "2.3.1",
-            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-            "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+            "version": "2.3.2",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+            "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -9336,6 +9347,8 @@
             "integrity": "sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==",
             "dev": true,
             "license": "MIT",
+            "optional": true,
+            "peer": true,
             "engines": {
                 "node": ">=4"
             }
@@ -9457,9 +9470,9 @@
             }
         },
         "node_modules/test-exclude/node_modules/brace-expansion": {
-            "version": "5.0.4",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.4.tgz",
-            "integrity": "sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg==",
+            "version": "5.0.6",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+            "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -9582,6 +9595,8 @@
             "integrity": "sha512-2Ac2RgzDe/cn48GvOe3M+o82pEFewD3UPbyoUHHdKasHwJKjds4fLXWf/Ux5kATBKN20oaFGu+jbElp1pos0mg==",
             "dev": true,
             "license": "MIT",
+            "optional": true,
+            "peer": true,
             "dependencies": {
                 "@types/json5": "^0.0.29",
                 "json5": "^1.0.2",
@@ -9751,16 +9766,16 @@
             }
         },
         "node_modules/typescript-eslint": {
-            "version": "8.59.0",
-            "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.59.0.tgz",
-            "integrity": "sha512-BU3ONW9X+v90EcCH9ZS6LMackcVtxRLlI3XrYyqZIwVSHIk7Qf7bFw1z0M9Q0IUxhTMZCf8piY9hTYaNEIASrw==",
+            "version": "8.60.1",
+            "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.60.1.tgz",
+            "integrity": "sha512-6m5hkkRAp8lKvhVpcprAIn5KkehQEh+47oHH2VGnExEh7dhNxXlg6GPAOIu6TxbVQxhebrJDvjl3020ooiWCMA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/eslint-plugin": "8.59.0",
-                "@typescript-eslint/parser": "8.59.0",
-                "@typescript-eslint/typescript-estree": "8.59.0",
-                "@typescript-eslint/utils": "8.59.0"
+                "@typescript-eslint/eslint-plugin": "8.60.1",
+                "@typescript-eslint/parser": "8.60.1",
+                "@typescript-eslint/typescript-estree": "8.60.1",
+                "@typescript-eslint/utils": "8.60.1"
             },
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"

--- a/package.json
+++ b/package.json
@@ -166,8 +166,7 @@
         "ws": "^8.18.3"
     },
     "devDependencies": {
-        "@eslint/js": "9.39.4",
-        "@playcanvas/eslint-config": "3.0.0-beta.3",
+        "@playcanvas/eslint-config": "3.0.0-beta.5",
         "@rollup/plugin-commonjs": "29.0.2",
         "@rollup/plugin-json": "6.1.0",
         "@rollup/plugin-node-resolve": "16.0.3",
@@ -185,19 +184,12 @@
         "@vscode/test-web": "0.0.80",
         "dotenv": "17.4.2",
         "eslint": "9.39.4",
-        "eslint-config-prettier": "10.1.8",
-        "eslint-import-resolver-typescript": "4.4.4",
-        "eslint-plugin-import": "2.32.0",
-        "eslint-plugin-package-json": "0.91.1",
-        "globals": "17.5.0",
-        "jsonc-eslint-parser": "2.4.2",
         "playcanvas": "2.18.1",
         "prettier": "3.8.3",
         "rollup": "4.60.2",
         "rollup-plugin-polyfill-node": "0.13.0",
         "sinon": "21.1.2",
-        "typescript": "6.0.3",
-        "typescript-eslint": "8.59.0"
+        "typescript": "6.0.3"
     },
     "engines": {
         "vscode": "^1.98.0"

--- a/package.json
+++ b/package.json
@@ -6,15 +6,15 @@
     "categories": [
         "Other"
     ],
+    "bugs": {
+        "url": "https://github.com/playcanvas/vscode-extension/issues"
+    },
     "repository": {
         "type": "git",
         "url": "https://github.com/playcanvas/vscode-extension.git"
     },
-    "bugs": {
-        "url": "https://github.com/playcanvas/vscode-extension/issues"
-    },
-    "author": "PlayCanvas",
     "license": "MIT",
+    "author": "PlayCanvas",
     "publisher": "PlayCanvas",
     "type": "commonjs",
     "main": "./out/extension.js",

--- a/plugin/package.json
+++ b/plugin/package.json
@@ -6,8 +6,8 @@
         "type": "git",
         "url": "https://github.com/playcanvas/vscode-extension.git"
     },
-    "author": "PlayCanvas",
     "license": "MIT",
+    "author": "PlayCanvas",
     "type": "commonjs",
     "main": "out/index.js",
     "files": [

--- a/src/connections/messenger.ts
+++ b/src/connections/messenger.ts
@@ -1,4 +1,5 @@
-import WebSocket, { type Data } from 'isomorphic-ws';
+import WebSocket from 'isomorphic-ws';
+import type {Data} from 'isomorphic-ws';
 
 import { WEB } from '../config';
 import { Log } from '../log';

--- a/src/connections/messenger.ts
+++ b/src/connections/messenger.ts
@@ -1,5 +1,5 @@
 import WebSocket from 'isomorphic-ws';
-import type {Data} from 'isomorphic-ws';
+import type { Data } from 'isomorphic-ws';
 
 import { WEB } from '../config';
 import { Log } from '../log';

--- a/src/connections/relay.ts
+++ b/src/connections/relay.ts
@@ -1,4 +1,5 @@
-import WebSocket, { type Data } from 'isomorphic-ws';
+import WebSocket from 'isomorphic-ws';
+import type {Data} from 'isomorphic-ws';
 
 import { WEB } from '../config';
 import { Log } from '../log';

--- a/src/connections/relay.ts
+++ b/src/connections/relay.ts
@@ -1,5 +1,5 @@
 import WebSocket from 'isomorphic-ws';
-import type {Data} from 'isomorphic-ws';
+import type { Data } from 'isomorphic-ws';
 
 import { WEB } from '../config';
 import { Log } from '../log';

--- a/src/connections/sharedb.ts
+++ b/src/connections/sharedb.ts
@@ -1,4 +1,5 @@
-import WebSocket, { type Data } from 'isomorphic-ws';
+import WebSocket from 'isomorphic-ws';
+import type {Data} from 'isomorphic-ws';
 import { type } from 'ot-text';
 import * as sharedb from 'sharedb/lib/client/index.js';
 import type { Error as ShareDbError, Socket } from 'sharedb/lib/sharedb.js';

--- a/src/connections/sharedb.ts
+++ b/src/connections/sharedb.ts
@@ -1,5 +1,5 @@
 import WebSocket from 'isomorphic-ws';
-import type {Data} from 'isomorphic-ws';
+import type { Data } from 'isomorphic-ws';
 import { type } from 'ot-text';
 import * as sharedb from 'sharedb/lib/client/index.js';
 import type { Error as ShareDbError, Socket } from 'sharedb/lib/sharedb.js';


### PR DESCRIPTION
Migrates the extension's ESLint setup to the shared v3 `/typescript` config (part of the rollout — playcanvas/eslint-config#48), now that `3.0.0-beta.5` ships the import-x resolver fix.

## What changed
- **`eslint.config.mjs`** (114 → 25 lines): the hand-rolled flat config — a near-verbatim copy of the shared `/typescript` ruleset — is replaced with `import typescriptConfig from '@playcanvas/eslint-config/typescript'`. The only things layered on top are this repo's own bits: the vscode `ignores` and the relaxed `package.json` rules (`require-exports`/`require-sideEffects`/`require-files` off).
- **`package.json`**: `@playcanvas/eslint-config` → `3.0.0-beta.5`, and the **8 direct eslint devDeps now bundled by `/typescript`** are removed (`@eslint/js`, `eslint-config-prettier`, `eslint-import-resolver-typescript`, `eslint-plugin-import`, `eslint-plugin-package-json`, `globals`, `jsonc-eslint-parser`, `typescript-eslint`). `eslint`, `prettier`, `typescript`, `@types/node` stay (used directly).

No import-rule overrides are kept, so the `/typescript` tier's `import/*`→`import-x/*` namespace change doesn't affect this repo. The `@typescript-eslint/*` eslint-disable comments in source keep working (that plugin is still registered by `/typescript`).

## Lint adjustments from the stricter shared config
The shared `/typescript` rules surfaced a few auto-fixable items (fixed in follow-up commits):
- inline `import X, { type Y }` → top-level `import type { Y }` (`import-x/consistent-type-specifier-style`)
- minor `package.json` field ordering (`eslint-plugin-package-json`)

## Status
`npm run lint`, build, and the regenerated `package-lock.json` are all in. CI green.