### PR TITLE
fix: route ancestor folder creates through coalescer

### DIFF
--- a/src/disk.ts
+++ b/src/disk.ts
@@ -1275,17 +1275,15 @@ class Disk extends Linker<{ folderUri: vscode.Uri; projectManager: ProjectManage
                                         return;
                                     }
 
-                                    // ensure ancestor folders exist before creating
-                                    // handles race condition where child events arrive before parent events
+                                    // ensure ancestor folders top-down — always delegate to create() so siblings
+                                    // serialise via the _creating coalescer across the messenger ack; echo each
+                                    // ancestor so a late watcher event for the folder is dropped, not re-queued.
                                     const segments = path.split('/');
                                     for (let j = 1; j < segments.length; j++) {
                                         const ancestorPath = segments.slice(0, j).join('/');
-                                        if (!projectManager.files.has(ancestorPath)) {
-                                            this._log.debug(
-                                                `create.local folder ${ancestorPath} (ensuring ancestor of ${path})`
-                                            );
-                                            await projectManager.create(ancestorPath, 'folder');
-                                        }
+                                        const ancestorUri = vscode.Uri.joinPath(folderUri, ancestorPath);
+                                        this._echo.set(`${ancestorUri}:create`, '');
+                                        await projectManager.create(ancestorPath, 'folder');
                                     }
 
                                     this._log.debug(`create.local ${type} ${op.uri}`);


### PR DESCRIPTION
## Summary
Git doesn't track folders, so a branch switch that adds files under previously-nonexistent nested folders only fires VS Code FS watcher events for the *leaf files*. The disk watcher's ancestor-ensure loop synthesises the missing folders via `projectManager.create`. With #309, `create()` coalesces concurrent calls for the same path across REST + messenger-ack — but the loop's `_files.has` short-circuit defeated that, because `_files` is set **optimistically** right after REST returns and before the ack lands.

| Step | Event A: `lib/foo.js` | Event B: `lib/bar.js` (concurrent) |
|---|---|---|
| 1 | ancestor loop → `create('lib')` | ancestor loop |
| 2 | REST returns uniqueId X | `files.has('lib')` → **true** (A's optimistic set) |
| 3 | `_files.set('lib', X)` *(optimistic)* | **skips** `create('lib')` — no coalesce |
| 4 | awaiting messenger ack… | `REST.assetCreate('lib/bar.js', parent=X)` |
| 5 | | server hasn't propagated `lib` → **HTTP 400 "parent folder is not found"** |

## Fix
- Drop the `_files.has` short-circuit; always delegate to `projectManager.create`. The `_creating` coalescer covers the not-yet-acked window; `_createOnce`'s existing `_files.get(path)?.type === type` early-return handles the fully-acked case at a few map-lookups' cost.
- Pre-set `_echo` per ancestor URI so any delayed FS watcher event for the folder is dropped, not re-queued (mirrors `_create`'s existing remote-driven flow at `disk.ts:282`).

| Requirement | Mechanism |
|---|---|
| Top-down ordering | Sequential `await` in `for j = 1..length-1`; concurrent siblings serialise via `_creating` |
| No echo back to client | Optimistic `_files.set` + `_addFolder` guard (`project-manager.ts:340`) skip self-emit; new `_echo.set` covers late FS events |

## Test plan
- [x] Branch with files under deeply-nested previously-nonexistent folders → `git checkout` from a branch without them → no `HTTP 400` in the output channel, all files appear server-side.
- [x] Single-file create with no missing ancestors still works (regression).
- [x] Remote folder creates from another client still write to local disk (regression — non-local `_addFolder` path untouched).