### PR TITLE
fix: sync local edits that revert the buffer to the on-disk bytes

### DIFF
--- a/src/disk.ts
+++ b/src/disk.ts
@@ -109,6 +109,8 @@ class Disk extends Linker<{ folderUri: vscode.Uri; projectManager: ProjectManage
 
     private _diskStat = new Map<string, { mtime: number; size: number }>();
 
+    private _remoteAhead = new Set<string>();
+
     private _saving = new Set<string>();
 
     private _blocked = new Set<string>();
@@ -370,6 +372,10 @@ class Disk extends Linker<{ folderUri: vscode.Uri; projectManager: ProjectManage
                 return;
             }
 
+            // remote op advances the OT doc past the on-disk bytes without rewriting disk,
+            // so a later revert-to-disk is a discard, not a local edit (#315 discard guard)
+            this._remoteAhead.add(uri.path);
+
             // transform undo/redo stacks against the remote op (OT-space)
             const mgr = this._undos.get(uri.path);
             if (mgr) {
@@ -473,6 +479,7 @@ class Disk extends Linker<{ folderUri: vscode.Uri; projectManager: ProjectManage
 
             this._diskHash.delete(uri.path);
             this._diskStat.delete(uri.path);
+            this._remoteAhead.delete(uri.path);
 
             this._log.debug(`delete.remote file ${uri}`);
         });
@@ -500,6 +507,7 @@ class Disk extends Linker<{ folderUri: vscode.Uri; projectManager: ProjectManage
             // next _update or _create write on newUri.path will repopulate
             this._diskHash.delete(oldUri.path);
             this._diskStat.delete(oldUri.path);
+            this._remoteAhead.delete(oldUri.path);
 
             this._log.debug(`rename.remote ${oldUri.path} -> ${newUri.path}`);
         });
@@ -1035,6 +1043,7 @@ class Disk extends Linker<{ folderUri: vscode.Uri; projectManager: ProjectManage
             const path = relativePath(document.uri, folderUri);
             this._undos.set(document.uri.path, new UndoManager());
             this._diskHash.set(document.uri.path, hash(norm(document.getText())));
+            this._remoteAhead.delete(document.uri.path);
             this._events.emit('asset:doc:open', path);
             this._dirty(document);
         });
@@ -1047,6 +1056,7 @@ class Disk extends Linker<{ folderUri: vscode.Uri; projectManager: ProjectManage
             this._undos.delete(document.uri.path);
             this._diskHash.delete(document.uri.path);
             this._diskStat.delete(document.uri.path);
+            this._remoteAhead.delete(document.uri.path);
             this._saving.delete(document.uri.path);
             this._blocked.delete(`${document.uri}`);
             this._opLocks.delete(`${document.uri}`);
@@ -1106,10 +1116,18 @@ class Disk extends Linker<{ folderUri: vscode.Uri; projectManager: ProjectManage
             // the on-disk bytes is a revert (Don't Save / Revert File), never a real edit.
             // the disk file is the derived save-only artifact (server treats the live OT
             // doc as source of truth), so pushing it upstream rolls every collaborator back
-            // to stale content (#315). the native close dialog can fire this while
-            // document.isDirty is still true, so do NOT gate on the transient dirty flag.
+            // to stale content (#315). a normal Revert File / discard clears the dirty
+            // flag, so !isDirty catches it (#278). the native close dialog can fire the
+            // revert while isDirty is still true (#315), but only after a remote op has
+            // advanced the OT doc past disk — so _remoteAhead covers that case. a purely
+            // local round-trip (move a line down then back up) lands on the disk hash too
+            // but stays dirty with no remote op, so it must still submit.
             // undo/redo carry a reason and are handled above.
-            if (!reason && hash(text) === this._diskHash.get(document.uri.path)) {
+            if (
+                !reason &&
+                hash(text) === this._diskHash.get(document.uri.path) &&
+                (!document.isDirty || this._remoteAhead.has(document.uri.path))
+            ) {
                 return;
             }
 
@@ -1186,6 +1204,7 @@ class Disk extends Linker<{ folderUri: vscode.Uri; projectManager: ProjectManage
             // native save completes before the remote save is triggered.
             const h = hash(norm(document.getText()));
             this._diskHash.set(document.uri.path, h);
+            this._remoteAhead.delete(document.uri.path);
             this._saving.add(document.uri.path);
 
             // check if ignore updated (only if file has unsaved changes)
@@ -1733,6 +1752,7 @@ class Disk extends Linker<{ folderUri: vscode.Uri; projectManager: ProjectManage
         this._types = undefined;
         this._diskHash.clear();
         this._diskStat.clear();
+        this._remoteAhead.clear();
         this._opLocks.clear();
         this._undos.forEach((m) => m.clear());
         this._undos.clear();

--- a/src/test/suite/extension.test.ts
+++ b/src/test/suite/extension.test.ts
@@ -1797,6 +1797,66 @@ suite('extension', () => {
         );
     });
 
+    test('move line down then back up syncs the reverse edit to remote', async () => {
+        // regression: autoSave is off, so _diskHash stays at the opened/saved content.
+        // moving a line down submits fine, but moving it back lands the buffer exactly on
+        // the on-disk bytes — the #315 discard guard then misread it as a Don't Save revert
+        // and dropped the op, leaving the server stuck on the first move (silent divergence).
+        // unlike #315, the divergence here is purely local (no remote op), so it must submit.
+
+        const folderUri = vscode.workspace.workspaceFolders?.[0]?.uri;
+        assert.ok(folderUri, 'workspace folder should exist');
+
+        const original = '// ALPHA\n// BETA\n// GAMMA';
+        const asset = await assetCreate({ name: 'move_line_roundtrip.js', content: original });
+        assert.ok(asset, 'asset should be created');
+
+        const uri = vscode.Uri.joinPath(folderUri, asset.name);
+        const tdoc = await vscode.workspace.openTextDocument(uri);
+        await vscode.window.showTextDocument(tdoc);
+        await waitForIdle('initial open settle');
+
+        // move line "// ALPHA" down (swap lines 0 and 1). this is the first edit after
+        // open, which fires the #278 transient isDirty=false external path — wait for the
+        // follow-up _dirtyReload applyEdit so its _locks releases before the next edit.
+        const moved = '// BETA\n// ALPHA\n// GAMMA';
+        const downSettled = waitForApplyEdit(uri, 2, 'move down dirty reload');
+        const down = new vscode.WorkspaceEdit();
+        down.replace(uri, new vscode.Range(0, 0, 1, 100), '// BETA\n// ALPHA');
+        await vscode.workspace.applyEdit(down);
+        await downSettled;
+        await waitForIdle('move line down settle');
+
+        assert.strictEqual(tdoc.getText(), moved, 'buffer should hold moved-down content');
+        assert.strictEqual(documents.get(asset.uniqueId), moved, 'first move must reach the server');
+
+        // move it back up — buffer returns to the on-disk content. no remote op happened
+        // and the buffer stays dirty, so this must submit rather than be read as a discard.
+        const doc = sharedb.subscriptions.get(`documents:${asset.uniqueId}`);
+        assert.ok(doc, 'sharedb document should exist');
+        doc.submitOp.resetHistory();
+
+        const up = new vscode.WorkspaceEdit();
+        up.replace(uri, new vscode.Range(0, 0, 1, 100), '// ALPHA\n// BETA');
+        await vscode.workspace.applyEdit(up);
+        await waitForIdle('move line back up settle');
+
+        assert.strictEqual(tdoc.getText(), original, 'buffer should be back to original');
+        assert.ok(doc.submitOp.callCount > 0, 'reverse move must submit an op, not be dropped as a discard');
+        assert.strictEqual(documents.get(asset.uniqueId), original, 'server must follow the reverse move back');
+
+        // clean up: the local move edits set file.dirty, and the round-tripped content
+        // matches the saved hash so no save path can clear it (both markSaved and the mock
+        // doc:save short-circuit on a matching hash). a lingering dirty file sits in
+        // unsafeFiles() and blocks the reload/branch-switch guarded tests later in the
+        // suite, so close the editor and delete the asset outright.
+        await vscode.commands.executeCommand('workbench.action.revertAndCloseActiveEditor');
+        const fileDeleted = waitForEmit('asset:file:delete', (args) => args[0] === asset.name, 'cleanup delete');
+        await assertResolves(vscode.workspace.fs.delete(uri), 'cleanup fs.delete');
+        await assertResolves(fileDeleted, 'cleanup asset:file:delete');
+        await waitForIdle('move line test cleanup');
+    });
+
     test('file save - local to remote', async () => {
         // get folder uri
         const folderUri = vscode.workspace.workspaceFolders?.[0]?.uri;


### PR DESCRIPTION
Moving a line down then back up (or any local edit that returns the buffer to the on-disk content) synced the first move but silently dropped the reverse one, leaving the server stuck on the first edit while the local buffer moved on.

The #315 discard guard skipped any non-undo change whose content matched `_diskHash`. With autoSave off, `_diskHash` stays at the saved content, so a local round-trip lands on it too and was misread as a Don't Save / Revert File discard.

Fix: gate the guard on `(!document.isDirty || _remoteAhead)`. A real revert clears the dirty flag; the only discard that fires while still dirty (the Windows native close dialog) does so after a remote op advanced the OT doc past disk — tracked by the new `_remoteAhead` set. A local round-trip stays dirty with no remote op, so it now submits.

Verified: lint clean; all 90 tests pass, including the #278 and #319 discard regressions plus a new `move line down then back up` test.