### PR TITLE
fix: stop the disk watcher duplicating open-file content

### DIFF
--- a/src/disk.ts
+++ b/src/disk.ts
@@ -249,10 +249,7 @@ class Disk extends Linker<{ folderUri: vscode.Uri; projectManager: ProjectManage
                     return;
                 }
 
-                const viewing =
-                    this._opened.has(uri.path) ||
-                    vscode.workspace.textDocuments.some((d) => d.uri.toString() === uri.toString());
-                if (viewing) {
+                if (this._isOpen(uri)) {
                     this._log.debug(`create.remote.open ${uri}`);
                     return;
                 }
@@ -318,6 +315,15 @@ class Disk extends Linker<{ folderUri: vscode.Uri; projectManager: ProjectManage
         });
     }
 
+    // robust open check — `_opened` is a hand-maintained shadow set that can drift;
+    // textDocuments is the source of truth. keeps the watcher from pushing open files upstream
+    private _isOpen(uri: vscode.Uri) {
+        return (
+            this._opened.has(uri.path) ||
+            vscode.workspace.textDocuments.some((d) => d.uri.toString() === uri.toString())
+        );
+    }
+
     private _update(uri: vscode.Uri, op: ShareDbTextOp, content: string, prev: string) {
         const snapshot = norm(content);
         return this._writeMutex.atomic([`${uri}`], async () => {
@@ -326,9 +332,7 @@ class Disk extends Linker<{ folderUri: vscode.Uri; projectManager: ProjectManage
             }
 
             // check if file is open in editor
-            const viewing =
-                this._opened.has(uri.path) ||
-                vscode.workspace.textDocuments.some((d) => d.uri.toString() === uri.toString());
+            const viewing = this._isOpen(uri);
 
             // update on disk if not open in editor (avoid conflicts with unsaved buffer content)
             if (!viewing) {
@@ -1335,6 +1339,12 @@ class Disk extends Linker<{ folderUri: vscode.Uri; projectManager: ProjectManage
                                         ) {
                                             return;
                                         }
+                                        // open file: editor's onDidChangeTextDocument owns reload+submit;
+                                        // pushing here too races and duplicates content
+                                        if (this._isOpen(op.uri)) {
+                                            this._log.debug(`change.local (atomic open-skip) ${op.uri}`);
+                                            return;
+                                        }
                                         this._log.debug(`change.local (atomic) ${op.uri}`);
                                         await projectManager.write(path, content);
                                         if (this._opened.has(op.uri.path)) {
@@ -1504,8 +1514,10 @@ class Disk extends Linker<{ folderUri: vscode.Uri; projectManager: ProjectManage
             }
 
             // check if document is not open
-            // NOTE: document change event handles open files
-            if (this._opened.has(uri.path)) {
+            // NOTE: document change event handles open files. use _isOpen, not the raw
+            // _opened set — a stale set lets the watcher push an open file's content
+            // upstream, racing the editor path and duplicating content on the server
+            if (this._isOpen(uri)) {
                 return;
             }
 

--- a/src/disk.ts
+++ b/src/disk.ts
@@ -90,8 +90,6 @@ class Disk extends Linker<{ folderUri: vscode.Uri; projectManager: ProjectManage
 
     private _projectManager?: ProjectManager;
 
-    private _opened = new Set<string>();
-
     private _echo: Map<string, string> = new Map<string, string>();
 
     private _locks = new Set<string>();
@@ -315,13 +313,10 @@ class Disk extends Linker<{ folderUri: vscode.Uri; projectManager: ProjectManage
         });
     }
 
-    // robust open check — `_opened` is a hand-maintained shadow set that can drift;
-    // textDocuments is the source of truth. keeps the watcher from pushing open files upstream
+    // open check — textDocuments is the source of truth. keeps the watcher from
+    // pushing open files upstream, racing the editor path and duplicating content
     private _isOpen(uri: vscode.Uri) {
-        return (
-            this._opened.has(uri.path) ||
-            vscode.workspace.textDocuments.some((d) => d.uri.toString() === uri.toString())
-        );
+        return vscode.workspace.textDocuments.some((d) => d.uri.toString() === uri.toString());
     }
 
     private _update(uri: vscode.Uri, op: ShareDbTextOp, content: string, prev: string) {
@@ -518,7 +513,7 @@ class Disk extends Linker<{ folderUri: vscode.Uri; projectManager: ProjectManage
 
             // open files: disk writes only via VS Code's native save.
             // no document.save() to avoid triggering formatOnSave.
-            if (this._opened.has(uri.path)) {
+            if (this._isOpen(uri)) {
                 const document = await vscode.workspace.openTextDocument(uri);
 
                 // empty documents: flush to disk and revert to clear mtime
@@ -549,7 +544,7 @@ class Disk extends Linker<{ folderUri: vscode.Uri; projectManager: ProjectManage
         // undo inverses reference pre-reload OT history — clear so undo can't resurrect missing content
         this._undos.get(uri.path)?.clear();
 
-        if (this._opened.has(uri.path)) {
+        if (this._isOpen(uri)) {
             // reconcile buffer with live ShareDB doc after subscribe
             await this._writeMutex.atomic([`${uri}`], async () => {
                 this._locks.add(`${uri}`);
@@ -627,7 +622,7 @@ class Disk extends Linker<{ folderUri: vscode.Uri; projectManager: ProjectManage
     }
 
     private async _reconcile(uri: vscode.Uri, path: string, type: 'file' | 'folder') {
-        if (type !== 'file' || !this._opened.has(uri.path)) {
+        if (type !== 'file' || !this._isOpen(uri)) {
             return;
         }
 
@@ -803,7 +798,7 @@ class Disk extends Linker<{ folderUri: vscode.Uri; projectManager: ProjectManage
         const assetFileFailed = this._events.on('asset:file:failed', async (path) => {
             const uri = vscode.Uri.joinPath(folderUri, path);
             const doc = vscode.workspace.textDocuments.find((d) => d.uri.toString() === uri.toString());
-            if (!doc || !this._opened.has(uri.path) || doc.isDirty) {
+            if (!doc || doc.isDirty) {
                 return;
             }
             await this._dirty(doc);
@@ -1026,7 +1021,6 @@ class Disk extends Linker<{ folderUri: vscode.Uri; projectManager: ProjectManage
                 continue;
             }
             const path = relativePath(open.uri, folderUri);
-            this._opened.add(open.uri.path);
             this._undos.set(open.uri.path, new UndoManager());
             if (!this._diskHash.has(open.uri.path)) {
                 this._diskHash.set(open.uri.path, hash(norm(open.getText())));
@@ -1039,7 +1033,6 @@ class Disk extends Linker<{ folderUri: vscode.Uri; projectManager: ProjectManage
                 return;
             }
             const path = relativePath(document.uri, folderUri);
-            this._opened.add(document.uri.path);
             this._undos.set(document.uri.path, new UndoManager());
             this._diskHash.set(document.uri.path, hash(norm(document.getText())));
             this._events.emit('asset:doc:open', path);
@@ -1050,7 +1043,6 @@ class Disk extends Linker<{ folderUri: vscode.Uri; projectManager: ProjectManage
                 return;
             }
             const path = relativePath(document.uri, folderUri);
-            this._opened.delete(document.uri.path);
             this._undos.get(document.uri.path)?.clear();
             this._undos.delete(document.uri.path);
             this._diskHash.delete(document.uri.path);
@@ -1347,13 +1339,12 @@ class Disk extends Linker<{ folderUri: vscode.Uri; projectManager: ProjectManage
                                         }
                                         this._log.debug(`change.local (atomic) ${op.uri}`);
                                         await projectManager.write(path, content);
-                                        if (this._opened.has(op.uri.path)) {
-                                            const doc = vscode.workspace.textDocuments.find(
-                                                (d) => d.uri.path === op.uri.path
-                                            );
-                                            if (doc) {
-                                                this._dirty(doc);
-                                            }
+                                        // dirtify if the file is open in an editor
+                                        const doc = vscode.workspace.textDocuments.find(
+                                            (d) => d.uri.path === op.uri.path
+                                        );
+                                        if (doc) {
+                                            this._dirty(doc);
                                         }
                                         return;
                                     }
@@ -1420,13 +1411,9 @@ class Disk extends Linker<{ folderUri: vscode.Uri; projectManager: ProjectManage
                                     await projectManager.write(path, content);
 
                                     // dirtify if file was opened while change was deferred
-                                    if (this._opened.has(op.uri.path)) {
-                                        const doc = vscode.workspace.textDocuments.find(
-                                            (d) => d.uri.path === op.uri.path
-                                        );
-                                        if (doc) {
-                                            this._dirty(doc);
-                                        }
+                                    const doc = vscode.workspace.textDocuments.find((d) => d.uri.path === op.uri.path);
+                                    if (doc) {
+                                        this._dirty(doc);
                                     }
 
                                     return Promise.resolve();
@@ -1514,9 +1501,8 @@ class Disk extends Linker<{ folderUri: vscode.Uri; projectManager: ProjectManage
             }
 
             // check if document is not open
-            // NOTE: document change event handles open files. use _isOpen, not the raw
-            // _opened set — a stale set lets the watcher push an open file's content
-            // upstream, racing the editor path and duplicating content on the server
+            // NOTE: document change event handles open files; the watcher must defer to
+            // it or it races the editor path and duplicates content on the server
             if (this._isOpen(uri)) {
                 return;
             }
@@ -1722,7 +1708,6 @@ class Disk extends Linker<{ folderUri: vscode.Uri; projectManager: ProjectManage
             await this._readMutex.clear();
             await this._writeMutex.clear();
             this._debouncer.clear();
-            this._opened.clear();
             this._ignoring = (_uri: vscode.Uri) => false;
             this._ignoreHash = '';
             this._types = undefined;


### PR DESCRIPTION
## Problem

A script open in VS Code could get its contents **duplicated** when the same file is also edited from outside the editor — an AI agent rewriting it, or a fast cut→save→paste→save while it's open in the web editor. It surfaces as a VS Code ↔ server desync.

## Cause

The disk watcher decided "is this file open?" from the hand-maintained `_opened` set, which can drift out of sync with the real open documents. When stale, the watcher pushed the file's disk content upstream — racing the editor's own `onDidChangeTextDocument` submission and duplicating content on the server.

## Fix

Make `vscode.workspace.textDocuments` the single source of truth: `_isOpen()` consults it directly, every open-check routes through `_isOpen`, and the drift-prone `_opened` set is removed entirely.

## Testing

- Suite green (89/89); `tsc` + lint clean.
- The `_opened` drift is a VS Code document-lifecycle quirk that isn't reproducible in the harness, so there's no automated regression test.
- Manual repro before merge: same script open in VS Code + the web editor, then `Ctrl+S, Ctrl+X, Ctrl+S, Ctrl+V, Ctrl+S` a few times — should no longer duplicate.