### PR TITLE
Bump @playcanvas/eslint-config to 3.0.0-beta.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
                 "ws": "^8.18.3"
             },
             "devDependencies": {
-                "@playcanvas/eslint-config": "3.0.0-beta.5",
+                "@playcanvas/eslint-config": "3.0.0-beta.6",
                 "@rollup/plugin-commonjs": "29.0.2",
                 "@rollup/plugin-json": "6.1.0",
                 "@rollup/plugin-node-resolve": "16.0.3",
@@ -822,9 +822,9 @@
             }
         },
         "node_modules/@playcanvas/eslint-config": {
-            "version": "3.0.0-beta.5",
-            "resolved": "https://registry.npmjs.org/@playcanvas/eslint-config/-/eslint-config-3.0.0-beta.5.tgz",
-            "integrity": "sha512-ItIq14McE3GlFjJkO3oPeqw2MHcKCoZnoWuNTv8B7dftE9lVftTi5TCBIBLG6/wxB6EaS6rK1zoIFoNpSazXwA==",
+            "version": "3.0.0-beta.6",
+            "resolved": "https://registry.npmjs.org/@playcanvas/eslint-config/-/eslint-config-3.0.0-beta.6.tgz",
+            "integrity": "sha512-P4AZcIVGdW50KpQ5YDvh5xuC6lrHEjfLJqLwTYfrQUfV7JSbtL5IvNYOLXTVf9JigTfIfyTS8XJjgDlaHtv9SA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {

--- a/package.json
+++ b/package.json
@@ -166,7 +166,7 @@
         "ws": "^8.18.3"
     },
     "devDependencies": {
-        "@playcanvas/eslint-config": "3.0.0-beta.5",
+        "@playcanvas/eslint-config": "3.0.0-beta.6",
         "@rollup/plugin-commonjs": "29.0.2",
         "@rollup/plugin-json": "6.1.0",
         "@rollup/plugin-node-resolve": "16.0.3",


### PR DESCRIPTION
Bumps the dev dependency `@playcanvas/eslint-config` from `3.0.0-beta.5` to `3.0.0-beta.6`.

beta.6 broadens the `/typescript` tier's file glob to `**/*.{js,mjs,cjs,ts,tsx,mts,cts}` (previously `{js,mjs,ts}`). This repo's lint (`prettier --check . && eslint .`) is **green** on beta.6 — no newly-covered file types introduced errors.

Follow-up to #311 (the v3 adoption), keeping this repo on the latest beta alongside the wave-1 consumer PRs.