### PR TITLE
Run npm.cmd through a shell on Windows so runtime type install works

### DIFF
--- a/src/type-installer.ts
+++ b/src/type-installer.ts
@@ -25,13 +25,20 @@ type Manifest = {
 
 type ChildProcess = typeof childProcess;
 
-const npm = () => (process.platform === 'win32' ? 'npm.cmd' : 'npm');
+const WIN = process.platform === 'win32';
+
+const npm = () => (WIN ? 'npm.cmd' : 'npm');
 
 const normalize = (version?: string) => (version || PLAYCANVAS_VERSION).replace(/^v/i, '');
 
 const run = async (proc: ChildProcess, cmd: string, args: string[], cwd: string) => {
     return new Promise<string>((resolve, reject) => {
-        const child = proc.spawn(cmd, args, { cwd, windowsHide: true });
+        // npm.cmd is a batch file — windows needs shell:true to run it, and shell space-joins args, so quote any with spaces
+        const child = proc.spawn(cmd, WIN ? args.map((a) => (/\s/.test(a) ? `"${a}"` : a)) : args, {
+            cwd,
+            windowsHide: true,
+            shell: WIN
+        });
         const chunks: string[] = [];
         const timer = setTimeout(() => {
             child.kill();


### PR DESCRIPTION
On Windows, runtime PlayCanvas type install always failed with "npm was not found" even when npm was installed and on PATH, silently falling back to bundled types.

`npm.cmd` is a batch file, and `child_process.spawn` without `shell: true` can't execute `.cmd`/`.bat` (modern Node throws `EINVAL`). The probe rejected and reported npm missing.

- Spawn with `shell: true` on Windows so `cmd.exe` runs `npm.cmd`; POSIX unchanged.
- Quote args containing spaces (shell space-joins the command line) — notably `--prefix <globalStorage path>` under `C:\Users\<name>\AppData\...`.

Verified on Windows: opening a project now installs types instead of warning. `npm run compile` + `npm run lint` pass. Integration tests stub `TypeInstaller`, so the spawn path isn't covered there.