### PR TITLE
fix: use asset item_id for create/rename on non-main branches

### DIFF
--- a/src/project-manager.ts
+++ b/src/project-manager.ts
@@ -996,7 +996,9 @@ class ProjectManager extends Linker<{ projectId: number; branchId: string }> {
             if (!file || file.type !== 'folder') {
                 throw this.error.set(() => fail`missing parent folder ${parentPath} of ${path}`);
             }
-            parent = file.uniqueId;
+            // REST keys by item_id; uniqueId (ShareDB _id) only equals item_id on the
+            // branch a folder was created on. fall back for optimistic folders not yet in the map.
+            parent = this._idUniqueId.getR(file.uniqueId) ?? file.uniqueId;
         }
 
         // create rest promise first to use in load promise
@@ -1162,9 +1164,15 @@ class ProjectManager extends Linker<{ projectId: number; branchId: string }> {
                 this._events.on('asset:update', onupdate);
             });
 
-            // rename asset
+            // rename asset (REST keys by item_id, not the ShareDB _id/uniqueId — they
+            // only match on the branch the asset was created on)
             const renamed = guard(
-                this._rest.assetRename(this._projectId, this._branchId, file.uniqueId, newName),
+                this._rest.assetRename(
+                    this._projectId,
+                    this._branchId,
+                    this._idUniqueId.getR(file.uniqueId) ?? file.uniqueId,
+                    newName
+                ),
                 this.error
             );
 

--- a/src/test/mocks/rest.ts
+++ b/src/test/mocks/rest.ts
@@ -200,11 +200,12 @@ class MockRest extends Rest {
                     documents.set(asset.uniqueId, document);
                 }
 
-                // call messenger assetCreated signal
+                // call messenger assetCreated signal — backend sends the asset _id
+                // (uniqueId) here, not item_id (see assets.onAssetCreated)
                 messenger.emit('asset.new', {
                     data: {
                         asset: {
-                            id: asset.item_id,
+                            id: `${asset.uniqueId}`,
                             name: asset.name,
                             type: asset.type,
                             branchId: _branchId

--- a/src/test/suite/extension.test.ts
+++ b/src/test/suite/extension.test.ts
@@ -1120,6 +1120,51 @@ suite('extension', () => {
         assert.deepStrictEqual(created, [parentName, subfolderName, fileName], 'assets should be created in order');
     });
 
+    test('file create - subfolder parent uses item_id not uniqueId (#323)', async () => {
+        // get folder uri
+        const folderUri = vscode.workspace.workspaceFolders?.[0]?.uri;
+        assert.ok(folderUri, 'workspace folder should exist');
+
+        // simulate a non-main branch: assets get item_id != uniqueId and REST asset
+        // endpoints match parent by item_id only (production semantics). teardown's
+        // resetFailures() clears both flags.
+        rest.distinctAssetIds = true;
+        rest.assetEndpointsUseItemIds = true;
+
+        const parentName = 'branch_parent';
+        const fileName = 'branch_child.js';
+        const fileContent = '// CHILD ON BRANCH';
+
+        rest.assetCreate.resetHistory();
+
+        const parentUri = vscode.Uri.joinPath(folderUri, parentName);
+        const fileUri = vscode.Uri.joinPath(parentUri, fileName);
+
+        const parentCreated = waitForEmit('asset.new', (args) => assetNewName(args, parentName), 'parent asset.new');
+        await vscode.workspace.fs.createDirectory(parentUri);
+        await parentCreated;
+
+        // parent folder now has divergent ids
+        const parentAsset = Array.from(assets.values()).find((a) => a.name === parentName);
+        assert.ok(parentAsset, 'parent folder asset should exist');
+        const parentItemId = parseInt(parentAsset.item_id, 10);
+        assert.notStrictEqual(parentItemId, parentAsset.uniqueId, 'fixture should have item_id != uniqueId');
+
+        // create child file inside the folder — would 400 (parent not found) if uniqueId is sent
+        const fileCreated = waitForEmit('asset.new', (args) => assetNewName(args, fileName), 'file asset.new');
+        await vscode.workspace.fs.writeFile(fileUri, buffer.from(fileContent));
+        await fileCreated;
+        await waitForIdle('branch child create settle');
+
+        const fileCall = rest.assetCreate.getCalls().find((c) => c.args[2].name === fileName);
+        assert.ok(fileCall, 'assetCreate should have been called for the child file');
+        assert.strictEqual(
+            fileCall.args[2].parent,
+            parentItemId,
+            'child create should send the parent folder item_id, not its uniqueId'
+        );
+    });
+
     test('folder create - siblings local to remote', async () => {
         // get folder uri
         const folderUri = vscode.workspace.workspaceFolders?.[0]?.uri;
@@ -2310,6 +2355,40 @@ suite('extension', () => {
             call.args,
             [project.id, projectSettings.branch, asset.uniqueId, newName],
             'assetRename args should match'
+        );
+    });
+
+    test('file rename - sends item_id not uniqueId (#323)', async () => {
+        // get folder uri
+        const folderUri = vscode.workspace.workspaceFolders?.[0]?.uri;
+        assert.ok(folderUri, 'workspace folder should exist');
+
+        // simulate a non-main branch: item_id != uniqueId and REST asset endpoints
+        // match by item_id only. teardown's resetFailures() clears both flags.
+        rest.distinctAssetIds = true;
+        rest.assetEndpointsUseItemIds = true;
+
+        const oldName = 'branch_rename.js';
+        const newName = 'branch_rename_renamed.js';
+        const document = `console.log('branch rename');\n`;
+        const asset = await assetCreate({ name: oldName, content: document });
+        const itemId = parseInt(asset.item_id, 10);
+        assert.notStrictEqual(itemId, asset.uniqueId, 'fixture should have item_id != uniqueId');
+
+        // rename op would never fire if uniqueId is sent (mock rejects it like the backend)
+        const renamed = assertOpsPromise(`assets:${asset.uniqueId}`, [[{ p: ['name'], oi: newName }]]);
+        rest.assetRename.resetHistory();
+
+        const oldUri = vscode.Uri.joinPath(folderUri, asset.name);
+        const newUri = vscode.Uri.joinPath(folderUri, newName);
+        await assertResolves(vscode.workspace.fs.rename(oldUri, newUri), 'fs.rename');
+        await assertResolves(renamed, 'asset.rename');
+
+        const call = rest.assetRename.getCall(0);
+        assert.deepStrictEqual(
+            call.args,
+            [project.id, projectSettings.branch, itemId, newName],
+            'rename should send the asset item_id, not its uniqueId'
         );
     });
 


### PR DESCRIPTION
Creating or renaming a file in a subfolder on a non-main branch failed with `400 parent folder is not found`. The extension was sending the folder's ShareDB `_id` (uniqueId) to the REST asset endpoints, which key by `item_id` — these only match on the branch the asset was created on, so it worked on main but 400'd everywhere else.

Now translates uniqueId → item_id (as `fetchContent` already does). Also tightened the test mocks to match backend semantics (REST matches `item_id`; `asset.new` carries `_id`), which is what had masked the bug.

Closes #323