### PR TITLE
fix: don't push a dirty-tab discard revert upstream as a rollback op

### DIFF
--- a/src/disk.ts
+++ b/src/disk.ts
@@ -1106,9 +1106,14 @@ class Disk extends Linker<{ folderUri: vscode.Uri; projectManager: ProjectManage
                 return;
             }
 
-            // skip discard/revert: buffer reverted to stale disk content,
-            // not a real edit. native undo/redo is handled above.
-            if (!reason && !document.isDirty && hash(text) === this._diskHash.get(document.uri.path)) {
+            // skip discard/revert: a non-undo/redo change that lands the buffer back on
+            // the on-disk bytes is a revert (Don't Save / Revert File), never a real edit.
+            // the disk file is the derived save-only artifact (server treats the live OT
+            // doc as source of truth), so pushing it upstream rolls every collaborator back
+            // to stale content (#315). the native close dialog can fire this while
+            // document.isDirty is still true, so do NOT gate on the transient dirty flag.
+            // undo/redo carry a reason and are handled above.
+            if (!reason && hash(text) === this._diskHash.get(document.uri.path)) {
                 return;
             }
 

--- a/src/test/suite/extension.test.ts
+++ b/src/test/suite/extension.test.ts
@@ -1677,6 +1677,79 @@ suite('extension', () => {
         assert.strictEqual(ops.length, 0, 'should not submit rollback ops on dirty close');
     });
 
+    test('file close - discard while still dirty does not roll back collaborator edits', async () => {
+        // regression #315: a collaborator's remote op lands in an inactive tab and marks
+        // it dirty. closing + "Don't Save" reverts the buffer to the stale on-disk bytes,
+        // firing onChange with no reason while isDirty is still true (the native close
+        // dialog fires before the dirty flag clears). the old guard gated on !isDirty, so
+        // it pushed that revert upstream as a rollback op, wiping the collaborator's edits
+        // for everyone. open-file remote ops never touch disk, so _diskHash stays at the
+        // last-saved hash and the revert lands exactly on it.
+
+        const folderUri = vscode.workspace.workspaceFolders?.[0]?.uri;
+        assert.ok(folderUri, 'workspace folder should exist');
+
+        const asset = await assetCreate({ name: 'discard_dirty_collab.js', content: '// ORIGINAL' });
+        assert.ok(asset, 'asset should be created');
+
+        const uri = vscode.Uri.joinPath(folderUri, asset.name);
+        const tdoc = await vscode.workspace.openTextDocument(uri);
+        await vscode.window.showTextDocument(tdoc);
+        await waitForIdle('initial open settle');
+
+        // collaborator edit arrives as a remote op on the open (inactive) tab
+        const collab = '// COLLAB B EDIT\n// ORIGINAL';
+        const changed = new Promise<void>((resolve) => {
+            const disposable = vscode.workspace.onDidChangeTextDocument((e) => {
+                if (e.document.uri.toString() === uri.toString() && e.document.getText() === collab) {
+                    disposable.dispose();
+                    resolve();
+                }
+            });
+        });
+        const doc = sharedb.subscriptions.get(`documents:${asset.uniqueId}`);
+        assert.ok(doc, 'sharedb document should exist');
+        doc.submitOp(['// COLLAB B EDIT\n'], { source: 'remote' });
+        await assertResolves(changed, 'collaborator edit buffer apply');
+        await waitForIdle('remote op settle');
+
+        assert.strictEqual(tdoc.getText(), collab, 'buffer should hold collaborator edit');
+        assert.strictEqual(tdoc.isDirty, true, 'remote op into open tab should mark it dirty');
+        assert.strictEqual(documents.get(asset.uniqueId), collab, 'OT doc should hold collaborator edit');
+
+        // capture dirty state when the revert fires — proves we exercise the isDirty=true
+        // path (the native-dialog timing), not the trivially-skipped isDirty=false path
+        let dirtyAtRevert: boolean | undefined;
+        const reverted = new Promise<void>((resolve) => {
+            const disposable = vscode.workspace.onDidChangeTextDocument((e) => {
+                if (e.document.uri.toString() === uri.toString() && e.document.getText() === '// ORIGINAL') {
+                    dirtyAtRevert = e.document.isDirty;
+                    disposable.dispose();
+                    resolve();
+                }
+            });
+        });
+
+        doc.submitOp.resetHistory();
+
+        // simulate "Don't Save": buffer reverts to on-disk content as a forward edit, so
+        // isDirty stays true (the revert command would clear it — that path is covered by
+        // the discard-after-first-keystroke test above)
+        const revert = new vscode.WorkspaceEdit();
+        revert.delete(uri, new vscode.Range(0, 0, 1, 0));
+        await vscode.workspace.applyEdit(revert);
+        await assertResolves(reverted, 'revert to disk change');
+        await waitForIdle('revert settle');
+
+        assert.strictEqual(dirtyAtRevert, true, 'revert must fire while still dirty to exercise #315');
+        assert.strictEqual(doc.submitOp.callCount, 0, 'discard revert must not submit a rollback op (#315)');
+        assert.strictEqual(
+            documents.get(asset.uniqueId),
+            collab,
+            'server doc must retain collaborator edit, not roll back'
+        );
+    });
+
     test('file save - local to remote', async () => {
         // get folder uri
         const folderUri = vscode.workspace.workspaceFolders?.[0]?.uri;


### PR DESCRIPTION
## Summary
A collaborator's edits landing in an inactive tab mark it dirty. Closing it and choosing "Don't Save" reverts the buffer to the last-saved on-disk bytes — and that revert was being submitted as an OT op, rolling the document back for everyone.

The discard guard only skipped the revert when `document.isDirty` was already false, but the native "Don't Save" dialog can fire the change while it's still true.

## Repro
Two collaborators on the same project + branch (Client A ideally on Windows — macOS clears `isDirty` before the dialog fires, so the old guard already worked there):

1. **A** opens `script.js`, then switches to another tab so it's inactive and unedited.
2. **B** edits the same script (add a marker line like `// EDIT FROM B`).
3. **A**'s inactive tab goes orange/dirty — B's edit is applied in-buffer, now newer than the saved file.
4. **A** closes the tab → native "Save changes?" dialog → **Don't Save**.

Before the fix: B's line disappears for everyone — the doc rolls back to the pre-B content. After: B's edit is retained.

## Fix
The on-disk file is just the last-saved artifact (the live doc is authoritative), so a revert to it should never be pushed upstream regardless of the dirty flag.

## Test plan
- [x] Full suite green (86 passing), including the existing discard/undo regressions.
- [x] Added a regression test for the dirty-close revert: a collaborator's remote op lands in an open tab, then the buffer reverts to disk while `isDirty` is still true — asserts no rollback op is submitted and the collaborator's edit is retained. Verified it fails against the old `!isDirty` guard.
- [x] Manually verified on Windows: closing the dirty tab with **Don't Save** retains the collaborator's edit.

Fixes #315
