### PR TITLE
Detect resume from suspend and reconnect before stale sockets desync

### DIFF
--- a/src/connections/constants.ts
+++ b/src/connections/constants.ts
@@ -2,6 +2,7 @@ export const PING_INTERVAL_MS = 1000;
 export const PONG_TIMEOUT_MS = 5 * 1000;
 export const RECONNECT_BASE_MS = 1000;
 export const RECONNECT_MAX_MS = 30 * 1000;
+export const RESUME_GAP_MS = 10 * 1000;
 export const CONNECT_TIMEOUT_MS = 10 * 1000;
 export const SUBSCRIBE_TIMEOUT_MS = 10 * 1000;
 export const AUTH_TIMEOUT_MS = 2 * 60 * 1000;

--- a/src/connections/messenger.ts
+++ b/src/connections/messenger.ts
@@ -13,7 +13,8 @@ import {
     PING_INTERVAL_MS,
     PONG_TIMEOUT_MS,
     RECONNECT_BASE_MS,
-    RECONNECT_MAX_MS
+    RECONNECT_MAX_MS,
+    RESUME_GAP_MS
 } from './constants';
 import { latency } from './latency';
 
@@ -95,6 +96,8 @@ class Messenger extends EventEmitter<EventMap> {
     private _getToken: (() => Promise<string | undefined>) | null = null;
 
     private _lastPong = 0;
+
+    private _lastTick = 0;
 
     private _pings: number[] = [];
 
@@ -193,6 +196,7 @@ class Messenger extends EventEmitter<EventMap> {
         // reset backoff on successful auth
         this._reconnectAttempt = 0;
         this._lastPong = Date.now();
+        this._lastTick = Date.now();
         this._pings.length = 0;
 
         // reset keep alive
@@ -200,6 +204,26 @@ class Messenger extends EventEmitter<EventMap> {
             clearInterval(this._alive);
         }
         this._alive = setInterval(() => {
+            // suspend/resume guard: interval starved past the resume gap means wall-clock
+            // jumped (sleep/lock); the socket may be a half-open zombie — force reconnect (#316)
+            const now = Date.now();
+            if (now - this._lastTick > RESUME_GAP_MS) {
+                this._log.warn('resume detected, forcing reconnect');
+                // stop the heartbeat and tear down without a close handshake — a dead
+                // peer never replies, pinning the socket CLOSING for ws's 30s timeout
+                if (this._alive) {
+                    clearInterval(this._alive);
+                    this._alive = null;
+                }
+                if (WEB) {
+                    socket.close(4001, 'resume');
+                } else {
+                    socket.terminate();
+                }
+                return;
+            }
+            this._lastTick = now;
+
             // check for pong timeout
             if (Date.now() - this._lastPong > PONG_TIMEOUT_MS) {
                 this._log.warn('pong timeout, closing socket');

--- a/src/connections/relay.ts
+++ b/src/connections/relay.ts
@@ -15,7 +15,8 @@ import {
     PING_INTERVAL_MS,
     PONG_TIMEOUT_MS,
     RECONNECT_BASE_MS,
-    RECONNECT_MAX_MS
+    RECONNECT_MAX_MS,
+    RESUME_GAP_MS
 } from './constants';
 import { latency } from './latency';
 
@@ -46,6 +47,8 @@ class Relay extends EventEmitter<EventMap> {
     private _getToken: (() => Promise<string | undefined>) | null = null;
 
     private _lastPong = 0;
+
+    private _lastTick = 0;
 
     private _pings: number[] = [];
 
@@ -156,6 +159,7 @@ class Relay extends EventEmitter<EventMap> {
         this._reconnectAttempt = 0;
         this._authRetried = false;
         this._lastPong = Date.now();
+        this._lastTick = Date.now();
         this._pings.length = 0;
 
         // reset keep alive
@@ -163,6 +167,26 @@ class Relay extends EventEmitter<EventMap> {
             clearInterval(this._alive);
         }
         this._alive = setInterval(() => {
+            // suspend/resume guard: interval starved past the resume gap means wall-clock
+            // jumped (sleep/lock); the socket may be a half-open zombie — force reconnect (#316)
+            const now = Date.now();
+            if (now - this._lastTick > RESUME_GAP_MS) {
+                this._log.warn('resume detected, forcing reconnect');
+                // stop the heartbeat and tear down without a close handshake — a dead
+                // peer never replies, pinning the socket CLOSING for ws's 30s timeout
+                if (this._alive) {
+                    clearInterval(this._alive);
+                    this._alive = null;
+                }
+                if (WEB) {
+                    socket.close(4001, 'resume');
+                } else {
+                    socket.terminate();
+                }
+                return;
+            }
+            this._lastTick = now;
+
             // check for pong timeout
             if (Date.now() - this._lastPong > PONG_TIMEOUT_MS) {
                 this._log.warn('pong timeout, closing socket');

--- a/src/connections/sharedb.ts
+++ b/src/connections/sharedb.ts
@@ -19,6 +19,7 @@ import {
     PONG_TIMEOUT_MS,
     RECONNECT_BASE_MS,
     RECONNECT_MAX_MS,
+    RESUME_GAP_MS,
     SUBSCRIBE_TIMEOUT_MS
 } from './constants';
 import { delay, latency } from './latency';
@@ -60,6 +61,8 @@ class ShareDb extends EventEmitter<EventMap> {
     private _getToken: (() => Promise<string | undefined>) | null = null;
 
     private _lastPong = 0;
+
+    private _lastTick = 0;
 
     url: string;
 
@@ -173,6 +176,7 @@ class ShareDb extends EventEmitter<EventMap> {
         this._reconnectAttempt = 0;
         this._authRetried = false;
         this._lastPong = Date.now();
+        this._lastTick = Date.now();
 
         if (this._connection) {
             this._connection.bindToSocket(socket as Socket);
@@ -188,7 +192,28 @@ class ShareDb extends EventEmitter<EventMap> {
             clearInterval(this._alive);
         }
         this._alive = setInterval(() => {
-            // check for pong timeout — server pings every 1s so we should always receive data
+            // suspend/resume guard: interval starved past the resume gap means wall-clock
+            // jumped (sleep/lock); the socket may be a half-open zombie — force reconnect (#316)
+            const now = Date.now();
+            if (now - this._lastTick > RESUME_GAP_MS) {
+                this._log.warn('resume detected, forcing reconnect');
+                // stop the heartbeat and tear down without a close handshake — a dead
+                // peer never replies, pinning the socket CLOSING for ws's 30s timeout
+                if (this._alive) {
+                    clearInterval(this._alive);
+                    this._alive = null;
+                }
+                if (WEB) {
+                    socket.close(4001, 'resume');
+                } else {
+                    socket.terminate();
+                }
+                return;
+            }
+            this._lastTick = now;
+
+            // check for pong timeout — inbound data is the pp echo of our own 1s ping;
+            // server ws pings are control frames that never surface as messages
             if (Date.now() - this._lastPong > PONG_TIMEOUT_MS) {
                 this._log.warn('pong timeout, closing socket');
                 socket.close(4001, 'pong timeout');

--- a/src/test/suite/extension.test.ts
+++ b/src/test/suite/extension.test.ts
@@ -2,9 +2,11 @@ import * as assert from 'assert';
 
 import * as sinon from 'sinon';
 import * as vscode from 'vscode';
+import { WebSocketServer } from 'ws';
 
 import * as authModule from '../../auth';
 import { NAME, PUBLISHER } from '../../config';
+import { RESUME_GAP_MS } from '../../connections/constants';
 import * as messengerModule from '../../connections/messenger';
 import * as relayModule from '../../connections/relay';
 import * as restModule from '../../connections/rest';
@@ -19,7 +21,7 @@ import { Debouncer } from '../../utils/debouncer';
 import { EventEmitter } from '../../utils/event-emitter';
 import { Mutex } from '../../utils/mutex';
 import { norm } from '../../utils/text';
-import { hash, tryCatch, withTimeout } from '../../utils/utils';
+import { hash, tryCatch, tryCatchSync, withTimeout } from '../../utils/utils';
 import { MockAuth } from '../mocks/auth';
 import { MockMessenger } from '../mocks/messenger';
 import {
@@ -3621,5 +3623,87 @@ suite('extension', () => {
             .getCalls()
             .find((c) => `${c.args[0]}`.includes('mock 500: assetCreate refused'));
         assert.ok(errorCall, 'showErrorMessage must surface the rest failure');
+    });
+});
+
+// regression #316: after an OS suspend (windows lock for hours) the websocket can
+// return as a half-open zombie whose buffered traffic keeps refreshing ShareDb._lastPong,
+// so the pong-timeout never trips, the doc never re-syncs, and resumed edits roll back
+// collaborators. the resume guard fires on the wall-clock jump regardless of inbound
+// traffic. exercises the real ShareDb (not the mock) against a local ws server; the
+// identical guard is mirrored in Messenger and Relay.
+suite('connections — resume guard (#316)', () => {
+    // MockShareDb extends the real class, so its prototype is the unstubbed ShareDb
+    const RealShareDb = Object.getPrototypeOf(MockShareDb) as typeof sharedbModule.ShareDb;
+    const clock = sinon.createSandbox();
+    let server: WebSocketServer;
+    let port = 0;
+    let connections = 0;
+    let keepalives: NodeJS.Timeout[] = [];
+    let sb: InstanceType<typeof sharedbModule.ShareDb> | undefined;
+
+    suiteSetup(async () => {
+        await new Promise<void>((resolve) => {
+            server = new WebSocketServer({ port: 0 }, () => {
+                port = (server.address() as { port: number }).port;
+                resolve();
+            });
+        });
+        server.on('connection', (ws) => {
+            connections++;
+            ws.on('message', (raw) => {
+                const str = raw.toString();
+                if (str.startsWith('auth')) {
+                    ws.send(`auth${JSON.stringify({ id: 1 })}`);
+                    // simulate buffered server traffic delivered on resume — any inbound
+                    // message refreshes ShareDb._lastPong, masking the dead socket
+                    keepalives.push(setInterval(() => ws.readyState === ws.OPEN && ws.send('hb:0'), 200));
+                    return;
+                }
+                // complete the sharedb protocol handshake so Connection.ping() can send
+                const [, msg] = tryCatchSync(() => JSON.parse(str));
+                if (msg?.a === 'hs') {
+                    ws.send(JSON.stringify({ a: 'hs', protocol: 1, protocolMinor: 1, id: '1', type: 'json0' }));
+                }
+            });
+        });
+    });
+
+    suiteTeardown(async () => {
+        keepalives.forEach(clearInterval);
+        await new Promise<void>((resolve) => server.close(() => resolve()));
+    });
+
+    setup(() => {
+        connections = 0;
+        keepalives = [];
+    });
+
+    teardown(() => {
+        clock.restore();
+        keepalives.forEach(clearInterval);
+        sb?.disconnect();
+        sb = undefined;
+    });
+
+    test('forces a reconnect on wall-clock jump even while traffic keeps the socket alive', async function () {
+        this.timeout(20000);
+
+        sb = new RealShareDb({ url: `ws://127.0.0.1:${port}`, origin: 'http://localhost' });
+        await sb.connect(async () => 'token');
+        assert.strictEqual(connections, 1, 'should connect once');
+
+        // simulate resume from suspend: wall-clock jumps past the resume gap while the
+        // server keeps sending traffic, so the pong-timeout never trips on its own.
+        // compute target before stubbing — Date.now() in the arg would hit the new stub
+        const jumped = Date.now() + RESUME_GAP_MS + 5000;
+        clock.stub(Date, 'now').returns(jumped);
+
+        // the next heartbeat tick should detect the gap and force-close → reconnect.
+        // poll on iteration count, not Date.now (stubbed) — ~15s real ceiling
+        for (let i = 0; i < 150 && connections < 2; i++) {
+            await new Promise((r) => setTimeout(r, 100));
+        }
+        assert.strictEqual(connections, 2, 'resume guard should force exactly one reconnect');
     });
 });

--- a/src/test/suite/extension.test.ts
+++ b/src/test/suite/extension.test.ts
@@ -3626,13 +3626,13 @@ suite('extension', () => {
     });
 });
 
-// regression #316: after an OS suspend (windows lock for hours) the websocket can
+// regression: after an OS suspend (windows lock for hours) the websocket can
 // return as a half-open zombie whose buffered traffic keeps refreshing ShareDb._lastPong,
 // so the pong-timeout never trips, the doc never re-syncs, and resumed edits roll back
 // collaborators. the resume guard fires on the wall-clock jump regardless of inbound
 // traffic. exercises the real ShareDb (not the mock) against a local ws server; the
 // identical guard is mirrored in Messenger and Relay.
-suite('connections — resume guard (#316)', () => {
+suite('connections - suspend recovery', () => {
     // MockShareDb extends the real class, so its prototype is the unstubbed ShareDb
     const RealShareDb = Object.getPrototypeOf(MockShareDb) as typeof sharedbModule.ShareDb;
     const clock = sinon.createSandbox();


### PR DESCRIPTION
## Problem

After an OS suspend (e.g. Windows locked for hours), a websocket can come back half-open: `readyState OPEN` but the server side is long gone. On resume, buffered inbound traffic refreshes `_lastPong`, so the heartbeat never trips — the doc stays pinned at a stale OT version while the UI shows "Connected", and resumed edits desync or roll back collaborators' work. The known workaround was manually running "reload project".

## Fix

The 1s heartbeat now also checks the wall clock: an interval starved past `RESUME_GAP_MS` (10s) means the process was suspended. The guard stops the heartbeat and `terminate()`s the socket (`close` on web, which has no terminate) — skipping the close handshake a dead peer would never answer — and the existing reconnect path resubscribes and resyncs docs server-authoritatively. Independent of `_lastPong`, so buffered traffic can't mask it. Applied identically to `sharedb`, `messenger`, and `relay`.

## Verification

- Regression test drives the real `ShareDb` against a local ws server, keeps traffic flowing to mask `_lastPong`, jumps `Date.now()` past the gap, and asserts exactly one reconnect (~2s). Red with the guard neutralized, green with it. Messenger/relay use copy-identical guards.
- Full suite green (87 passing); lint clean.

Known limitation: messenger events missed while suspended aren't replayed by the server, so the asset tree can stay stale until a project reload — tracked separately as a backend follow-up.

Fixes #316