### PR TITLE
fix: CRLF paste-undo desync and buffer corruption on Windows

### DIFF
--- a/src/disk.ts
+++ b/src/disk.ts
@@ -837,56 +837,53 @@ class Disk extends Linker<{ folderUri: vscode.Uri; projectManager: ProjectManage
         ) => {
             this._locks.add(`${uri}`);
             await tryCatch(async () => {
-                // capture pre-apply canonical text for correct buffer-space delta
-                const pre = file.doc.text;
-
                 // apply to OT canonical state (submits to ShareDB)
                 file.doc.apply(op);
+                const target = file.doc.text;
 
-                // apply visual edit to buffer
+                // write the buffer to match canonical via a minimal diff against
+                // the ACTUAL current buffer — never assume it equals pre-op
+                // canonical. a stale buffer (e.g. a prior buffer write that failed
+                // to land) would otherwise be misread as concurrent user input and
+                // the op transformed against a phantom divergence, duplicating
+                // content. diffing against the live buffer self-heals any drift.
                 const doc = await vscode.workspace.openTextDocument(uri);
-                const raw = doc.getText();
-                const buf = norm(raw);
+                const buf = norm(doc.getText());
+                const bufOp = delta(buf, target);
 
-                // delta from pre-apply canonical to buffer gives true user divergence
-                const userOp = delta(pre, buf);
-                const bufOp = userOp ? (ottext.transform(op, userOp, 'right') as ShareDbTextOp) : op;
-                const edit = sharedb2vscode(doc, uri, [bufOp], buf);
-                const applied = await vscode.workspace.applyEdit(edit);
-
-                if (!applied) {
-                    this._log.warn(`sync.undo.apply failed ${uri}`);
-                    return;
-                }
-
-                // reconcile: recover keystrokes typed during applyEdit await
-                const postText = norm(doc.getText());
-                const expected = ottext.apply(buf, bufOp) as string;
-
-                const late = delta(expected, postText);
-                if (late) {
-                    const adv = delta(expected, file.doc.text);
-                    const adjusted = adv ? (ottext.transform(late, adv, 'left') as ShareDbTextOp) : late;
-                    file.doc.apply(adjusted);
-                }
-
-                // cursor: position after the buffer-space op's primary edit
-                const active = vscode.window.activeTextEditor;
-                if (active && active.document.uri.toString() === uri.toString()) {
-                    let cursor = 0;
-                    if (bufOp.length === 1) {
-                        if (typeof bufOp[0] === 'string') {
-                            cursor = bufOp[0].length;
+                if (bufOp) {
+                    const edit = sharedb2vscode(doc, uri, [bufOp], buf);
+                    const applied = await vscode.workspace.applyEdit(edit);
+                    if (!applied) {
+                        this._log.warn(`sync.undo.apply failed ${uri}`);
+                    } else {
+                        // reconcile keystrokes typed during the applyEdit await
+                        const late = delta(target, norm(doc.getText()));
+                        if (late) {
+                            const adv = delta(target, file.doc.text);
+                            const adjusted = adv ? (ottext.transform(late, adv, 'left') as ShareDbTextOp) : late;
+                            file.doc.apply(adjusted);
                         }
-                    } else if (bufOp.length > 1 && typeof bufOp[0] === 'number') {
-                        cursor = bufOp[0];
-                        if (typeof bufOp[1] === 'string') {
-                            cursor += bufOp[1].length;
+
+                        // cursor: position after the op's primary edit
+                        const active = vscode.window.activeTextEditor;
+                        if (active && active.document.uri.toString() === uri.toString()) {
+                            let cursor = 0;
+                            if (bufOp.length === 1) {
+                                if (typeof bufOp[0] === 'string') {
+                                    cursor = bufOp[0].length;
+                                }
+                            } else if (bufOp.length > 1 && typeof bufOp[0] === 'number') {
+                                cursor = bufOp[0];
+                                if (typeof bufOp[1] === 'string') {
+                                    cursor += bufOp[1].length;
+                                }
+                            }
+                            const pos = doc.positionAt(cursor);
+                            active.selection = new vscode.Selection(pos, pos);
+                            active.revealRange(new vscode.Range(pos, pos), vscode.TextEditorRevealType.Default);
                         }
                     }
-                    const pos = doc.positionAt(cursor);
-                    active.selection = new vscode.Selection(pos, pos);
-                    active.revealRange(new vscode.Range(pos, pos), vscode.TextEditorRevealType.Default);
                 }
 
                 // mark dirty

--- a/src/disk.ts
+++ b/src/disk.ts
@@ -953,6 +953,58 @@ class Disk extends Linker<{ folderUri: vscode.Uri; projectManager: ProjectManage
         };
     }
 
+    private _resetNativeHistory(document: vscode.TextDocument, text: string) {
+        const key = `${document.uri}`;
+        void this._writeMutex.atomic([key], async () => {
+            if (this._locks.has(key)) {
+                return;
+            }
+
+            const raw = document.getText();
+            const next = document.eol === vscode.EndOfLine.CRLF ? text.replace(/\n/g, '\r\n') : text;
+            if (raw === next) {
+                return;
+            }
+
+            const edit = new vscode.WorkspaceEdit();
+            edit.replace(document.uri, new vscode.Range(document.positionAt(0), document.positionAt(raw.length)), next);
+
+            this._locks.add(key);
+            const [err, applied] = await tryCatch(Promise.resolve(vscode.workspace.applyEdit(edit)));
+            this._locks.delete(key);
+            if (err || !applied) {
+                this._log.warn(`native history reset failed ${document.uri}`);
+            }
+        });
+    }
+
+    private _syncNativeHistory(
+        document: vscode.TextDocument,
+        path: string,
+        file: { doc: { text: string; apply: (op: ShareDbTextOp) => void }; dirty: boolean },
+        mgr: UndoManager | undefined,
+        redo: boolean
+    ) {
+        const op = redo ? mgr?.redo(file.doc.text) : mgr?.undo(file.doc.text);
+        if (!op) {
+            this._resetNativeHistory(document, file.doc.text);
+            return;
+        }
+
+        const expected = ottext.apply(file.doc.text, op) as string;
+        file.doc.apply(op);
+
+        const wasDirty = file.dirty;
+        file.dirty = true;
+        if (!wasDirty) {
+            this._events.emit('asset:file:dirty', path, true);
+        }
+
+        if (norm(document.getText()) !== expected) {
+            this._resetNativeHistory(document, expected);
+        }
+    }
+
     private _watchDocument(folderUri: vscode.Uri, projectManager: ProjectManager) {
         for (const open of vscode.workspace.textDocuments) {
             if (!uriStartsWith(open.uri, folderUri)) {
@@ -1030,6 +1082,12 @@ class Disk extends Linker<{ folderUri: vscode.Uri; projectManager: ProjectManage
                 return;
             }
 
+            const mgr = this._undos.get(document.uri.path);
+            if (reason === vscode.TextDocumentChangeReason.Undo || reason === vscode.TextDocumentChangeReason.Redo) {
+                this._syncNativeHistory(document, path, file, mgr, reason === vscode.TextDocumentChangeReason.Redo);
+                return;
+            }
+
             // check if content actually changed (avoid echo and discard)
             // normalize to LF — canonical OT state is always LF
             const text = norm(document.getText());
@@ -1038,17 +1096,16 @@ class Disk extends Linker<{ folderUri: vscode.Uri; projectManager: ProjectManage
             }
 
             // skip discard/revert: buffer reverted to stale disk content,
-            // not a real edit. undo/redo are real edits that must reconcile OT state.
+            // not a real edit. native undo/redo is handled above.
             if (!reason && !document.isDirty && hash(text) === this._diskHash.get(document.uri.path)) {
                 return;
             }
 
             // submit ops via OTDocument (applies locally + submits to ShareDB)
             const ops = vscode2sharedb(document, contentChanges, file.doc.text);
-            const mgr = this._undos.get(document.uri.path);
             for (const op of ops) {
                 // push inverse to undo stack for local edits
-                // (undo/redo apply under _locks, so they never reach here)
+                // (extension undo/redo apply under _locks, so they never reach here)
                 if (mgr) {
                     const snap = file.doc.text;
                     const inv = ottext.semanticInvert(snap, op) as ShareDbTextOp;

--- a/src/disk.ts
+++ b/src/disk.ts
@@ -820,13 +820,25 @@ class Disk extends Linker<{ folderUri: vscode.Uri; projectManager: ProjectManage
     }
 
     private _watchUndoRedo(folderUri: vscode.Uri, projectManager: ProjectManager) {
-        // track active editor to gate keybindings
-        const updateCtx = (e?: vscode.TextEditor) => {
-            const collab = e && uriStartsWith(e.document.uri, folderUri);
-            vscode.commands.executeCommand('setContext', 'playcanvas.active', !!collab);
+        // gate the undo/redo keybindings on an active collab editor. re-derive
+        // from the LIVE activeTextEditor on focus/visible-editor changes too, not
+        // just active-editor changes — a stale context lets Ctrl+Z fall through to
+        // native undo, which bypasses OT sync. (the native-undo handler stays as a
+        // safety net for Edit-menu / palette undo, which keybindings can't gate.)
+        let active: boolean | undefined;
+        const updateCtx = () => {
+            const e = vscode.window.activeTextEditor;
+            const next = !!(e && uriStartsWith(e.document.uri, folderUri));
+            if (next === active) {
+                return;
+            }
+            active = next;
+            vscode.commands.executeCommand('setContext', 'playcanvas.active', next);
         };
-        updateCtx(vscode.window.activeTextEditor);
+        updateCtx();
         const onEditor = vscode.window.onDidChangeActiveTextEditor(updateCtx);
+        const onVisible = vscode.window.onDidChangeVisibleTextEditors(updateCtx);
+        const onWindow = vscode.window.onDidChangeWindowState(updateCtx);
 
         // shared apply logic for undo/redo — op pop + apply are atomic inside mutex
         const applyOp = async (
@@ -944,6 +956,8 @@ class Disk extends Linker<{ folderUri: vscode.Uri; projectManager: ProjectManage
 
         return () => {
             onEditor.dispose();
+            onVisible.dispose();
+            onWindow.dispose();
             undoCmd.dispose();
             redoCmd.dispose();
             vscode.commands.executeCommand('setContext', 'playcanvas.active', false);

--- a/src/test/suite/extension.test.ts
+++ b/src/test/suite/extension.test.ts
@@ -18,6 +18,7 @@ import * as buffer from '../../utils/buffer';
 import { Debouncer } from '../../utils/debouncer';
 import { EventEmitter } from '../../utils/event-emitter';
 import { Mutex } from '../../utils/mutex';
+import { norm } from '../../utils/text';
 import { hash, tryCatch, withTimeout } from '../../utils/utils';
 import { MockAuth } from '../mocks/auth';
 import { MockMessenger } from '../mocks/messenger';
@@ -3034,6 +3035,73 @@ suite('extension', () => {
 
         assert.strictEqual(tdoc.getText(), '// LOCAL\n// ORIGINAL', 'buffer should have local edit again');
         assert.strictEqual(documents.get(asset.uniqueId), '// LOCAL\n// ORIGINAL', 'OT doc should match');
+    });
+
+    test('native undo/redo after CRLF whole-buffer paste stays synced', async () => {
+        const folderUri = vscode.workspace.workspaceFolders?.[0]?.uri;
+        assert.ok(folderUri, 'workspace folder should exist');
+
+        const asset = await assetCreate({ name: 'crlf_native_undo.js', content: 'CCC' });
+        assert.ok(asset, 'asset should be created');
+
+        const uri = vscode.Uri.joinPath(folderUri, asset.name);
+        const tdoc = await vscode.workspace.openTextDocument(uri);
+        const editor = await vscode.window.showTextDocument(tdoc);
+        await assertResolves(
+            new Promise<void>((resolve) => {
+                if (!tdoc.isDirty && tdoc.getText() === 'CCC') {
+                    resolve();
+                    return;
+                }
+                const disposable = vscode.workspace.onDidChangeTextDocument((e) => {
+                    if (e.document.uri.toString() !== uri.toString()) {
+                        return;
+                    }
+                    if (!tdoc.isDirty && tdoc.getText() === 'CCC') {
+                        disposable.dispose();
+                        resolve();
+                    }
+                });
+            }),
+            'initial document settle'
+        );
+
+        await editor.edit((edit) => {
+            edit.setEndOfLine(vscode.EndOfLine.CRLF);
+        });
+        assert.strictEqual(tdoc.eol, vscode.EndOfLine.CRLF, 'document should use CRLF for this regression');
+
+        const pasteOp = assertOpsPromise(`documents:${asset.uniqueId}`, [['AAA\nBBB', { d: 3 }]]);
+        await editor.edit(
+            (edit) => {
+                edit.replace(
+                    new vscode.Range(tdoc.positionAt(0), tdoc.positionAt(tdoc.getText().length)),
+                    'AAA\r\nBBB'
+                );
+            },
+            { undoStopBefore: true, undoStopAfter: true }
+        );
+        await assertResolves(pasteOp, 'CRLF whole-buffer paste op');
+        await waitForIdle('CRLF paste settle');
+
+        assert.strictEqual(norm(tdoc.getText()), 'AAA\nBBB', 'buffer should contain pasted text');
+        assert.strictEqual(documents.get(asset.uniqueId), 'AAA\nBBB', 'OT doc should match pasted buffer');
+
+        const undoOp = assertOpsPromise(`documents:${asset.uniqueId}`, [[{ d: 7 }, 'CCC']]);
+        await vscode.commands.executeCommand('undo');
+        await assertResolves(undoOp, 'native undo op');
+        await waitForIdle('native undo settle');
+
+        assert.strictEqual(norm(tdoc.getText()), 'CCC', 'native undo should revert the buffer');
+        assert.strictEqual(documents.get(asset.uniqueId), 'CCC', 'native undo should sync OT doc');
+
+        const redoOp = assertOpsPromise(`documents:${asset.uniqueId}`, [['AAA\nBBB', { d: 3 }]]);
+        await vscode.commands.executeCommand('redo');
+        await assertResolves(redoOp, 'native redo op');
+        await waitForIdle('native redo settle');
+
+        assert.strictEqual(norm(tdoc.getText()), 'AAA\nBBB', 'native redo should restore pasted text');
+        assert.strictEqual(documents.get(asset.uniqueId), 'AAA\nBBB', 'native redo should sync OT doc');
     });
 
     test('undo skips remote edits - only reverts local', async () => {

--- a/src/test/suite/extension.test.ts
+++ b/src/test/suite/extension.test.ts
@@ -3104,6 +3104,84 @@ suite('extension', () => {
         assert.strictEqual(documents.get(asset.uniqueId), 'AAA\nBBB', 'native redo should sync OT doc');
     });
 
+    test('playcanvas.undo/redo command after CRLF shared-prefix paste stays synced', async () => {
+        const folderUri = vscode.workspace.workspaceFolders?.[0]?.uri;
+        assert.ok(folderUri, 'workspace folder should exist');
+
+        const asset = await assetCreate({ name: 'crlf_cmd_undo.js', content: 'AAA\nBBB\nCCC' });
+        assert.ok(asset, 'asset should be created');
+
+        const uri = vscode.Uri.joinPath(folderUri, asset.name);
+        const tdoc = await vscode.workspace.openTextDocument(uri);
+        const editor = await vscode.window.showTextDocument(tdoc);
+        await assertResolves(
+            new Promise<void>((resolve) => {
+                if (!tdoc.isDirty && norm(tdoc.getText()) === 'AAA\nBBB\nCCC') {
+                    resolve();
+                    return;
+                }
+                const disposable = vscode.workspace.onDidChangeTextDocument((e) => {
+                    if (e.document.uri.toString() !== uri.toString()) {
+                        return;
+                    }
+                    if (!tdoc.isDirty && norm(tdoc.getText()) === 'AAA\nBBB\nCCC') {
+                        disposable.dispose();
+                        resolve();
+                    }
+                });
+            }),
+            'initial document settle'
+        );
+
+        await editor.edit((edit) => {
+            edit.setEndOfLine(vscode.EndOfLine.CRLF);
+        });
+        assert.strictEqual(tdoc.eol, vscode.EndOfLine.CRLF, 'document should use CRLF for this regression');
+
+        // whole-buffer paste that SHARES a prefix (prefix>0 -> no leading-0 op,
+        // so this exercises the applyOp path, not the #318 leading-0 fix)
+        const pasteOp = assertOpsPromise(`documents:${asset.uniqueId}`, [[4, 'XXX', { d: 3 }]]);
+        await editor.edit(
+            (edit) => {
+                edit.replace(
+                    new vscode.Range(tdoc.positionAt(0), tdoc.positionAt(tdoc.getText().length)),
+                    'AAA\r\nXXX\r\nCCC'
+                );
+            },
+            { undoStopBefore: true, undoStopAfter: true }
+        );
+        await assertResolves(pasteOp, 'CRLF shared-prefix paste op');
+        await waitForIdle('CRLF paste settle');
+
+        assert.strictEqual(norm(tdoc.getText()), 'AAA\nXXX\nCCC', 'buffer should contain pasted text');
+        assert.strictEqual(documents.get(asset.uniqueId), 'AAA\nXXX\nCCC', 'OT doc should match pasted buffer');
+
+        // undo via the command path (applyOp) — buffer + OT must both revert.
+        // semanticInvert mirrors structure: the insert-first paste op inverts to
+        // a delete-first undo op.
+        const undoOp = assertOpsPromise(`documents:${asset.uniqueId}`, [[4, { d: 3 }, 'BBB']]);
+        await vscode.commands.executeCommand('playcanvas.undo');
+        await assertResolves(undoOp, 'command undo op');
+        await waitForIdle('command undo settle');
+        assert.strictEqual(norm(tdoc.getText()), 'AAA\nBBB\nCCC', 'undo should revert the buffer');
+        assert.strictEqual(documents.get(asset.uniqueId), 'AAA\nBBB\nCCC', 'undo should sync OT doc');
+
+        const redoOp = assertOpsPromise(`documents:${asset.uniqueId}`, [[4, 'XXX', { d: 3 }]]);
+        await vscode.commands.executeCommand('playcanvas.redo');
+        await assertResolves(redoOp, 'command redo op');
+        await waitForIdle('command redo settle');
+        assert.strictEqual(norm(tdoc.getText()), 'AAA\nXXX\nCCC', 'redo should restore pasted text');
+        assert.strictEqual(documents.get(asset.uniqueId), 'AAA\nXXX\nCCC', 'redo should sync OT doc');
+
+        // second undo must revert cleanly — no duplication / offset corruption
+        const undoOp2 = assertOpsPromise(`documents:${asset.uniqueId}`, [[4, { d: 3 }, 'BBB']]);
+        await vscode.commands.executeCommand('playcanvas.undo');
+        await assertResolves(undoOp2, 'command second undo op');
+        await waitForIdle('command second undo settle');
+        assert.strictEqual(norm(tdoc.getText()), 'AAA\nBBB\nCCC', 'second undo should revert again');
+        assert.strictEqual(documents.get(asset.uniqueId), 'AAA\nBBB\nCCC', 'second undo should sync OT doc');
+    });
+
     test('undo skips remote edits - only reverts local', async () => {
         const folderUri = vscode.workspace.workspaceFolders?.[0]?.uri;
         assert.ok(folderUri, 'workspace folder should exist');

--- a/src/test/suite/utils.test.ts
+++ b/src/test/suite/utils.test.ts
@@ -1,6 +1,9 @@
 import * as assert from 'assert';
 
+import { type as ottext } from 'ot-text';
+
 import type { Project } from '../../typings/models';
+import { delta } from '../../utils/text';
 import { sanitizeName, projectToName } from '../../utils/utils';
 
 suite('utils', () => {
@@ -46,5 +49,31 @@ suite('utils', () => {
 
     test('project to name - raw', () => {
         assert.strictEqual(projectToName({ name: 'foo/bar', id: 1 } as Project, false), 'foo/bar (1)');
+    });
+});
+
+suite('delta', () => {
+    // #318: delta must not emit a leading 0 skip — ot-text checkOp rejects it
+    // (threw in semanticInvert on a crlf select-all+paste, desyncing the doc)
+
+    test('full replace at offset 0 - valid op, no leading 0 skip', () => {
+        const op = delta('CCC', 'AAA\nBBB');
+        assert.ok(op);
+        assert.doesNotThrow(() => ottext.semanticInvert('CCC', op));
+        assert.strictEqual(ottext.apply('CCC', op), 'AAA\nBBB');
+    });
+
+    test('insert at offset 0 - valid op, no leading 0 skip', () => {
+        const op = delta('BC', 'ABC');
+        assert.ok(op);
+        assert.doesNotThrow(() => ottext.semanticInvert('BC', op));
+        assert.strictEqual(ottext.apply('BC', op), 'ABC');
+    });
+
+    test('delete at offset 0 - valid op, no leading 0 skip', () => {
+        const op = delta('ABC', 'BC');
+        assert.ok(op);
+        assert.doesNotThrow(() => ottext.semanticInvert('ABC', op));
+        assert.strictEqual(ottext.apply('ABC', op), 'BC');
     });
 });

--- a/src/utils/text.ts
+++ b/src/utils/text.ts
@@ -26,7 +26,9 @@ export const delta = (from: string, to: string): ShareDbTextOp | null => {
     const { prefix, suffix } = diff(from, to);
     const del = from.length - prefix - suffix;
     const ins = to.substring(prefix, to.length - suffix);
-    return del > 0 && ins.length > 0 ? [prefix, ins, { d: del }] : del > 0 ? [prefix, { d: del }] : [prefix, ins];
+    // omit a leading 0 skip — ot-text checkOp rejects skip=0 (#318)
+    const op: ShareDbTextOp = del > 0 && ins.length > 0 ? [ins, { d: del }] : del > 0 ? [{ d: del }] : [ins];
+    return prefix ? [prefix, ...op] : op;
 };
 
 export const stat = (op: ShareDbTextOp) => {


### PR DESCRIPTION
## Summary
On Windows (CRLF), pasting one script's contents over another and then undoing left VS Code out of sync with ShareDB, and repeated undo/redo could duplicate/corrupt the buffer. Several distinct defects, all gated on CRLF buffers:

1. **Leading-0 op.** `delta()` emitted a leading `0` skip for offset-0 replace/insert/delete ops; `ot-text` rejects `skip=0`. The rejected op threw while building undo history — before the edit reached `OTDocument.apply()` — leaving VS Code dirty while ShareDB stayed stale. (Only triggers when the paste differs from offset 0.)
2. **Stale-buffer amplification on undo.** The `playcanvas.undo`/`redo` command (`applyOp`) applied the op to ShareDB first, then computed the buffer edit as `delta(pre, buf)`, assuming the buffer still matched canonical. If the buffer went stale (server advanced, buffer write didn't land), the staleness was misread as concurrent user input and the op was transformed against a phantom divergence — duplicating content with an offset shift. This corrupted the reporter's case: `script1`/`script2` share the `var Script` prefix, so the leading-0 path never fires and the real fault is here.
3. **Stale keybinding context.** `playcanvas.active` was only re-derived on active-editor changes, so it could go stale and let `Ctrl+Z` fall through to native undo, which bypasses OT sync.

## Fix
- **`delta()`** omits the leading skip for offset-0 ops, matching the LF edit path, so the paste op is valid and undo history + ShareDB submission both proceed through the OT path.
- **Native undo/redo** document changes route through the extension `UndoManager` + `OTDocument.apply()`, with a buffer reset if native history diverges from OT state.
- **`applyOp`** now diffs the op's authoritative result against the **live buffer** (never assuming it equals pre-op canonical), so any drift self-heals instead of compounding into duplication.
- **`playcanvas.active`** re-derives from the live `activeTextEditor` on focus and visible-editor changes too, keeping the command path authoritative. The native-undo handler is retained as a safety net for Edit-menu / Command-Palette undo, which keybindings can't gate.

## Test plan
- [x] Unit coverage for offset-0 `delta()` ops.
- [x] CRLF whole-buffer paste + native undo/redo stays synced with ShareDB.
- [x] `playcanvas.undo`/`redo` command over a CRLF shared-prefix paste stays synced through undo → redo → undo (no duplication).
- [x] Full suite: 85 passing.

Manual (Windows):
- [x] Copy all of `script1`, select all in `script2`, paste — `script2` updates without becoming stuck dirty/unsaveable.
- [x] `Ctrl+Z` in `script2` — paste undone, buffer stays synced with the web editor.
- [x] `Ctrl+Z` / `Ctrl+Y` / `Ctrl+Z` repeated — no duplicate/corrupted text.
- [x] Re-test the dead-hotkey path on Windows after the context hardening.

Fixes #318
