### PR TITLE
feat: add pullpush sync preview

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
                 "@sentry/browser": "^10.49.0",
                 "ignore": "^7.0.5",
                 "isomorphic-ws": "^5.0.0",
+                "node-diff3": "3.1.2",
                 "ot-text": "github:playcanvas/ot-text",
                 "playcanvas-plugin": "file:plugin",
                 "sharedb": "3.2.1",
@@ -7418,6 +7419,15 @@
             "dev": true,
             "license": "MIT",
             "optional": true
+        },
+        "node_modules/node-diff3": {
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/node-diff3/-/node-diff3-3.1.2.tgz",
+            "integrity": "sha512-wUd9TWy059I8mZdH6G3LPNlAEfxDvXtn/RcyFrbqL3v34WlDxn+Mh4HDhOwWuaMk/ROVepe5tTpnGHbve6Db2g==",
+            "license": "MIT",
+            "engines": {
+                "node": ">14"
+            }
         },
         "node_modules/node-exports-info": {
             "version": "1.6.0",

--- a/package.json
+++ b/package.json
@@ -110,6 +110,10 @@
             {
                 "command": "playcanvas.pull",
                 "title": "PlayCanvas: Pull"
+            },
+            {
+                "command": "playcanvas.push",
+                "title": "PlayCanvas: Push"
             }
         ],
         "keybindings": [

--- a/package.json
+++ b/package.json
@@ -109,13 +109,29 @@
             },
             {
                 "command": "playcanvas.pull",
-                "title": "PlayCanvas: Pull"
+                "title": "PlayCanvas: Pull",
+                "icon": "$(cloud-download)"
             },
             {
                 "command": "playcanvas.push",
-                "title": "PlayCanvas: Push"
+                "title": "PlayCanvas: Push",
+                "icon": "$(cloud-upload)"
             }
         ],
+        "menus": {
+            "scm/title": [
+                {
+                    "command": "playcanvas.pull",
+                    "when": "scmProvider == playcanvas",
+                    "group": "navigation"
+                },
+                {
+                    "command": "playcanvas.push",
+                    "when": "scmProvider == playcanvas",
+                    "group": "navigation"
+                }
+            ]
+        },
         "keybindings": [
             {
                 "command": "playcanvas.undo",

--- a/package.json
+++ b/package.json
@@ -116,6 +116,11 @@
                 "command": "playcanvas.push",
                 "title": "PlayCanvas: Push",
                 "icon": "$(cloud-upload)"
+            },
+            {
+                "command": "playcanvas.discard",
+                "title": "PlayCanvas: Discard Changes",
+                "icon": "$(discard)"
             }
         ],
         "menus": {
@@ -129,6 +134,13 @@
                     "command": "playcanvas.push",
                     "when": "scmProvider == playcanvas",
                     "group": "navigation"
+                }
+            ],
+            "scm/resourceState/context": [
+                {
+                    "command": "playcanvas.discard",
+                    "when": "scmProvider == playcanvas",
+                    "group": "inline"
                 }
             ]
         },

--- a/package.json
+++ b/package.json
@@ -63,10 +63,10 @@
                     ],
                     "enumDescriptions": [
                         "Sync edits with the server in real time (default).",
-                        "Experimental: git-style manual pull/push (native only)."
+                        "Preview: Git-style manual pull/push against the realtime document (native only)."
                     ],
                     "default": "realtime",
-                    "description": "How the native extension syncs with the server. 'pullpush' is experimental and currently observes status only."
+                    "description": "How the native extension syncs with the server. 'pullpush' uses explicit Git-style pull/push with the realtime document as the remote."
                 }
             }
         },

--- a/package.json
+++ b/package.json
@@ -160,6 +160,7 @@
         "@sentry/browser": "^10.49.0",
         "ignore": "^7.0.5",
         "isomorphic-ws": "^5.0.0",
+        "node-diff3": "3.1.2",
         "ot-text": "github:playcanvas/ot-text",
         "playcanvas-plugin": "file:plugin",
         "sharedb": "3.2.1",

--- a/package.json
+++ b/package.json
@@ -166,6 +166,18 @@
                 "command": "playcanvas.redo",
                 "key": "ctrl+y",
                 "when": "playcanvas.active && textInputFocus && !editorReadonly && !isMac"
+            },
+            {
+                "command": "playcanvas.push",
+                "key": "ctrl+alt+up",
+                "mac": "cmd+alt+up",
+                "when": "playcanvas.pullpush"
+            },
+            {
+                "command": "playcanvas.pull",
+                "key": "ctrl+alt+down",
+                "mac": "cmd+alt+down",
+                "when": "playcanvas.pullpush"
             }
         ],
         "typescriptServerPlugins": [

--- a/package.json
+++ b/package.json
@@ -121,6 +121,11 @@
                 "command": "playcanvas.discard",
                 "title": "PlayCanvas: Discard Changes",
                 "icon": "$(discard)"
+            },
+            {
+                "command": "playcanvas.resolveMerge",
+                "title": "PlayCanvas: Resolve in Merge Editor",
+                "icon": "$(git-merge)"
             }
         ],
         "menus": {

--- a/package.json
+++ b/package.json
@@ -54,6 +54,19 @@
                     "type": "string",
                     "default": "",
                     "description": "Specify the root directory for PlayCanvas projects (non-web extension only). Leave empty to use the default directory."
+                },
+                "playcanvas.syncMode": {
+                    "type": "string",
+                    "enum": [
+                        "realtime",
+                        "pullpush"
+                    ],
+                    "enumDescriptions": [
+                        "Sync edits with the server in real time (default).",
+                        "Experimental: git-style manual pull/push (native only)."
+                    ],
+                    "default": "realtime",
+                    "description": "How the native extension syncs with the server. 'pullpush' is experimental and currently observes status only."
                 }
             }
         },

--- a/package.json
+++ b/package.json
@@ -106,6 +106,10 @@
             {
                 "command": "playcanvas.redo",
                 "title": "PlayCanvas: Redo"
+            },
+            {
+                "command": "playcanvas.pull",
+                "title": "PlayCanvas: Pull"
             }
         ],
         "keybindings": [

--- a/src/connections/rest.ts
+++ b/src/connections/rest.ts
@@ -10,36 +10,6 @@ const BASE_DELAY_MS = 1000;
 const MAX_DELAY_MS = 30 * 1000;
 const RETRYABLE_STATUS = new Set([408, 429, 500, 502, 503, 504]);
 
-export type SyncItem = {
-    kind: 'asset';
-    id: number;
-    path: string;
-    type: 'file' | 'folder';
-    modifiedAt: string;
-    fileHash?: string;
-    docVersion?: number;
-    text?: string;
-};
-
-export type SyncPullResponse = {
-    base: string;
-    items: SyncItem[];
-};
-
-export type SyncPushOp =
-    | { type: 'create_file'; path: string; text: string }
-    | { type: 'create_folder'; path: string }
-    | { type: 'update_text'; id: number; text: string }
-    | { type: 'rename'; id: number; path: string }
-    | { type: 'delete'; id: number };
-
-export type SyncPushRequest = {
-    clientId: string;
-    seq: number;
-    base: string;
-    ops: [SyncPushOp];
-};
-
 class Rest {
     private _log = new Log(this.constructor.name);
 
@@ -225,14 +195,6 @@ class Rest {
     async projectBranches(projectId: number) {
         const { result } = await this._request<{ result: Branch[] }>('GET', `projects/${projectId}/branches`);
         return result;
-    }
-
-    async syncPull(projectId: number, branchId: string) {
-        return this._request<SyncPullResponse>('GET', `projects/${projectId}/branches/${branchId}/pull`);
-    }
-
-    async syncPush(projectId: number, branchId: string, body: SyncPushRequest) {
-        return this._request<SyncPullResponse>('POST', `projects/${projectId}/branches/${branchId}/push`, body);
     }
 
     async id() {

--- a/src/connections/rest.ts
+++ b/src/connections/rest.ts
@@ -10,6 +10,36 @@ const BASE_DELAY_MS = 1000;
 const MAX_DELAY_MS = 30 * 1000;
 const RETRYABLE_STATUS = new Set([408, 429, 500, 502, 503, 504]);
 
+export type SyncItem = {
+    kind: 'asset';
+    id: number;
+    path: string;
+    type: 'file' | 'folder';
+    modifiedAt: string;
+    fileHash?: string;
+    docVersion?: number;
+    text?: string;
+};
+
+export type SyncPullResponse = {
+    base: string;
+    items: SyncItem[];
+};
+
+export type SyncPushOp =
+    | { type: 'create_file'; path: string; text: string }
+    | { type: 'create_folder'; path: string }
+    | { type: 'update_text'; id: number; text: string }
+    | { type: 'rename'; id: number; path: string }
+    | { type: 'delete'; id: number };
+
+export type SyncPushRequest = {
+    clientId: string;
+    seq: number;
+    base: string;
+    ops: [SyncPushOp];
+};
+
 class Rest {
     private _log = new Log(this.constructor.name);
 
@@ -195,6 +225,14 @@ class Rest {
     async projectBranches(projectId: number) {
         const { result } = await this._request<{ result: Branch[] }>('GET', `projects/${projectId}/branches`);
         return result;
+    }
+
+    async syncPull(projectId: number, branchId: string) {
+        return this._request<SyncPullResponse>('GET', `projects/${projectId}/branches/${branchId}/pull`);
+    }
+
+    async syncPush(projectId: number, branchId: string, body: SyncPushRequest) {
+        return this._request<SyncPullResponse>('POST', `projects/${projectId}/branches/${branchId}/push`, body);
     }
 
     async id() {

--- a/src/disk.ts
+++ b/src/disk.ts
@@ -854,10 +854,12 @@ class Disk extends Linker<{ folderUri: vscode.Uri; projectManager: ProjectManage
         // just active-editor changes — a stale context lets Ctrl+Z fall through to
         // native undo, which bypasses OT sync. (the native-undo handler stays as a
         // safety net for Edit-menu / palette undo, which keybindings can't gate.)
+        // in pullpush mode editing is local, so keep playcanvas.active false —
+        // let native undo/redo handle cmd+z
         let active: boolean | undefined;
         const updateCtx = () => {
             const e = vscode.window.activeTextEditor;
-            const next = !!(e && uriStartsWith(e.document.uri, folderUri));
+            const next = !!(!this._pullPush && e && uriStartsWith(e.document.uri, folderUri));
             if (next === active) {
                 return;
             }

--- a/src/disk.ts
+++ b/src/disk.ts
@@ -131,10 +131,13 @@ class Disk extends Linker<{ folderUri: vscode.Uri; projectManager: ProjectManage
 
     private _types?: TypeFiles;
 
-    constructor({ events }: { events: EventEmitter<EventMap> }) {
+    private _pullPush = false;
+
+    constructor({ events, pullPush = false }: { events: EventEmitter<EventMap>; pullPush?: boolean }) {
         super();
 
         this._events = events;
+        this._pullPush = pullPush;
     }
 
     private _checkIgnoreUpdated(uri: vscode.Uri, deleted = false) {
@@ -261,6 +264,12 @@ class Disk extends Linker<{ folderUri: vscode.Uri; projectManager: ProjectManage
                 const contentText = norm(buffer.toString(content));
                 if (existingText === contentText) {
                     this._diskHash.set(uri.path, hash(contentText));
+                    return;
+                }
+
+                // pullpush: never clobber divergent local content — the sync
+                // engine classifies it; remote lands only via explicit pull
+                if (this._pullPush) {
                     return;
                 }
 
@@ -549,6 +558,15 @@ class Disk extends Linker<{ folderUri: vscode.Uri; projectManager: ProjectManage
     }
 
     private async _subscribed(uri: vscode.Uri, path: string, content: string, dirty: boolean) {
+        // pullpush: subscribe never mutates buffer or disk — keep the dirty
+        // indicator, leave reconciliation to the sync engine
+        if (this._pullPush) {
+            if (dirty) {
+                this._events.emit('asset:file:dirty', path, true);
+            }
+            return;
+        }
+
         // undo inverses reference pre-reload OT history — clear so undo can't resurrect missing content
         this._undos.get(uri.path)?.clear();
 
@@ -774,6 +792,10 @@ class Disk extends Linker<{ folderUri: vscode.Uri; projectManager: ProjectManage
             await this._reconcile(uri, path, type);
         });
         const assetFileUpdate = this._events.on('asset:file:update', async (path, op, content, prev) => {
+            // pullpush mode: the sync engine tracks remote changes; never auto-write to disk
+            if (this._pullPush) {
+                return;
+            }
             const uri = vscode.Uri.joinPath(folderUri, path);
             const key = `${uri}`;
             this._opLocks.set(key, (this._opLocks.get(key) ?? 0) + 1);
@@ -1067,6 +1089,11 @@ class Disk extends Linker<{ folderUri: vscode.Uri; projectManager: ProjectManage
             const { document, contentChanges, reason } = e;
             // check if in folder
             if (!uriStartsWith(document.uri, folderUri)) {
+                return;
+            }
+
+            // pullpush mode: edits are local-only; never submit keystrokes upstream
+            if (this._pullPush) {
                 return;
             }
 
@@ -1535,6 +1562,11 @@ class Disk extends Linker<{ folderUri: vscode.Uri; projectManager: ProjectManage
             const path = relativePath(uri, folderUri);
             const file = projectManager.files.get(path);
             if (!file || file.type === 'folder') {
+                return;
+            }
+
+            // pullpush mode: closed-file edits stay local; never submit upstream
+            if (this._pullPush) {
                 return;
             }
 

--- a/src/disk.ts
+++ b/src/disk.ts
@@ -84,6 +84,14 @@ class Disk extends Linker<{ folderUri: vscode.Uri; projectManager: ProjectManage
     // .cursor is Cursor's equivalent editor-local config dir.
     static VCS_IGNORE = '.git\n.hg\n.svn\n.vscode\n.cursor\n';
 
+    static ignoreMatcher(text: string, folderUri: vscode.Uri) {
+        const ig = ignore().add(`${Disk.VCS_IGNORE}${text}`);
+        return (uri: vscode.Uri) => {
+            const path = relativePath(uri, folderUri);
+            return !!path && path !== Disk.IGNORE_FILE && ig.ignores(path);
+        };
+    }
+
     private _events: EventEmitter<EventMap>;
 
     private _folderUri?: vscode.Uri;
@@ -172,24 +180,7 @@ class Disk extends Linker<{ folderUri: vscode.Uri; projectManager: ProjectManage
 
     private _parseIgnoreText(text: string, folderUri: vscode.Uri, h = hash(text)) {
         this._ignoreHash = h;
-
-        // prepend vcs rules so .git/.hg/.svn are always excluded (prevents binary round-trip corruption)
-        const ig = ignore().add(`${Disk.VCS_IGNORE}${text}`);
-        this._ignoring = (uri: vscode.Uri) => {
-            const path = relativePath(uri, folderUri);
-
-            // skip root
-            if (!path) {
-                return false;
-            }
-
-            // skip ignore file itself
-            if (path === Disk.IGNORE_FILE) {
-                return false;
-            }
-
-            return ig.ignores(path);
-        };
+        this._ignoring = Disk.ignoreMatcher(text, folderUri);
         if (text) {
             this._log.debug(`parsed ignore file ${vscode.Uri.joinPath(folderUri, Disk.IGNORE_FILE)}`);
         }

--- a/src/disk.ts
+++ b/src/disk.ts
@@ -1211,6 +1211,10 @@ class Disk extends Linker<{ folderUri: vscode.Uri; projectManager: ProjectManage
             );
         });
         const onsave = vscode.workspace.onWillSaveTextDocument((e) => {
+            // pullpush mode: saving is local-only — no server save on cmd+s
+            if (this._pullPush) {
+                return;
+            }
             const { document } = e;
 
             // check if file is in memory
@@ -1242,6 +1246,10 @@ class Disk extends Linker<{ folderUri: vscode.Uri; projectManager: ProjectManage
             }
         });
         const ondidsave = vscode.workspace.onDidSaveTextDocument((document) => {
+            // pullpush mode: saving is local-only — server save happens on Push
+            if (this._pullPush) {
+                return;
+            }
             if (!uriStartsWith(document.uri, folderUri)) {
                 return;
             }

--- a/src/disk.ts
+++ b/src/disk.ts
@@ -837,6 +837,23 @@ class Disk extends Linker<{ folderUri: vscode.Uri; projectManager: ProjectManage
                 await this._reconcile(uri, path, type);
             }).then(([err]) => done(err ?? undefined));
         });
+        const syncFileApplyUpdate = this._events.on('sync:file:apply:update', (path, content, done) => {
+            const uri = vscode.Uri.joinPath(folderUri, path);
+            void tryCatch(async () => {
+                await this._writeMutex.atomic([`${uri}`], async () => {
+                    this._checkIgnoreUpdated(uri);
+                    this._debouncer.cancel(`${uri}`);
+                    const h = hash(content);
+                    this._echo.set(`${uri}:change`, h);
+                    await vscode.workspace.fs.writeFile(uri, content);
+                    this._diskHash.set(uri.path, h);
+                    const [, st] = await tryCatch(Promise.resolve(vscode.workspace.fs.stat(uri)));
+                    if (st) {
+                        this._diskStat.set(uri.path, { mtime: st.mtime, size: st.size });
+                    }
+                });
+            }).then(([err]) => done(err ?? undefined));
+        });
         const syncFileApplyDelete = this._events.on('sync:file:apply:delete', (path, done) => {
             const uri = vscode.Uri.joinPath(folderUri, path);
             void tryCatch(async () => {
@@ -876,6 +893,7 @@ class Disk extends Linker<{ folderUri: vscode.Uri; projectManager: ProjectManage
             this._events.off('asset:file:rename', assetFileRename);
             this._events.off('asset:file:delete', assetFileDelete);
             this._events.off('sync:file:apply:create', syncFileApplyCreate);
+            this._events.off('sync:file:apply:update', syncFileApplyUpdate);
             this._events.off('sync:file:apply:delete', syncFileApplyDelete);
             this._events.off('sync:file:apply:rename', syncFileApplyRename);
             this._events.off('asset:file:save', assetFileSave);
@@ -1714,6 +1732,14 @@ class Disk extends Linker<{ folderUri: vscode.Uri; projectManager: ProjectManage
         // install baseline vcs-aware ignore filter before any disk writes —
         // .pcignore content is parsed later once stubs are on disk
         this._parseIgnoreText('', folderUri);
+        let bootstrap = true;
+        if (this._pullPush && (await fileExists(folderUri))) {
+            const existing = await readDirRecursive(folderUri);
+            bootstrap = !existing.some((uri) => {
+                const path = relativePath(uri, folderUri);
+                return path === Disk.TYPE_DIR || path.startsWith(`${Disk.TYPE_DIR}/`) || !this._ignoring(uri);
+            });
+        }
 
         // sort into hierarchy
         // TODO: store as tree instead of flat map and sorting
@@ -1755,6 +1781,10 @@ class Disk extends Linker<{ folderUri: vscode.Uri; projectManager: ProjectManage
         const writeAll = (entries: typeof ordered, type: 'file' | 'folder') =>
             pool(entries, WRITE_CONCURRENCY, async ([path, file]) => {
                 const uri = vscode.Uri.joinPath(folderUri, path);
+                if (!bootstrap && !(await fileExists(uri))) {
+                    updatingDiskNext();
+                    return;
+                }
                 let content: Uint8Array;
                 if (file.type === 'file') {
                     content = buffer.from(file.doc.text);
@@ -1784,27 +1814,29 @@ class Disk extends Linker<{ folderUri: vscode.Uri; projectManager: ProjectManage
         // write type definition files to .pc/
         await this._writeTypeFiles(folderUri, types);
 
-        // remove old files deepest-first — siblings at each level parallelize
-        const levels = new Map<number, vscode.Uri[]>();
-        for (const uri of await readDirRecursive(folderUri)) {
-            const path = relativePath(uri, folderUri);
-            if (
-                !projectManager.files.has(path) &&
-                path !== Disk.TYPE_DIR &&
-                !path.startsWith(`${Disk.TYPE_DIR}/`) &&
-                !this._ignoring(uri)
-            ) {
-                const depth = path.split('/').length;
-                const bucket = levels.get(depth);
-                if (bucket) {
-                    bucket.push(uri);
-                } else {
-                    levels.set(depth, [uri]);
+        if (bootstrap) {
+            // remove old files deepest-first — siblings at each level parallelize
+            const levels = new Map<number, vscode.Uri[]>();
+            for (const uri of await readDirRecursive(folderUri)) {
+                const path = relativePath(uri, folderUri);
+                if (
+                    !projectManager.files.has(path) &&
+                    path !== Disk.TYPE_DIR &&
+                    !path.startsWith(`${Disk.TYPE_DIR}/`) &&
+                    !this._ignoring(uri)
+                ) {
+                    const depth = path.split('/').length;
+                    const bucket = levels.get(depth);
+                    if (bucket) {
+                        bucket.push(uri);
+                    } else {
+                        levels.set(depth, [uri]);
+                    }
                 }
             }
-        }
-        for (const depth of [...levels.keys()].sort((a, b) => b - a)) {
-            await pool(levels.get(depth)!, WRITE_CONCURRENCY, (uri) => this._delete(uri));
+            for (const depth of [...levels.keys()].sort((a, b) => b - a)) {
+                await pool(levels.get(depth)!, WRITE_CONCURRENCY, (uri) => this._delete(uri));
+            }
         }
 
         // watchers

--- a/src/disk.ts
+++ b/src/disk.ts
@@ -786,6 +786,9 @@ class Disk extends Linker<{ folderUri: vscode.Uri; projectManager: ProjectManage
 
     private _watchEvents(folderUri: vscode.Uri) {
         const assetFileCreate = this._events.on('asset:file:create', async (path, type, content) => {
+            if (this._pullPush) {
+                return;
+            }
             const uri = vscode.Uri.joinPath(folderUri, path);
             this._checkIgnoreUpdated(uri);
             await this._create(uri, type, content);
@@ -809,16 +812,46 @@ class Disk extends Linker<{ folderUri: vscode.Uri; projectManager: ProjectManage
             }
         });
         const assetFileDelete = this._events.on('asset:file:delete', async (path) => {
+            if (this._pullPush) {
+                return;
+            }
             const uri = vscode.Uri.joinPath(folderUri, path);
             this._checkIgnoreUpdated(uri, true);
             await this._delete(uri);
         });
         const assetFileRename = this._events.on('asset:file:rename', async (oldPath, newPath) => {
+            if (this._pullPush) {
+                return;
+            }
             const oldUri = vscode.Uri.joinPath(folderUri, oldPath);
             const newUri = vscode.Uri.joinPath(folderUri, newPath);
             this._checkIgnoreUpdated(oldUri);
             this._checkIgnoreUpdated(newUri);
             await this._rename(oldUri, newUri);
+        });
+        const syncFileApplyCreate = this._events.on('sync:file:apply:create', (path, type, content, done) => {
+            const uri = vscode.Uri.joinPath(folderUri, path);
+            void tryCatch(async () => {
+                this._checkIgnoreUpdated(uri);
+                await this._create(uri, type, content);
+                await this._reconcile(uri, path, type);
+            }).then(([err]) => done(err ?? undefined));
+        });
+        const syncFileApplyDelete = this._events.on('sync:file:apply:delete', (path, done) => {
+            const uri = vscode.Uri.joinPath(folderUri, path);
+            void tryCatch(async () => {
+                this._checkIgnoreUpdated(uri, true);
+                await this._delete(uri);
+            }).then(([err]) => done(err ?? undefined));
+        });
+        const syncFileApplyRename = this._events.on('sync:file:apply:rename', (oldPath, newPath, done) => {
+            const oldUri = vscode.Uri.joinPath(folderUri, oldPath);
+            const newUri = vscode.Uri.joinPath(folderUri, newPath);
+            void tryCatch(async () => {
+                this._checkIgnoreUpdated(oldUri);
+                this._checkIgnoreUpdated(newUri);
+                await this._rename(oldUri, newUri);
+            }).then(([err]) => done(err ?? undefined));
         });
         const assetFileSave = this._events.on('asset:file:save', async (path) => {
             const uri = vscode.Uri.joinPath(folderUri, path);
@@ -842,6 +875,9 @@ class Disk extends Linker<{ folderUri: vscode.Uri; projectManager: ProjectManage
             this._events.off('asset:file:update', assetFileUpdate);
             this._events.off('asset:file:rename', assetFileRename);
             this._events.off('asset:file:delete', assetFileDelete);
+            this._events.off('sync:file:apply:create', syncFileApplyCreate);
+            this._events.off('sync:file:apply:delete', syncFileApplyDelete);
+            this._events.off('sync:file:apply:rename', syncFileApplyRename);
             this._events.off('asset:file:save', assetFileSave);
             this._events.off('asset:file:failed', assetFileFailed);
             this._events.off('asset:file:subscribed', assetFileSubscribed);
@@ -1353,6 +1389,10 @@ class Disk extends Linker<{ folderUri: vscode.Uri; projectManager: ProjectManage
                                         }
 
                                         this._log.debug(`rename.local ${op2.uri} -> ${op1.uri}`);
+                                        if (this._pullPush) {
+                                            this._events.emit('sync:file:rename', path2, path1, type2);
+                                            return;
+                                        }
                                         return projectManager.rename(path2, path1);
                                     });
                                     i++;
@@ -1394,6 +1434,10 @@ class Disk extends Linker<{ folderUri: vscode.Uri; projectManager: ProjectManage
                                             return;
                                         }
                                         this._log.debug(`change.local (atomic) ${op.uri}`);
+                                        if (this._pullPush) {
+                                            this._events.emit('sync:file:update', path);
+                                            return;
+                                        }
                                         await projectManager.write(path, content);
                                         // dirtify if the file is open in an editor
                                         const doc = vscode.workspace.textDocuments.find(
@@ -1402,6 +1446,12 @@ class Disk extends Linker<{ folderUri: vscode.Uri; projectManager: ProjectManage
                                         if (doc) {
                                             this._dirty(doc);
                                         }
+                                        return;
+                                    }
+
+                                    if (this._pullPush) {
+                                        this._log.debug(`create.local ${type} ${op.uri}`);
+                                        this._events.emit('sync:file:create', path, type);
                                         return;
                                     }
 
@@ -1464,6 +1514,10 @@ class Disk extends Linker<{ folderUri: vscode.Uri; projectManager: ProjectManage
                                     }
 
                                     this._log.debug(`change.local ${op.uri}`);
+                                    if (this._pullPush) {
+                                        this._events.emit('sync:file:update', path);
+                                        return;
+                                    }
                                     await projectManager.write(path, content);
 
                                     // dirtify if file was opened while change was deferred
@@ -1486,6 +1540,10 @@ class Disk extends Linker<{ folderUri: vscode.Uri; projectManager: ProjectManage
                                     }
 
                                     this._log.debug(`delete.local ${type} ${op.uri}`);
+                                    if (this._pullPush) {
+                                        this._events.emit('sync:file:delete', path, type);
+                                        return;
+                                    }
                                     return projectManager.delete(path, type);
                                 });
                                 break;
@@ -1577,6 +1635,7 @@ class Disk extends Linker<{ folderUri: vscode.Uri; projectManager: ProjectManage
 
             // pullpush mode: closed-file edits stay local; never submit upstream
             if (this._pullPush) {
+                this._events.emit('sync:file:update', path);
                 return;
             }
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -284,7 +284,7 @@ export const activate = async (context: vscode.ExtensionContext) => {
         }
     });
 
-    // experimental pull command (native pullpush mode)
+    // experimental pull/push commands (native pullpush mode)
     if (pullPush) {
         context.subscriptions.push(
             vscode.commands.registerCommand(`${NAME}.pull`, async () => {
@@ -293,6 +293,14 @@ export const activate = async (context: vscode.ExtensionContext) => {
                     void vscode.window.showWarningMessage(`PlayCanvas Pull: ${err.message}`);
                 } else {
                     void vscode.window.showInformationMessage('PlayCanvas: pulled latest changes');
+                }
+            }),
+            vscode.commands.registerCommand(`${NAME}.push`, async () => {
+                const [err] = await tryCatch(() => nativeSync.push());
+                if (err) {
+                    void vscode.window.showWarningMessage(`PlayCanvas Push: ${err.message}`);
+                } else {
+                    void vscode.window.showInformationMessage('PlayCanvas: pushed local changes');
                 }
             })
         );

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -26,6 +26,7 @@ import { ProjectManager } from './project-manager';
 import { CollabProvider } from './providers/collab-provider';
 import { DecorationProvider } from './providers/decoration-provider';
 import { closeSentry, setSentryCollaborators, setSentryProject, setSentryUser } from './sentry';
+import { PlayCanvasScm } from './sync/scm';
 import { NativeSyncEngine } from './sync/sync-engine';
 import { TypeInstaller } from './type-installer';
 import type { EventMap } from './typings/event-map';
@@ -306,6 +307,15 @@ export const activate = async (context: vscode.ExtensionContext) => {
         );
     }
 
+    // native source control panel (experimental; only linked in pullpush mode)
+    const scm = new PlayCanvasScm();
+    effect(() => {
+        const err = scm.error.get();
+        if (err) {
+            failure.set(() => ({ err, source: 'native-scm' }));
+        }
+    });
+
     // reload function
     let reloading = false;
     const reload = async (projectManager: ProjectManager, branchId?: string) => {
@@ -323,6 +333,7 @@ export const activate = async (context: vscode.ExtensionContext) => {
             const uriState = await uriHandler.unlink();
             const collabState = await collabProvider.unlink();
             const dirtyState = await decorationProvider.unlink();
+            const scmState = pullPush ? await scm.unlink() : undefined;
             const nativeSyncState = pullPush ? await nativeSync.unlink() : undefined;
             const diskState = await disk.unlink();
             const projectState = await projectManager.unlink();
@@ -340,6 +351,9 @@ export const activate = async (context: vscode.ExtensionContext) => {
             await disk.link({ ...diskState, types });
             if (pullPush && nativeSyncState) {
                 await nativeSync.link(nativeSyncState);
+            }
+            if (pullPush && scmState) {
+                await scm.link(scmState);
             }
             await decorationProvider.link(dirtyState);
             await collabProvider.link(collabState);
@@ -806,12 +820,18 @@ export const activate = async (context: vscode.ExtensionContext) => {
             })
         );
 
-        // link native sync engine (experimental pullpush mode)
+        // link native sync engine + source control panel (experimental pullpush mode)
         if (pullPush) {
             await nativeSync.link({ folderUri, projectManager, projectId: project.id, branchId });
             context.subscriptions.push(
                 new vscode.Disposable(() => {
                     void nativeSync.unlink();
+                })
+            );
+            await scm.link({ folderUri, engine: nativeSync });
+            context.subscriptions.push(
+                new vscode.Disposable(() => {
+                    void scm.unlink();
                 })
             );
         }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -26,6 +26,7 @@ import { ProjectManager } from './project-manager';
 import { CollabProvider } from './providers/collab-provider';
 import { DecorationProvider } from './providers/decoration-provider';
 import { closeSentry, setSentryCollaborators, setSentryProject, setSentryUser } from './sentry';
+import { NativeSyncEngine } from './sync/sync-engine';
 import { TypeInstaller } from './type-installer';
 import type { EventMap } from './typings/event-map';
 import type { Project } from './typings/models';
@@ -88,6 +89,9 @@ export const activate = async (context: vscode.ExtensionContext) => {
     const rootUri = ROOT_FOLDER
         ? vscode.Uri.parse(`${ROOT_FOLDER}/${ENV}`)
         : vscode.Uri.parse(config.get<string>('rootDir') || `${context.globalStorageUri.path}/${ENV}`);
+
+    // experimental git-style pull/push sync (native only; off by default)
+    const pullPush = !WEB && config.get<string>('syncMode') === 'pullpush';
 
     // auth
     const auth = new Auth(context);
@@ -270,6 +274,15 @@ export const activate = async (context: vscode.ExtensionContext) => {
         }
     });
 
+    // native sync engine (experimental; only linked in pullpush mode)
+    const nativeSync = new NativeSyncEngine({ events, storageUri: context.globalStorageUri });
+    effect(() => {
+        const err = nativeSync.error.get();
+        if (err) {
+            failure.set(() => ({ err, source: 'native-sync' }));
+        }
+    });
+
     // reload function
     let reloading = false;
     const reload = async (projectManager: ProjectManager, branchId?: string) => {
@@ -287,6 +300,7 @@ export const activate = async (context: vscode.ExtensionContext) => {
             const uriState = await uriHandler.unlink();
             const collabState = await collabProvider.unlink();
             const dirtyState = await decorationProvider.unlink();
+            const nativeSyncState = pullPush ? await nativeSync.unlink() : undefined;
             const diskState = await disk.unlink();
             const projectState = await projectManager.unlink();
 
@@ -301,6 +315,9 @@ export const activate = async (context: vscode.ExtensionContext) => {
                 version: config.engineVersion
             });
             await disk.link({ ...diskState, types });
+            if (pullPush && nativeSyncState) {
+                await nativeSync.link(nativeSyncState);
+            }
             await decorationProvider.link(dirtyState);
             await collabProvider.link(collabState);
             await uriHandler.link(uriState);
@@ -765,6 +782,16 @@ export const activate = async (context: vscode.ExtensionContext) => {
                 void decorationProvider.unlink();
             })
         );
+
+        // link native sync engine (experimental pullpush mode)
+        if (pullPush) {
+            await nativeSync.link({ folderUri, projectManager, projectId: project.id, branchId });
+            context.subscriptions.push(
+                new vscode.Disposable(() => {
+                    void nativeSync.unlink();
+                })
+            );
+        }
 
         // desync surfaces — sticky status-bar item + one-shot toast per
         // false→true transition. signal resets to false on project unlink.

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -895,7 +895,7 @@ export const activate = async (context: vscode.ExtensionContext) => {
 
         // link native sync engine + source control panel (experimental pullpush mode)
         if (pullPush) {
-            await nativeSync.link({ folderUri, projectManager, projectId: project.id, branchId });
+            await nativeSync.link({ folderUri, projectManager, projectId: project.id, branchId, rest });
             context.subscriptions.push(
                 new vscode.Disposable(() => {
                     void nativeSync.unlink();

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -474,7 +474,7 @@ export const activate = async (context: vscode.ExtensionContext) => {
     relay.on('room:leave', updateCollabTags);
 
     // dirty decoration provider
-    const decorationProvider = new DecorationProvider({ events });
+    const decorationProvider = new DecorationProvider({ events, syncEngine: pullPush ? nativeSync : undefined });
     effect(() => {
         const err = decorationProvider.error.get();
         if (err) {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -284,6 +284,20 @@ export const activate = async (context: vscode.ExtensionContext) => {
         }
     });
 
+    // experimental pull command (native pullpush mode)
+    if (pullPush) {
+        context.subscriptions.push(
+            vscode.commands.registerCommand(`${NAME}.pull`, async () => {
+                const [err] = await tryCatch(() => nativeSync.pull());
+                if (err) {
+                    void vscode.window.showWarningMessage(`PlayCanvas Pull: ${err.message}`);
+                } else {
+                    void vscode.window.showInformationMessage('PlayCanvas: pulled latest changes');
+                }
+            })
+        );
+    }
+
     // reload function
     let reloading = false;
     const reload = async (projectManager: ProjectManager, branchId?: string) => {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -265,7 +265,8 @@ export const activate = async (context: vscode.ExtensionContext) => {
     const typeInstaller = new TypeInstaller({ context });
 
     const disk = new Disk({
-        events
+        events,
+        pullPush
     });
     effect(() => {
         const err = disk.error.get();

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -895,7 +895,7 @@ export const activate = async (context: vscode.ExtensionContext) => {
 
         // link native sync engine + source control panel (experimental pullpush mode)
         if (pullPush) {
-            await nativeSync.link({ folderUri, projectManager, projectId: project.id, branchId, rest });
+            await nativeSync.link({ folderUri, projectManager, projectId: project.id, branchId });
             context.subscriptions.push(
                 new vscode.Disposable(() => {
                     void nativeSync.unlink();

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -34,7 +34,7 @@ import type { Project } from './typings/models';
 import { fail } from './utils/error';
 import { EventEmitter } from './utils/event-emitter';
 import { computed, effect, signal } from './utils/signal';
-import { projectToName, tryCatch, uriStartsWith, wait } from './utils/utils';
+import { parsePath, projectToName, tryCatch, uriStartsWith, wait } from './utils/utils';
 
 const HEARTBEAT_MS = 5 * 60 * 1000;
 const PING_SAMPLE_MS = 60 * 1000;
@@ -302,6 +302,25 @@ export const activate = async (context: vscode.ExtensionContext) => {
                     void vscode.window.showWarningMessage(`PlayCanvas Push: ${err.message}`);
                 } else {
                     void vscode.window.showInformationMessage('PlayCanvas: pushed local changes');
+                }
+            }),
+            vscode.commands.registerCommand(`${NAME}.discard`, async (resource?: vscode.SourceControlResourceState) => {
+                const uri = resource?.resourceUri;
+                if (!uri) {
+                    return;
+                }
+                const [, name] = parsePath(uri.path);
+                const choice = await vscode.window.showWarningMessage(
+                    `Discard local changes to ${name}? This cannot be undone.`,
+                    { modal: true },
+                    'Discard'
+                );
+                if (choice !== 'Discard') {
+                    return;
+                }
+                const [err] = await tryCatch(() => nativeSync.discard(uri));
+                if (err) {
+                    void vscode.window.showWarningMessage(`PlayCanvas Discard: ${err.message}`);
                 }
             })
         );

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -322,7 +322,29 @@ export const activate = async (context: vscode.ExtensionContext) => {
                 if (err) {
                     void vscode.window.showWarningMessage(`PlayCanvas Discard: ${err.message}`);
                 }
-            })
+            }),
+            vscode.commands.registerCommand(
+                `${NAME}.resolveMerge`,
+                async (arg?: vscode.Uri | vscode.SourceControlResourceState) => {
+                    const uri = arg instanceof vscode.Uri ? arg : arg?.resourceUri;
+                    if (!uri) {
+                        return;
+                    }
+                    const input = (scheme: string) => uri.with({ scheme });
+                    const [err] = await tryCatch(async () =>
+                        vscode.commands.executeCommand('_open.mergeEditor', {
+                            base: input('playcanvas-merge-base'),
+                            input1: { uri: input('playcanvas-merge-local'), title: 'Working (your changes)' },
+                            input2: { uri: input('playcanvas-merge-remote'), title: 'Server (incoming)' },
+                            output: uri
+                        })
+                    );
+                    if (err) {
+                        // fallback: open the file with inline conflict markers
+                        await vscode.window.showTextDocument(uri);
+                    }
+                }
+            )
         );
     }
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -344,6 +344,38 @@ export const activate = async (context: vscode.ExtensionContext) => {
                         await vscode.window.showTextDocument(uri);
                     }
                 }
+            ),
+            vscode.commands.registerCommand(
+                `${NAME}.resolveStructuralConflict`,
+                async (arg?: vscode.Uri | vscode.SourceControlResourceState) => {
+                    const uri = arg instanceof vscode.Uri ? arg : arg?.resourceUri;
+                    if (!uri || !nativeSync.structuralConflict(uri)) {
+                        return;
+                    }
+                    const choice = await vscode.window.showQuickPick(
+                        [
+                            { label: 'Accept Incoming', action: 'incoming' },
+                            { label: 'Keep Current', action: 'current' },
+                            { label: 'Mark Resolved', action: 'resolved' }
+                        ],
+                        { placeHolder: 'Resolve PlayCanvas structural conflict' }
+                    );
+                    if (!choice) {
+                        return;
+                    }
+                    const [err] = await tryCatch(async () => {
+                        if (choice.action === 'incoming') {
+                            await nativeSync.acceptIncoming(uri);
+                        } else if (choice.action === 'current') {
+                            await nativeSync.keepCurrent(uri);
+                        } else {
+                            await nativeSync.markResolved(uri);
+                        }
+                    });
+                    if (err) {
+                        void vscode.window.showWarningMessage(`PlayCanvas Resolve: ${err.message}`);
+                    }
+                }
             )
         );
     }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -366,10 +366,8 @@ export const activate = async (context: vscode.ExtensionContext) => {
                     const [err] = await tryCatch(async () => {
                         if (choice.action === 'incoming') {
                             await nativeSync.acceptIncoming(uri);
-                        } else if (choice.action === 'current') {
-                            await nativeSync.keepCurrent(uri);
                         } else {
-                            await nativeSync.markResolved(uri);
+                            await nativeSync.keepCurrent(uri);
                         }
                     });
                     if (err) {

--- a/src/project-manager.ts
+++ b/src/project-manager.ts
@@ -246,6 +246,11 @@ class ProjectManager extends Linker<{ projectId: number; branchId: string }> {
                     object[key].splice(parseInt(o.p[o.p.length - 1], 10), 1);
                     this._events.emit('asset:update', uniqueId, key, before, object[key]);
                 }
+
+                // closed-file remote signal: asset file metadata (incl. hash) changed
+                if (o.p[0] === 'file') {
+                    this._events.emit('asset:file:hash', this._assetPath(uniqueId));
+                }
             }
         });
     }
@@ -1487,7 +1492,23 @@ class ProjectManager extends Linker<{ projectId: number; branchId: string }> {
         await this._sharedb.unsubscribe('documents', `${uniqueId}`);
         this._sharedb.sendRaw(`close:document:${uniqueId}`);
         this._files.set(path, { type: 'stub', uniqueId, dirty: file.dirty });
+        this._events.emit('asset:file:unsubscribed', path);
         this._log.debug(`unsubscribed ${path}`);
+    }
+
+    // saved (S3) hash for a file, from always-live asset metadata — no subscription
+    savedHash(path: string) {
+        const file = this._files.get(path);
+        return file ? this._assets.get(file.uniqueId)?.file?.hash : undefined;
+    }
+
+    // saved (S3) content for a closed file — normalized to LF, no subscription
+    async savedContent(path: string) {
+        const file = this._files.get(path);
+        if (!file) {
+            return undefined;
+        }
+        return norm(buffer.toString(await this.fetchContent(file.uniqueId)));
     }
 
     async fetchContent(uniqueId: number) {

--- a/src/project-manager.ts
+++ b/src/project-manager.ts
@@ -1337,16 +1337,6 @@ class ProjectManager extends Linker<{ projectId: number; branchId: string }> {
         return file?.type === 'stub';
     }
 
-    // last-flushed S3 hash from replicated asset metadata — lets the sync
-    // engine track remote state for stubs without subscribing their docs
-    fileHash(path: string) {
-        const file = this._files.get(path);
-        if (!file || file.type === 'folder') {
-            return undefined;
-        }
-        return this._assets.get(file.uniqueId)?.file?.hash;
-    }
-
     saveFailed() {
         return this._saveFailed.size > 0;
     }

--- a/src/project-manager.ts
+++ b/src/project-manager.ts
@@ -1337,6 +1337,16 @@ class ProjectManager extends Linker<{ projectId: number; branchId: string }> {
         return file?.type === 'stub';
     }
 
+    // last-flushed S3 hash from replicated asset metadata — lets the sync
+    // engine track remote state for stubs without subscribing their docs
+    fileHash(path: string) {
+        const file = this._files.get(path);
+        if (!file || file.type === 'folder') {
+            return undefined;
+        }
+        return this._assets.get(file.uniqueId)?.file?.hash;
+    }
+
     saveFailed() {
         return this._saveFailed.size > 0;
     }

--- a/src/providers/decoration-provider.ts
+++ b/src/providers/decoration-provider.ts
@@ -2,11 +2,14 @@ import * as vscode from 'vscode';
 
 import { Disk } from '../disk';
 import type { ProjectManager } from '../project-manager';
+import { SCM_SCHEME } from '../sync/scm';
+import type { SyncState } from '../sync/status';
+import type { NativeSyncEngine } from '../sync/sync-engine';
 import type { EventMap } from '../typings/event-map';
 import { fail } from '../utils/error';
 import type { EventEmitter } from '../utils/event-emitter';
 import { Linker } from '../utils/linker';
-import { signal } from '../utils/signal';
+import { effect, signal } from '../utils/signal';
 
 const MANAGED_COLOR = new vscode.ThemeColor('playcanvas.managedForeground');
 const MANAGED_DECORATION: vscode.FileDecoration = {
@@ -15,12 +18,40 @@ const MANAGED_DECORATION: vscode.FileDecoration = {
     tooltip: 'Managed by PlayCanvas'
 };
 const DIRTY_COLOR = new vscode.ThemeColor('playcanvas.dirtyForeground');
+const SYNC_DECORATION: Record<
+    Exclude<SyncState, 'clean'>,
+    { badge: string; color: string; tooltip: string; strikeThrough?: boolean }
+> = {
+    modified: { badge: 'M', color: 'gitDecoration.modifiedResourceForeground', tooltip: 'Modified' },
+    behind: { badge: 'M', color: 'gitDecoration.modifiedResourceForeground', tooltip: 'Incoming' },
+    both: { badge: 'M', color: 'gitDecoration.modifiedResourceForeground', tooltip: 'Modified, incoming' },
+    conflicted: { badge: '!', color: 'gitDecoration.conflictingResourceForeground', tooltip: 'Conflict' },
+    added: { badge: 'A', color: 'gitDecoration.addedResourceForeground', tooltip: 'Added' },
+    deleted: { badge: 'D', color: 'gitDecoration.deletedResourceForeground', tooltip: 'Deleted', strikeThrough: true },
+    renamed: { badge: 'R', color: 'gitDecoration.renamedResourceForeground', tooltip: 'Renamed' }
+};
+
+const syncDecoration = (state: SyncState) => {
+    if (state === 'clean') {
+        return undefined;
+    }
+    const d = SYNC_DECORATION[state];
+    return {
+        badge: d.badge,
+        color: new vscode.ThemeColor(d.color),
+        tooltip: d.tooltip,
+        strikeThrough: d.strikeThrough,
+        propagate: false
+    };
+};
 
 class DecorationProvider
     extends Linker<{ folderUri: vscode.Uri; projectManager: ProjectManager }>
     implements vscode.FileDecorationProvider
 {
     private _events: EventEmitter<EventMap>;
+
+    private _syncEngine?: NativeSyncEngine;
 
     private _folderUri?: vscode.Uri;
 
@@ -31,15 +62,16 @@ class DecorationProvider
 
     error = signal<Error | undefined>(undefined);
 
-    constructor({ events }: { events: EventEmitter<EventMap> }) {
+    constructor({ events, syncEngine }: { events: EventEmitter<EventMap>; syncEngine?: NativeSyncEngine }) {
         super();
         this._events = events;
+        this._syncEngine = syncEngine;
     }
 
     provideFileDecoration(uri: vscode.Uri) {
         // badge for .pc/ directory and its managed files
         const segments = uri.path.split('/');
-        if (segments.includes(Disk.TYPE_DIR)) {
+        if (uri.scheme !== SCM_SCHEME && segments.includes(Disk.TYPE_DIR)) {
             return MANAGED_DECORATION;
         }
 
@@ -55,6 +87,10 @@ class DecorationProvider
         }
 
         const path = uri.path.slice(folderUri.path.length + 1);
+        if (uri.scheme === SCM_SCHEME) {
+            return syncDecoration(this._syncEngine?.status(path) ?? 'clean');
+        }
+
         const file = pm.files.get(path);
         if (!file || file.type !== 'file' || !file.dirty) {
             return undefined;
@@ -89,6 +125,12 @@ class DecorationProvider
             this._fire(from);
             this._fire(to);
         });
+        const stopSync = this._syncEngine
+            ? effect(() => {
+                  this._syncEngine?.changed.get();
+                  this._onDidChangeFileDecorations.fire(undefined);
+              })
+            : undefined;
 
         // fire initial decorations for already-dirty files
         const uris: vscode.Uri[] = [];
@@ -108,6 +150,7 @@ class DecorationProvider
             this._events.off('asset:file:create', onCreate);
             this._events.off('asset:file:delete', onDelete);
             this._events.off('asset:file:rename', onRename);
+            stopSync?.();
 
             // clear all decorations
             this._onDidChangeFileDecorations.fire(undefined);
@@ -133,4 +176,4 @@ class DecorationProvider
     }
 }
 
-export { DecorationProvider };
+export { DecorationProvider, syncDecoration };

--- a/src/providers/decoration-provider.ts
+++ b/src/providers/decoration-provider.ts
@@ -88,7 +88,7 @@ class DecorationProvider
 
         const path = uri.path.slice(folderUri.path.length + 1);
         if (uri.scheme === SCM_SCHEME) {
-            return syncDecoration(this._syncEngine?.status(path) ?? 'clean');
+            return syncDecoration(this._syncEngine?.decorationStatus(path) ?? 'clean');
         }
 
         const file = pm.files.get(path);

--- a/src/sync/base-store.ts
+++ b/src/sync/base-store.ts
@@ -1,5 +1,3 @@
-import { randomUUID } from 'crypto';
-
 import * as vscode from 'vscode';
 
 import type { SyncItem, SyncPullResponse } from '../connections/rest';
@@ -25,6 +23,13 @@ type BaseFile = {
     entries?: Record<string, BaseEntry>;
 };
 
+// web build's crypto polyfill has no randomUUID; uuid v4 via Math.random (id, not a secret)
+const randomId = () =>
+    'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, (c) => {
+        const r = (Math.random() * 16) | 0;
+        return (c === 'x' ? r : (r & 0x3) | 0x8).toString(16);
+    });
+
 // persists the merge base (server snapshot at last pull) per project+branch,
 // in globalStorage so it never enters the user's workspace or git.
 export class BaseStore {
@@ -34,7 +39,7 @@ export class BaseStore {
 
     private _pathIds = new Map<string, number>();
 
-    private _clientId: string = randomUUID();
+    private _clientId: string = randomId();
 
     private _seq = 0;
 
@@ -60,7 +65,7 @@ export class BaseStore {
         this._folderId = folderId;
         this._entries.clear();
         this._pathIds.clear();
-        this._clientId = randomUUID();
+        this._clientId = randomId();
         this._seq = 0;
         this._base = '';
 

--- a/src/sync/base-store.ts
+++ b/src/sync/base-store.ts
@@ -17,17 +17,20 @@ export class BaseStore {
 
     private _branchId?: string;
 
+    private _folderId = 'default';
+
     constructor({ storageUri }: { storageUri: vscode.Uri }) {
         this._storageUri = storageUri;
     }
 
     private _uri(projectId: number, branchId: string) {
-        return vscode.Uri.joinPath(this._storageUri, 'base', `${projectId}-${branchId}.json`);
+        return vscode.Uri.joinPath(this._storageUri, 'base', `${projectId}-${branchId}-${this._folderId}.json`);
     }
 
-    async load(projectId: number, branchId: string) {
+    async load(projectId: number, branchId: string, folderId = 'default') {
         this._projectId = projectId;
         this._branchId = branchId;
+        this._folderId = folderId;
         this._entries.clear();
 
         const [err, data] = await tryCatch(async () => vscode.workspace.fs.readFile(this._uri(projectId, branchId)));

--- a/src/sync/base-store.ts
+++ b/src/sync/base-store.ts
@@ -1,49 +1,26 @@
 import * as vscode from 'vscode';
 
-import type { SyncItem, SyncPullResponse } from '../connections/rest';
 import * as buffer from '../utils/buffer';
 import { norm } from '../utils/text';
 import { hash, tryCatch, tryCatchSync } from '../utils/utils';
 
 type ConflictEntry = { base: string; local: string; remote: string };
-type ItemType = 'file' | 'folder';
 export type BaseEntry = {
-    id?: number;
-    path?: string;
-    type?: ItemType;
     text: string;
     hash: string;
     conflict?: ConflictEntry;
 };
 type BaseFile = {
     version?: 1;
-    clientId?: string;
-    seq?: number;
-    base?: string;
     entries?: Record<string, BaseEntry>;
 };
 
-// web build's crypto polyfill has no randomUUID; uuid v4 via Math.random (id, not a secret)
-const randomId = () =>
-    'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, (c) => {
-        const r = (Math.random() * 16) | 0;
-        return (c === 'x' ? r : (r & 0x3) | 0x8).toString(16);
-    });
-
-// persists the merge base (server snapshot at last pull) per project+branch,
-// in globalStorage so it never enters the user's workspace or git.
+// persists the merge base (last-pulled text per file, keyed by uniqueId) per
+// project+branch, in globalStorage so it never enters the workspace or git.
 export class BaseStore {
     private _storageUri: vscode.Uri;
 
     private _entries = new Map<number, BaseEntry>();
-
-    private _pathIds = new Map<string, number>();
-
-    private _clientId: string = randomId();
-
-    private _seq = 0;
-
-    private _base = '';
 
     private _projectId?: number;
 
@@ -64,10 +41,6 @@ export class BaseStore {
         this._branchId = branchId;
         this._folderId = folderId;
         this._entries.clear();
-        this._pathIds.clear();
-        this._clientId = randomId();
-        this._seq = 0;
-        this._base = '';
 
         const [err, data] = await tryCatch(async () => vscode.workspace.fs.readFile(this._uri(projectId, branchId)));
         if (err) {
@@ -83,99 +56,13 @@ export class BaseStore {
 
         const file = parsed as BaseFile;
         const entries = file.entries ? file.entries : (parsed as Record<string, BaseEntry>);
-        if (typeof file.clientId === 'string') {
-            this._clientId = file.clientId;
-        }
-        if (typeof file.seq === 'number' && Number.isSafeInteger(file.seq)) {
-            this._seq = file.seq;
-        }
-        if (typeof file.base === 'string') {
-            this._base = file.base;
-        }
-
         for (const [id, entry] of Object.entries(entries)) {
-            const key = Number(id);
-            this._entries.set(key, entry);
-            if (entry.path !== undefined) {
-                this._pathIds.set(entry.path, key);
-            }
+            this._entries.set(Number(id), entry);
         }
     }
 
     get(uniqueId: number) {
         return this._entries.get(uniqueId);
-    }
-
-    get base() {
-        return this._base;
-    }
-
-    get clientId() {
-        return this._clientId;
-    }
-
-    get seq() {
-        return this._seq;
-    }
-
-    setBase(base: string) {
-        this._base = base;
-    }
-
-    setSeq(seq: number) {
-        this._seq = seq;
-    }
-
-    byPath(path: string) {
-        const id = this._pathIds.get(path);
-        return id === undefined ? undefined : this._entries.get(id);
-    }
-
-    items() {
-        return Array.from(this._entries.values());
-    }
-
-    private _entry(item: SyncItem) {
-        const text = norm(item.type === 'file' ? (item.text ?? '') : '');
-        return {
-            ...this._entries.get(item.id),
-            id: item.id,
-            path: item.path,
-            type: item.type,
-            text,
-            hash: hash(text)
-        };
-    }
-
-    setItem(item: SyncItem) {
-        const current = this._entries.get(item.id);
-        if (current?.path !== undefined) {
-            this._pathIds.delete(current.path);
-        }
-        const entry = this._entry(item);
-        this._entries.set(item.id, entry);
-        this._pathIds.set(item.path, item.id);
-    }
-
-    deleteItem(id: number) {
-        const entry = this._entries.get(id);
-        if (entry?.path !== undefined) {
-            this._pathIds.delete(entry.path);
-        }
-        this._entries.delete(id);
-    }
-
-    setSnapshot(snapshot: SyncPullResponse) {
-        const entries = new Map<number, BaseEntry>();
-        const paths = new Map<string, number>();
-        for (const item of snapshot.items) {
-            const entry = this._entry(item);
-            entries.set(item.id, entry);
-            paths.set(item.path, item.id);
-        }
-        this._entries = entries;
-        this._pathIds = paths;
-        this._base = snapshot.base;
     }
 
     set(uniqueId: number, text: string) {
@@ -212,15 +99,7 @@ export class BaseStore {
         await vscode.workspace.fs.createDirectory(vscode.Uri.joinPath(this._storageUri, 'base'));
         await vscode.workspace.fs.writeFile(
             this._uri(this._projectId, this._branchId),
-            buffer.from(
-                JSON.stringify({
-                    version: 1,
-                    clientId: this._clientId,
-                    seq: this._seq,
-                    base: this._base,
-                    entries: obj
-                })
-            )
+            buffer.from(JSON.stringify({ version: 1, entries: obj }))
         );
     }
 }

--- a/src/sync/base-store.ts
+++ b/src/sync/base-store.ts
@@ -8,6 +8,7 @@ type ConflictEntry = { base: string; local: string; remote: string };
 export type BaseEntry = {
     text: string;
     hash: string;
+    savedHash?: string;
     conflict?: ConflictEntry;
 };
 type BaseFile = {
@@ -65,9 +66,15 @@ export class BaseStore {
         return this._entries.get(uniqueId);
     }
 
-    set(uniqueId: number, text: string) {
+    set(uniqueId: number, text: string, savedHash?: string) {
         const value = norm(text);
-        this._entries.set(uniqueId, { ...this._entries.get(uniqueId), text: value, hash: hash(value) });
+        const existing = this._entries.get(uniqueId);
+        this._entries.set(uniqueId, {
+            ...existing,
+            text: value,
+            hash: hash(value),
+            savedHash: savedHash ?? existing?.savedHash
+        });
     }
 
     conflict(uniqueId: number) {

--- a/src/sync/base-store.ts
+++ b/src/sync/base-store.ts
@@ -4,7 +4,8 @@ import * as buffer from '../utils/buffer';
 import { norm } from '../utils/text';
 import { hash, tryCatch, tryCatchSync } from '../utils/utils';
 
-type BaseEntry = { text: string; hash: string };
+type ConflictEntry = { base: string; local: string; remote: string };
+type BaseEntry = { text: string; hash: string; conflict?: ConflictEntry };
 
 // persists the merge base (server snapshot at last pull) per project+branch,
 // in globalStorage so it never enters the user's workspace or git.
@@ -54,7 +55,25 @@ export class BaseStore {
 
     set(uniqueId: number, text: string) {
         const value = norm(text);
-        this._entries.set(uniqueId, { text: value, hash: hash(value) });
+        this._entries.set(uniqueId, { ...this._entries.get(uniqueId), text: value, hash: hash(value) });
+    }
+
+    conflict(uniqueId: number) {
+        return this._entries.get(uniqueId)?.conflict;
+    }
+
+    setConflict(uniqueId: number, conflict: ConflictEntry) {
+        const entry = this._entries.get(uniqueId);
+        if (entry) {
+            entry.conflict = conflict;
+        }
+    }
+
+    deleteConflict(uniqueId: number) {
+        const entry = this._entries.get(uniqueId);
+        if (entry) {
+            delete entry.conflict;
+        }
     }
 
     async flush() {

--- a/src/sync/base-store.ts
+++ b/src/sync/base-store.ts
@@ -54,10 +54,6 @@ export class BaseStore {
         this._entries.set(uniqueId, { text: value, hash: hash(value) });
     }
 
-    delete(uniqueId: number) {
-        this._entries.delete(uniqueId);
-    }
-
     async flush() {
         if (this._projectId === undefined || this._branchId === undefined) {
             return;

--- a/src/sync/base-store.ts
+++ b/src/sync/base-store.ts
@@ -1,0 +1,75 @@
+import * as vscode from 'vscode';
+
+import * as buffer from '../utils/buffer';
+import { norm } from '../utils/text';
+import { hash, tryCatch, tryCatchSync } from '../utils/utils';
+
+type BaseEntry = { text: string; hash: string };
+
+// persists the merge base (server snapshot at last pull) per project+branch,
+// in globalStorage so it never enters the user's workspace or git.
+export class BaseStore {
+    private _storageUri: vscode.Uri;
+
+    private _entries = new Map<number, BaseEntry>();
+
+    private _projectId?: number;
+
+    private _branchId?: string;
+
+    constructor({ storageUri }: { storageUri: vscode.Uri }) {
+        this._storageUri = storageUri;
+    }
+
+    private _uri(projectId: number, branchId: string) {
+        return vscode.Uri.joinPath(this._storageUri, 'base', `${projectId}-${branchId}.json`);
+    }
+
+    async load(projectId: number, branchId: string) {
+        this._projectId = projectId;
+        this._branchId = branchId;
+        this._entries.clear();
+
+        const [err, data] = await tryCatch(async () => vscode.workspace.fs.readFile(this._uri(projectId, branchId)));
+        if (err) {
+            return; // no base persisted yet
+        }
+
+        const [perr, parsed] = tryCatchSync(() => JSON.parse(buffer.toString(data)) as Record<string, BaseEntry>);
+        if (perr || !parsed) {
+            return; // corrupt base file — treat as empty
+        }
+
+        for (const [id, entry] of Object.entries(parsed)) {
+            this._entries.set(Number(id), entry);
+        }
+    }
+
+    get(uniqueId: number) {
+        return this._entries.get(uniqueId);
+    }
+
+    set(uniqueId: number, text: string) {
+        const value = norm(text);
+        this._entries.set(uniqueId, { text: value, hash: hash(value) });
+    }
+
+    delete(uniqueId: number) {
+        this._entries.delete(uniqueId);
+    }
+
+    async flush() {
+        if (this._projectId === undefined || this._branchId === undefined) {
+            return;
+        }
+        const obj: Record<string, BaseEntry> = {};
+        for (const [id, entry] of this._entries) {
+            obj[id] = entry;
+        }
+        await vscode.workspace.fs.createDirectory(vscode.Uri.joinPath(this._storageUri, 'base'));
+        await vscode.workspace.fs.writeFile(
+            this._uri(this._projectId, this._branchId),
+            buffer.from(JSON.stringify(obj))
+        );
+    }
+}

--- a/src/sync/base-store.ts
+++ b/src/sync/base-store.ts
@@ -1,11 +1,29 @@
+import { randomUUID } from 'crypto';
+
 import * as vscode from 'vscode';
 
+import type { SyncItem, SyncPullResponse } from '../connections/rest';
 import * as buffer from '../utils/buffer';
 import { norm } from '../utils/text';
 import { hash, tryCatch, tryCatchSync } from '../utils/utils';
 
 type ConflictEntry = { base: string; local: string; remote: string };
-type BaseEntry = { text: string; hash: string; conflict?: ConflictEntry };
+type ItemType = 'file' | 'folder';
+export type BaseEntry = {
+    id?: number;
+    path?: string;
+    type?: ItemType;
+    text: string;
+    hash: string;
+    conflict?: ConflictEntry;
+};
+type BaseFile = {
+    version?: 1;
+    clientId?: string;
+    seq?: number;
+    base?: string;
+    entries?: Record<string, BaseEntry>;
+};
 
 // persists the merge base (server snapshot at last pull) per project+branch,
 // in globalStorage so it never enters the user's workspace or git.
@@ -13,6 +31,14 @@ export class BaseStore {
     private _storageUri: vscode.Uri;
 
     private _entries = new Map<number, BaseEntry>();
+
+    private _pathIds = new Map<string, number>();
+
+    private _clientId: string = randomUUID();
+
+    private _seq = 0;
+
+    private _base = '';
 
     private _projectId?: number;
 
@@ -33,24 +59,118 @@ export class BaseStore {
         this._branchId = branchId;
         this._folderId = folderId;
         this._entries.clear();
+        this._pathIds.clear();
+        this._clientId = randomUUID();
+        this._seq = 0;
+        this._base = '';
 
         const [err, data] = await tryCatch(async () => vscode.workspace.fs.readFile(this._uri(projectId, branchId)));
         if (err) {
             return; // no base persisted yet
         }
 
-        const [perr, parsed] = tryCatchSync(() => JSON.parse(buffer.toString(data)) as Record<string, BaseEntry>);
+        const [perr, parsed] = tryCatchSync(
+            () => JSON.parse(buffer.toString(data)) as BaseFile | Record<string, BaseEntry>
+        );
         if (perr || !parsed) {
             return; // corrupt base file — treat as empty
         }
 
-        for (const [id, entry] of Object.entries(parsed)) {
-            this._entries.set(Number(id), entry);
+        const file = parsed as BaseFile;
+        const entries = file.entries ? file.entries : (parsed as Record<string, BaseEntry>);
+        if (typeof file.clientId === 'string') {
+            this._clientId = file.clientId;
+        }
+        if (typeof file.seq === 'number' && Number.isSafeInteger(file.seq)) {
+            this._seq = file.seq;
+        }
+        if (typeof file.base === 'string') {
+            this._base = file.base;
+        }
+
+        for (const [id, entry] of Object.entries(entries)) {
+            const key = Number(id);
+            this._entries.set(key, entry);
+            if (entry.path !== undefined) {
+                this._pathIds.set(entry.path, key);
+            }
         }
     }
 
     get(uniqueId: number) {
         return this._entries.get(uniqueId);
+    }
+
+    get base() {
+        return this._base;
+    }
+
+    get clientId() {
+        return this._clientId;
+    }
+
+    get seq() {
+        return this._seq;
+    }
+
+    setBase(base: string) {
+        this._base = base;
+    }
+
+    setSeq(seq: number) {
+        this._seq = seq;
+    }
+
+    byPath(path: string) {
+        const id = this._pathIds.get(path);
+        return id === undefined ? undefined : this._entries.get(id);
+    }
+
+    items() {
+        return Array.from(this._entries.values());
+    }
+
+    private _entry(item: SyncItem) {
+        const text = norm(item.type === 'file' ? (item.text ?? '') : '');
+        return {
+            ...this._entries.get(item.id),
+            id: item.id,
+            path: item.path,
+            type: item.type,
+            text,
+            hash: hash(text)
+        };
+    }
+
+    setItem(item: SyncItem) {
+        const current = this._entries.get(item.id);
+        if (current?.path !== undefined) {
+            this._pathIds.delete(current.path);
+        }
+        const entry = this._entry(item);
+        this._entries.set(item.id, entry);
+        this._pathIds.set(item.path, item.id);
+    }
+
+    deleteItem(id: number) {
+        const entry = this._entries.get(id);
+        if (entry?.path !== undefined) {
+            this._pathIds.delete(entry.path);
+        }
+        this._entries.delete(id);
+    }
+
+    setSnapshot(snapshot: SyncPullResponse) {
+        const entries = new Map<number, BaseEntry>();
+        const paths = new Map<string, number>();
+        for (const item of snapshot.items) {
+            const entry = this._entry(item);
+            entries.set(item.id, entry);
+            paths.set(item.path, item.id);
+        }
+        this._entries = entries;
+        this._pathIds = paths;
+        this._base = snapshot.base;
     }
 
     set(uniqueId: number, text: string) {
@@ -87,7 +207,15 @@ export class BaseStore {
         await vscode.workspace.fs.createDirectory(vscode.Uri.joinPath(this._storageUri, 'base'));
         await vscode.workspace.fs.writeFile(
             this._uri(this._projectId, this._branchId),
-            buffer.from(JSON.stringify(obj))
+            buffer.from(
+                JSON.stringify({
+                    version: 1,
+                    clientId: this._clientId,
+                    seq: this._seq,
+                    base: this._base,
+                    entries: obj
+                })
+            )
         );
     }
 }

--- a/src/sync/markers.ts
+++ b/src/sync/markers.ts
@@ -1,0 +1,9 @@
+// git-style conflict markers written by the 3-way merge
+export const CONFLICT_START = '<<<<<<< Working (your changes)';
+export const CONFLICT_SEP = '=======';
+export const CONFLICT_END = '>>>>>>> Server (origin)';
+
+// matches a line beginning with a 7-char conflict marker
+const CONFLICT_MARKER_RE = /^(<{7}|={7}|>{7})(\s|$)/m;
+
+export const hasConflictMarkers = (text: string) => CONFLICT_MARKER_RE.test(text);

--- a/src/sync/merge.ts
+++ b/src/sync/merge.ts
@@ -1,0 +1,26 @@
+import { diff3Merge } from 'node-diff3';
+
+import { norm } from '../utils/text';
+
+import { CONFLICT_END, CONFLICT_SEP, CONFLICT_START } from './markers';
+
+// line-based 3-way merge -> git-style conflict markers.
+// base = last pulled ancestor, local = working tree, remote = current server.
+export const merge = (base: string, local: string, remote: string) => {
+    const regions = diff3Merge<string>(norm(local).split('\n'), norm(base).split('\n'), norm(remote).split('\n'), {
+        excludeFalseConflicts: true
+    });
+
+    const out: string[] = [];
+    let conflicted = false;
+    for (const region of regions) {
+        if (region.ok) {
+            out.push(...region.ok);
+        } else if (region.conflict) {
+            conflicted = true;
+            out.push(CONFLICT_START, ...region.conflict.a, CONFLICT_SEP, ...region.conflict.b, CONFLICT_END);
+        }
+    }
+
+    return { text: out.join('\n'), conflicted };
+};

--- a/src/sync/scm.ts
+++ b/src/sync/scm.ts
@@ -147,7 +147,7 @@ class PlayCanvasScm extends Linker<LinkParams> {
         const remoteChanged = new vscode.EventEmitter<vscode.Uri>();
         const remote = vscode.workspace.registerTextDocumentContentProvider(REMOTE_SCHEME, {
             onDidChange: remoteChanged.event,
-            provideTextDocumentContent: (uri) => engine.remoteText(relativePath(uri, folderUri)) ?? ''
+            provideTextDocumentContent: async (uri) => (await engine.remoteText(relativePath(uri, folderUri))) ?? ''
         });
 
         // serve ancestor/local/remote for the merge editor (one scheme each)

--- a/src/sync/scm.ts
+++ b/src/sync/scm.ts
@@ -33,6 +33,8 @@ class PlayCanvasScm extends Linker<LinkParams> {
 
     private _merge?: vscode.SourceControlResourceGroup;
 
+    private _statusItem?: vscode.StatusBarItem;
+
     error = signal<Error | undefined>(undefined);
 
     private _resource(uri: vscode.Uri, path: string, state: SyncState) {
@@ -129,6 +131,25 @@ class PlayCanvasScm extends Linker<LinkParams> {
         this._incoming.resourceStates = incoming;
         this._merge.resourceStates = merge;
         this._scm.count = changes.length + merge.length;
+
+        // status-bar summary: ↓ incoming, ↑ outgoing, conflicts (disk vs cloud)
+        const item = this._statusItem;
+        if (item) {
+            const parts = ['$(cloud) PlayCanvas'];
+            if (merge.length) {
+                parts.push(`$(warning) ${merge.length}`);
+            }
+            if (incoming.length) {
+                parts.push(`↓${incoming.length}`);
+            }
+            if (changes.length) {
+                parts.push(`↑${changes.length}`);
+            }
+            item.text = parts.join(' ');
+            item.tooltip = `PlayCanvas: ${incoming.length} incoming, ${changes.length} outgoing${
+                merge.length ? `, ${merge.length} conflicted` : ''
+            }`;
+        }
     }
 
     async link({ folderUri, engine }: LinkParams) {
@@ -147,6 +168,11 @@ class PlayCanvasScm extends Linker<LinkParams> {
         changes.hideWhenEmpty = true;
         incoming.hideWhenEmpty = true;
         merge.hideWhenEmpty = true;
+
+        // status-bar sync summary; click reveals the Source Control view
+        const statusItem = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Left, 100);
+        statusItem.command = 'workbench.view.scm';
+        statusItem.show();
 
         // gutter diff: working vs base
         scm.quickDiffProvider = {
@@ -204,6 +230,7 @@ class PlayCanvasScm extends Linker<LinkParams> {
         this._changes = changes;
         this._incoming = incoming;
         this._merge = merge;
+        this._statusItem = statusItem;
 
         // re-render whenever the engine's status changes; invalidate base/remote
         // virtual docs too (only uris with an open editor get re-read by vscode)
@@ -219,6 +246,7 @@ class PlayCanvasScm extends Linker<LinkParams> {
 
         this._cleanup.push(async () => {
             stop();
+            statusItem.dispose();
             debouncer.clear();
             onChange.dispose();
             onSave.dispose();
@@ -249,6 +277,7 @@ class PlayCanvasScm extends Linker<LinkParams> {
         this._changes = undefined;
         this._incoming = undefined;
         this._merge = undefined;
+        this._statusItem = undefined;
         void vscode.commands.executeCommand('setContext', 'playcanvas.pullpush', false);
         this._log.info(`unlinked ${folderUri.toString()}`);
         return { folderUri, engine };

--- a/src/sync/scm.ts
+++ b/src/sync/scm.ts
@@ -11,6 +11,7 @@ import type { NativeSyncEngine } from './sync-engine';
 
 const BASE_SCHEME = 'playcanvas-base';
 const REMOTE_SCHEME = 'playcanvas-remote';
+const MERGE_SCHEME = 'playcanvas-merge';
 const REFRESH_DELAY = 200;
 
 type LinkParams = { folderUri: vscode.Uri; engine: NativeSyncEngine };
@@ -32,6 +33,17 @@ class PlayCanvasScm extends Linker<LinkParams> {
     error = signal<Error | undefined>(undefined);
 
     private _resource(uri: vscode.Uri, path: string, state: SyncState) {
+        if (state === 'conflicted') {
+            return {
+                resourceUri: uri,
+                decorations: { tooltip: 'conflict — open the merge editor' },
+                command: {
+                    command: 'playcanvas.resolveMerge',
+                    title: 'Resolve in Merge Editor',
+                    arguments: [uri]
+                }
+            };
+        }
         // incoming: diff against the live remote — working vs base is empty here
         if (state === 'behind') {
             return {
@@ -138,6 +150,15 @@ class PlayCanvasScm extends Linker<LinkParams> {
             provideTextDocumentContent: (uri) => engine.remoteText(relativePath(uri, folderUri)) ?? ''
         });
 
+        // serve ancestor/local/remote for the merge editor (one scheme each)
+        const mergeProvider = (field: 'base' | 'local' | 'remote') =>
+            vscode.workspace.registerTextDocumentContentProvider(`${MERGE_SCHEME}-${field}`, {
+                provideTextDocumentContent: (uri) => engine.mergeInputs(relativePath(uri, folderUri))?.[field] ?? ''
+            });
+        const mergeBase = mergeProvider('base');
+        const mergeLocal = mergeProvider('local');
+        const mergeRemote = mergeProvider('remote');
+
         // recompute status of the saved file (saveAll during pull/push fires
         // one event per buffer — a full refresh each would rescan the project)
         const onSave = vscode.workspace.onDidSaveTextDocument((doc) => {
@@ -185,6 +206,9 @@ class PlayCanvasScm extends Linker<LinkParams> {
             baseChanged.dispose();
             remote.dispose();
             remoteChanged.dispose();
+            mergeBase.dispose();
+            mergeLocal.dispose();
+            mergeRemote.dispose();
             scm.dispose();
         });
 

--- a/src/sync/scm.ts
+++ b/src/sync/scm.ts
@@ -1,0 +1,194 @@
+import * as vscode from 'vscode';
+
+import { fail } from '../utils/error';
+import { Linker } from '../utils/linker';
+import { effect, signal } from '../utils/signal';
+import { relativePath, uriStartsWith } from '../utils/utils';
+
+import type { SyncState } from './status';
+import type { NativeSyncEngine } from './sync-engine';
+
+const BASE_SCHEME = 'playcanvas-base';
+const REMOTE_SCHEME = 'playcanvas-remote';
+
+type LinkParams = { folderUri: vscode.Uri; engine: NativeSyncEngine };
+
+// git-style Source Control panel backed by the NativeSyncEngine status.
+class PlayCanvasScm extends Linker<LinkParams> {
+    private _folderUri?: vscode.Uri;
+
+    private _engine?: NativeSyncEngine;
+
+    private _scm?: vscode.SourceControl;
+
+    private _changes?: vscode.SourceControlResourceGroup;
+
+    private _incoming?: vscode.SourceControlResourceGroup;
+
+    private _merge?: vscode.SourceControlResourceGroup;
+
+    error = signal<Error | undefined>(undefined);
+
+    private _resource(uri: vscode.Uri, path: string, state: SyncState) {
+        // incoming: diff against the live remote — working vs base is empty here
+        if (state === 'behind') {
+            return {
+                resourceUri: uri,
+                decorations: { tooltip: 'incoming — pull to apply' },
+                command: {
+                    command: 'vscode.diff',
+                    title: 'Open Changes',
+                    arguments: [uri, uri.with({ scheme: REMOTE_SCHEME }), `${path} (working vs remote)`]
+                }
+            };
+        }
+        return {
+            resourceUri: uri,
+            decorations: { tooltip: state },
+            command: {
+                command: 'vscode.diff',
+                title: 'Open Changes',
+                arguments: [uri.with({ scheme: BASE_SCHEME }), uri, `${path} (working vs base)`]
+            }
+        };
+    }
+
+    private _render() {
+        const folderUri = this._folderUri;
+        const engine = this._engine;
+        if (!folderUri || !engine || !this._changes || !this._incoming || !this._merge || !this._scm) {
+            return;
+        }
+
+        const changes: vscode.SourceControlResourceState[] = [];
+        const incoming: vscode.SourceControlResourceState[] = [];
+        const merge: vscode.SourceControlResourceState[] = [];
+        for (const [path, state] of engine.statuses()) {
+            const uri = vscode.Uri.joinPath(folderUri, path);
+            const rs = this._resource(uri, path, state);
+            if (state === 'conflicted') {
+                merge.push(rs);
+            } else if (state === 'behind') {
+                incoming.push(rs);
+            } else if (state === 'modified' || state === 'both') {
+                changes.push(rs);
+                // both: surface the server side too — base vs remote isolates
+                // what pull will merge, without conflating your local edits
+                if (state === 'both') {
+                    incoming.push({
+                        resourceUri: uri,
+                        decorations: { tooltip: 'incoming — pull to merge' },
+                        command: {
+                            command: 'vscode.diff',
+                            title: 'Open Changes',
+                            arguments: [
+                                uri.with({ scheme: BASE_SCHEME }),
+                                uri.with({ scheme: REMOTE_SCHEME }),
+                                `${path} (base vs remote)`
+                            ]
+                        }
+                    });
+                }
+            }
+        }
+        this._changes.resourceStates = changes;
+        this._incoming.resourceStates = incoming;
+        this._merge.resourceStates = merge;
+        this._scm.count = changes.length + merge.length;
+    }
+
+    async link({ folderUri, engine }: LinkParams) {
+        if (this._folderUri !== undefined) {
+            throw this.error.set(() => fail`already linked`);
+        }
+        await super.unlink();
+
+        const scm = vscode.scm.createSourceControl('playcanvas', 'PlayCanvas', folderUri);
+        scm.inputBox.visible = false;
+        const changes = scm.createResourceGroup('changes', 'Changes');
+        const incoming = scm.createResourceGroup('incoming', 'Incoming Changes');
+        const merge = scm.createResourceGroup('merge', 'Merge Changes');
+        changes.hideWhenEmpty = true;
+        incoming.hideWhenEmpty = true;
+        merge.hideWhenEmpty = true;
+
+        // gutter diff: working vs base
+        scm.quickDiffProvider = {
+            provideOriginalResource: (uri) =>
+                uriStartsWith(uri, folderUri) ? uri.with({ scheme: BASE_SCHEME }) : undefined
+        };
+
+        // serve base content for the playcanvas-base: scheme. onDidChange
+        // invalidates cached gutter quick-diffs when push/pull advance the base
+        const baseChanged = new vscode.EventEmitter<vscode.Uri>();
+        const content = vscode.workspace.registerTextDocumentContentProvider(BASE_SCHEME, {
+            onDidChange: baseChanged.event,
+            provideTextDocumentContent: (uri) => engine.baseText(relativePath(uri, folderUri)) ?? ''
+        });
+
+        // serve live remote content (R) for incoming diffs. onDidChange keeps an
+        // open diff current while a collaborator keeps typing (R moves between renders)
+        const remoteChanged = new vscode.EventEmitter<vscode.Uri>();
+        const remote = vscode.workspace.registerTextDocumentContentProvider(REMOTE_SCHEME, {
+            onDidChange: remoteChanged.event,
+            provideTextDocumentContent: (uri) => engine.remoteText(relativePath(uri, folderUri)) ?? ''
+        });
+
+        // recompute status on local save (edits are local-only in pullpush mode)
+        const onSave = vscode.workspace.onDidSaveTextDocument((doc) => {
+            if (uriStartsWith(doc.uri, folderUri)) {
+                void engine.refresh();
+            }
+        });
+
+        this._folderUri = folderUri;
+        this._engine = engine;
+        this._scm = scm;
+        this._changes = changes;
+        this._incoming = incoming;
+        this._merge = merge;
+
+        // re-render whenever the engine's status changes; invalidate base/remote
+        // virtual docs too (only uris with an open editor get re-read by vscode)
+        const stop = effect(() => {
+            engine.changed.get();
+            this._render();
+            for (const path of engine.statuses().keys()) {
+                const uri = vscode.Uri.joinPath(folderUri, path);
+                baseChanged.fire(uri.with({ scheme: BASE_SCHEME }));
+                remoteChanged.fire(uri.with({ scheme: REMOTE_SCHEME }));
+            }
+        });
+
+        this._cleanup.push(async () => {
+            stop();
+            onSave.dispose();
+            content.dispose();
+            baseChanged.dispose();
+            remote.dispose();
+            remoteChanged.dispose();
+            scm.dispose();
+        });
+
+        this._log.info(`linked ${folderUri.toString()}`);
+    }
+
+    async unlink() {
+        const folderUri = this._folderUri;
+        const engine = this._engine;
+        if (!folderUri || !engine) {
+            throw this.error.set(() => fail`unlink called before link`);
+        }
+        await super.unlink();
+        this._folderUri = undefined;
+        this._engine = undefined;
+        this._scm = undefined;
+        this._changes = undefined;
+        this._incoming = undefined;
+        this._merge = undefined;
+        this._log.info(`unlinked ${folderUri.toString()}`);
+        return { folderUri, engine };
+    }
+}
+
+export { PlayCanvasScm };

--- a/src/sync/scm.ts
+++ b/src/sync/scm.ts
@@ -12,29 +12,12 @@ import type { NativeSyncEngine } from './sync-engine';
 const BASE_SCHEME = 'playcanvas-base';
 const REMOTE_SCHEME = 'playcanvas-remote';
 const MERGE_SCHEME = 'playcanvas-merge';
+const SCM_SCHEME = 'playcanvas-scm';
 const REFRESH_DELAY = 200;
-const DECORATION: Record<SyncState, { letter: string; color: string; tooltip: string; strikeThrough?: boolean }> = {
-    clean: { letter: '', color: 'gitDecoration.modifiedResourceForeground', tooltip: 'clean' },
-    modified: { letter: 'M', color: 'gitDecoration.modifiedResourceForeground', tooltip: 'modified' },
-    behind: { letter: 'M', color: 'gitDecoration.modifiedResourceForeground', tooltip: 'incoming' },
-    both: { letter: 'M', color: 'gitDecoration.modifiedResourceForeground', tooltip: 'modified, incoming' },
-    conflicted: { letter: '!', color: 'gitDecoration.conflictingResourceForeground', tooltip: 'conflict' },
-    added: { letter: 'A', color: 'gitDecoration.addedResourceForeground', tooltip: 'added' },
-    deleted: { letter: 'D', color: 'gitDecoration.deletedResourceForeground', tooltip: 'deleted', strikeThrough: true },
-    renamed: { letter: 'R', color: 'gitDecoration.renamedResourceForeground', tooltip: 'renamed' }
-};
 
 type LinkParams = { folderUri: vscode.Uri; engine: NativeSyncEngine };
 
-const scmDecoration = (state: SyncState, tooltip = DECORATION[state].tooltip) => {
-    const d = DECORATION[state];
-    return {
-        letter: d.letter,
-        color: new vscode.ThemeColor(d.color),
-        priority: state === 'conflicted' ? 4 : 1,
-        decorations: { tooltip, strikeThrough: d.strikeThrough }
-    };
-};
+const scmUri = (uri: vscode.Uri) => uri.with({ scheme: SCM_SCHEME });
 
 // git-style Source Control panel backed by the NativeSyncEngine status.
 class PlayCanvasScm extends Linker<LinkParams> {
@@ -56,8 +39,8 @@ class PlayCanvasScm extends Linker<LinkParams> {
         if (state === 'conflicted') {
             if (this._engine?.structuralConflict(path)) {
                 return {
-                    resourceUri: uri,
-                    ...scmDecoration(state, 'structural conflict — resolve'),
+                    resourceUri: scmUri(uri),
+                    decorations: { tooltip: 'structural conflict — resolve' },
                     command: {
                         command: 'playcanvas.resolveStructuralConflict',
                         title: 'Resolve Structural Conflict',
@@ -66,8 +49,8 @@ class PlayCanvasScm extends Linker<LinkParams> {
                 };
             }
             return {
-                resourceUri: uri,
-                ...scmDecoration(state, 'conflict — open the merge editor'),
+                resourceUri: scmUri(uri),
+                decorations: { tooltip: 'conflict — open the merge editor' },
                 command: {
                     command: 'playcanvas.resolveMerge',
                     title: 'Resolve in Merge Editor',
@@ -78,8 +61,8 @@ class PlayCanvasScm extends Linker<LinkParams> {
         // incoming: diff against the live remote — working vs base is empty here
         if (state === 'behind') {
             return {
-                resourceUri: uri,
-                ...scmDecoration(state, 'incoming — pull to apply'),
+                resourceUri: scmUri(uri),
+                decorations: { tooltip: 'incoming — pull to apply' },
                 command: {
                     command: 'vscode.diff',
                     title: 'Open Changes',
@@ -88,8 +71,8 @@ class PlayCanvasScm extends Linker<LinkParams> {
             };
         }
         return {
-            resourceUri: uri,
-            ...scmDecoration(state),
+            resourceUri: scmUri(uri),
+            decorations: { tooltip: state, strikeThrough: state === 'deleted' },
             command: {
                 command: 'vscode.diff',
                 title: 'Open Changes',
@@ -127,8 +110,8 @@ class PlayCanvasScm extends Linker<LinkParams> {
                 // what pull will merge, without conflating your local edits
                 if (state === 'both') {
                     incoming.push({
-                        resourceUri: uri,
-                        ...scmDecoration('behind', 'incoming — pull to merge'),
+                        resourceUri: scmUri(uri),
+                        decorations: { tooltip: 'incoming — pull to merge' },
                         command: {
                             command: 'vscode.diff',
                             title: 'Open Changes',
@@ -272,4 +255,4 @@ class PlayCanvasScm extends Linker<LinkParams> {
     }
 }
 
-export { PlayCanvasScm, scmDecoration };
+export { PlayCanvasScm, SCM_SCHEME, scmUri };

--- a/src/sync/scm.ts
+++ b/src/sync/scm.ts
@@ -103,7 +103,9 @@ class PlayCanvasScm extends Linker<LinkParams> {
         }
         await super.unlink();
 
-        const scm = vscode.scm.createSourceControl('playcanvas', 'PlayCanvas', folderUri);
+        // no rootUri: sharing git's project folder makes VS Code render git's
+        // resource-group actions (stage/discard) on our groups
+        const scm = vscode.scm.createSourceControl('playcanvas', 'PlayCanvas');
         scm.inputBox.visible = false;
         const changes = scm.createResourceGroup('changes', 'Changes');
         const incoming = scm.createResourceGroup('incoming', 'Incoming Changes');

--- a/src/sync/scm.ts
+++ b/src/sync/scm.ts
@@ -13,8 +13,28 @@ const BASE_SCHEME = 'playcanvas-base';
 const REMOTE_SCHEME = 'playcanvas-remote';
 const MERGE_SCHEME = 'playcanvas-merge';
 const REFRESH_DELAY = 200;
+const DECORATION: Record<SyncState, { letter: string; color: string; tooltip: string; strikeThrough?: boolean }> = {
+    clean: { letter: '', color: 'gitDecoration.modifiedResourceForeground', tooltip: 'clean' },
+    modified: { letter: 'M', color: 'gitDecoration.modifiedResourceForeground', tooltip: 'modified' },
+    behind: { letter: 'M', color: 'gitDecoration.modifiedResourceForeground', tooltip: 'incoming' },
+    both: { letter: 'M', color: 'gitDecoration.modifiedResourceForeground', tooltip: 'modified, incoming' },
+    conflicted: { letter: '!', color: 'gitDecoration.conflictingResourceForeground', tooltip: 'conflict' },
+    added: { letter: 'A', color: 'gitDecoration.addedResourceForeground', tooltip: 'added' },
+    deleted: { letter: 'D', color: 'gitDecoration.deletedResourceForeground', tooltip: 'deleted', strikeThrough: true },
+    renamed: { letter: 'R', color: 'gitDecoration.renamedResourceForeground', tooltip: 'renamed' }
+};
 
 type LinkParams = { folderUri: vscode.Uri; engine: NativeSyncEngine };
+
+const scmDecoration = (state: SyncState, tooltip = DECORATION[state].tooltip) => {
+    const d = DECORATION[state];
+    return {
+        letter: d.letter,
+        color: new vscode.ThemeColor(d.color),
+        priority: state === 'conflicted' ? 4 : 1,
+        decorations: { tooltip, strikeThrough: d.strikeThrough }
+    };
+};
 
 // git-style Source Control panel backed by the NativeSyncEngine status.
 class PlayCanvasScm extends Linker<LinkParams> {
@@ -37,7 +57,7 @@ class PlayCanvasScm extends Linker<LinkParams> {
             if (this._engine?.structuralConflict(path)) {
                 return {
                     resourceUri: uri,
-                    decorations: { tooltip: 'structural conflict — resolve' },
+                    ...scmDecoration(state, 'structural conflict — resolve'),
                     command: {
                         command: 'playcanvas.resolveStructuralConflict',
                         title: 'Resolve Structural Conflict',
@@ -47,7 +67,7 @@ class PlayCanvasScm extends Linker<LinkParams> {
             }
             return {
                 resourceUri: uri,
-                decorations: { tooltip: 'conflict — open the merge editor' },
+                ...scmDecoration(state, 'conflict — open the merge editor'),
                 command: {
                     command: 'playcanvas.resolveMerge',
                     title: 'Resolve in Merge Editor',
@@ -59,7 +79,7 @@ class PlayCanvasScm extends Linker<LinkParams> {
         if (state === 'behind') {
             return {
                 resourceUri: uri,
-                decorations: { tooltip: 'incoming — pull to apply' },
+                ...scmDecoration(state, 'incoming — pull to apply'),
                 command: {
                     command: 'vscode.diff',
                     title: 'Open Changes',
@@ -69,7 +89,7 @@ class PlayCanvasScm extends Linker<LinkParams> {
         }
         return {
             resourceUri: uri,
-            decorations: { tooltip: state },
+            ...scmDecoration(state),
             command: {
                 command: 'vscode.diff',
                 title: 'Open Changes',
@@ -108,7 +128,7 @@ class PlayCanvasScm extends Linker<LinkParams> {
                 if (state === 'both') {
                     incoming.push({
                         resourceUri: uri,
-                        decorations: { tooltip: 'incoming — pull to merge' },
+                        ...scmDecoration('behind', 'incoming — pull to merge'),
                         command: {
                             command: 'vscode.diff',
                             title: 'Open Changes',
@@ -252,4 +272,4 @@ class PlayCanvasScm extends Linker<LinkParams> {
     }
 }
 
-export { PlayCanvasScm };
+export { PlayCanvasScm, scmDecoration };

--- a/src/sync/scm.ts
+++ b/src/sync/scm.ts
@@ -34,6 +34,17 @@ class PlayCanvasScm extends Linker<LinkParams> {
 
     private _resource(uri: vscode.Uri, path: string, state: SyncState) {
         if (state === 'conflicted') {
+            if (this._engine?.structuralConflict(path)) {
+                return {
+                    resourceUri: uri,
+                    decorations: { tooltip: 'structural conflict — resolve' },
+                    command: {
+                        command: 'playcanvas.resolveStructuralConflict',
+                        title: 'Resolve Structural Conflict',
+                        arguments: [uri]
+                    }
+                };
+            }
             return {
                 resourceUri: uri,
                 decorations: { tooltip: 'conflict — open the merge editor' },
@@ -84,7 +95,13 @@ class PlayCanvasScm extends Linker<LinkParams> {
                 merge.push(rs);
             } else if (state === 'behind') {
                 incoming.push(rs);
-            } else if (state === 'modified' || state === 'both') {
+            } else if (
+                state === 'modified' ||
+                state === 'both' ||
+                state === 'added' ||
+                state === 'deleted' ||
+                state === 'renamed'
+            ) {
                 changes.push(rs);
                 // both: surface the server side too — base vs remote isolates
                 // what pull will merge, without conflating your local edits
@@ -212,6 +229,7 @@ class PlayCanvasScm extends Linker<LinkParams> {
             scm.dispose();
         });
 
+        void vscode.commands.executeCommand('setContext', 'playcanvas.pullpush', true);
         this._log.info(`linked ${folderUri.toString()}`);
     }
 
@@ -228,6 +246,7 @@ class PlayCanvasScm extends Linker<LinkParams> {
         this._changes = undefined;
         this._incoming = undefined;
         this._merge = undefined;
+        void vscode.commands.executeCommand('setContext', 'playcanvas.pullpush', false);
         this._log.info(`unlinked ${folderUri.toString()}`);
         return { folderUri, engine };
     }

--- a/src/sync/scm.ts
+++ b/src/sync/scm.ts
@@ -1,15 +1,17 @@
 import * as vscode from 'vscode';
 
+import { Debouncer } from '../utils/debouncer';
 import { fail } from '../utils/error';
 import { Linker } from '../utils/linker';
 import { effect, signal } from '../utils/signal';
-import { relativePath, uriStartsWith } from '../utils/utils';
+import { relativePath, uriStartsWith, tryCatch } from '../utils/utils';
 
 import type { SyncState } from './status';
 import type { NativeSyncEngine } from './sync-engine';
 
 const BASE_SCHEME = 'playcanvas-base';
 const REMOTE_SCHEME = 'playcanvas-remote';
+const REFRESH_DELAY = 200;
 
 type LinkParams = { folderUri: vscode.Uri; engine: NativeSyncEngine };
 
@@ -136,11 +138,23 @@ class PlayCanvasScm extends Linker<LinkParams> {
             provideTextDocumentContent: (uri) => engine.remoteText(relativePath(uri, folderUri)) ?? ''
         });
 
-        // recompute status on local save (edits are local-only in pullpush mode)
+        // recompute status of the saved file (saveAll during pull/push fires
+        // one event per buffer — a full refresh each would rescan the project)
         const onSave = vscode.workspace.onDidSaveTextDocument((doc) => {
             if (uriStartsWith(doc.uri, folderUri)) {
-                void engine.refresh();
+                void engine.refresh(relativePath(doc.uri, folderUri));
             }
+        });
+
+        // live status: per-path debounce so concurrent edits to different files
+        // don't cancel each other's refresh
+        const debouncer = new Debouncer<void>(REFRESH_DELAY);
+        const onChange = vscode.workspace.onDidChangeTextDocument((e) => {
+            if (!uriStartsWith(e.document.uri, folderUri)) {
+                return;
+            }
+            const path = relativePath(e.document.uri, folderUri);
+            void tryCatch(debouncer.debounce(path, () => engine.refresh(path)));
         });
 
         this._folderUri = folderUri;
@@ -164,6 +178,8 @@ class PlayCanvasScm extends Linker<LinkParams> {
 
         this._cleanup.push(async () => {
             stop();
+            debouncer.clear();
+            onChange.dispose();
             onSave.dispose();
             content.dispose();
             baseChanged.dispose();

--- a/src/sync/status.ts
+++ b/src/sync/status.ts
@@ -1,0 +1,23 @@
+import { hasConflictMarkers } from './markers';
+
+export type SyncState = 'clean' | 'modified' | 'behind' | 'both' | 'conflicted';
+
+// classify a file's content sync state.
+// base = last pull, working = disk, remote = current server.
+export const classify = (baseHash: string, workingHash: string, remoteHash: string, working: string) => {
+    if (hasConflictMarkers(working)) {
+        return 'conflicted' as const;
+    }
+    const ahead = workingHash !== baseHash;
+    const behind = remoteHash !== baseHash;
+    if (ahead && behind) {
+        return 'both' as const;
+    }
+    if (ahead) {
+        return 'modified' as const;
+    }
+    if (behind) {
+        return 'behind' as const;
+    }
+    return 'clean' as const;
+};

--- a/src/sync/status.ts
+++ b/src/sync/status.ts
@@ -1,6 +1,6 @@
 import { hasConflictMarkers } from './markers';
 
-export type SyncState = 'clean' | 'modified' | 'behind' | 'both' | 'conflicted';
+export type SyncState = 'clean' | 'modified' | 'behind' | 'both' | 'conflicted' | 'added' | 'deleted' | 'renamed';
 
 // classify a file's content sync state.
 // base = last pull, working = disk, remote = current server.

--- a/src/sync/status.ts
+++ b/src/sync/status.ts
@@ -1,13 +1,8 @@
-import { hasConflictMarkers } from './markers';
-
 export type SyncState = 'clean' | 'modified' | 'behind' | 'both' | 'conflicted' | 'added' | 'deleted' | 'renamed';
 
 // classify a file's content sync state.
 // base = last pull, working = disk, remote = current server.
-export const classify = (baseHash: string, workingHash: string, remoteHash: string, working: string) => {
-    if (hasConflictMarkers(working)) {
-        return 'conflicted' as const;
-    }
+export const classify = (baseHash: string, workingHash: string, remoteHash: string, _working: string) => {
     const ahead = workingHash !== baseHash;
     const behind = remoteHash !== baseHash;
     if (ahead && behind) {

--- a/src/sync/sync-engine.ts
+++ b/src/sync/sync-engine.ts
@@ -499,6 +499,54 @@ class NativeSyncEngine extends Linker<LinkParams> {
         }
     }
 
+    private async _pushContent(path: string) {
+        const folderUri = this._folderUri;
+        const pm = this._projectManager;
+        const f = pm?.files.get(path);
+        if (!folderUri || !pm || !f || f.type === 'folder') {
+            return;
+        }
+        const working = await this._readDisk(folderUri, path);
+        if (working === undefined) {
+            return;
+        }
+        // closed-file local edits live on stubs — subscribe to submit.
+        // released on the flush ack (asset:file:save), not here: the doc
+        // has pending ops until then and an early close races the save
+        let file = f;
+        let fresh = false;
+        if (file.type === 'stub') {
+            const promoted = await pm.subscribe(path);
+            if (!promoted) {
+                return;
+            }
+            file = promoted;
+            this._promoted.add(path);
+            fresh = true;
+        }
+        if (file.type !== 'file') {
+            return;
+        }
+        const base = this._base.get(file.uniqueId);
+        // re-check remote is still unchanged, synchronous with write()'s apply
+        // so a remote op can't interleave — went behind mid-push, leave for pull
+        if (base && norm(file.doc.text) !== base.text) {
+            if (fresh) {
+                this._promoted.delete(path);
+                await this._release(path);
+            }
+            throw fail`remote has changes — pull before pushing`;
+        }
+        if (norm(file.doc.text) === working) {
+            this._base.set(file.uniqueId, working);
+            return;
+        }
+        // write() diffs against the live doc and marks dirty so save() flushes
+        await pm.write(path, buffer.from(working));
+        await this._save(path);
+        this._base.set(file.uniqueId, working);
+    }
+
     private async _refresh(path: string) {
         const folderUri = this._folderUri;
         const pm = this._projectManager;
@@ -759,6 +807,11 @@ class NativeSyncEngine extends Linker<LinkParams> {
                 throw err;
             }
             this._local.delete(op.path);
+            this._status.delete(op.path);
+            if (op.type === 'file') {
+                await this.refresh(op.path);
+                await this._pushContent(op.path);
+            }
         }
         for (const op of added) {
             const content =
@@ -790,41 +843,7 @@ class NativeSyncEngine extends Linker<LinkParams> {
             if (f.type === 'folder' || this._status.get(path) !== 'modified') {
                 continue;
             }
-            const working = await this._readDisk(folderUri, path);
-            if (working === undefined) {
-                continue;
-            }
-            // closed-file local edits live on stubs — subscribe to submit.
-            // released on the flush ack (asset:file:save), not here: the doc
-            // has pending ops until then and an early close races the save
-            let file = f;
-            let fresh = false;
-            if (file.type === 'stub') {
-                const promoted = await pm.subscribe(path);
-                if (!promoted) {
-                    continue;
-                }
-                file = promoted;
-                this._promoted.add(path);
-                fresh = true;
-            }
-            if (file.type !== 'file') {
-                continue;
-            }
-            const base = this._base.get(file.uniqueId);
-            // re-check remote is still unchanged, synchronous with write()'s apply
-            // so a remote op can't interleave — went behind mid-push, leave for pull
-            if (base && norm(file.doc.text) !== base.text) {
-                if (fresh) {
-                    this._promoted.delete(path);
-                    await this._release(path);
-                }
-                throw fail`remote has changes — pull before pushing`;
-            }
-            // write() diffs against the live doc and marks dirty so save() flushes
-            await pm.write(path, buffer.from(working));
-            await this._save(path);
-            this._base.set(file.uniqueId, working);
+            await this._pushContent(path);
         }
 
         await this._base.flush();

--- a/src/sync/sync-engine.ts
+++ b/src/sync/sync-engine.ts
@@ -76,15 +76,7 @@ class NativeSyncEngine extends Linker<LinkParams> {
 
     structuralConflict(target: string | vscode.Uri) {
         const path = this._path(target);
-        const op = this._remote.get(path);
-        if (!op?.conflicted) {
-            return undefined;
-        }
-        return {
-            action: op.action,
-            path: op.path,
-            from: op.action === 'renamed' ? op.from : undefined
-        };
+        return this._remote.get(path)?.conflicted;
     }
 
     baseText(path: string) {
@@ -337,25 +329,7 @@ class NativeSyncEngine extends Linker<LinkParams> {
     }
 
     async markResolved(uri: vscode.Uri) {
-        const path = this._path(uri);
-        const op = this._remote.get(path);
-        if (!op) {
-            return;
-        }
-        this._remote.delete(path);
-        this._dropLocal(op.path, op.action === 'renamed' ? op.from : op.path);
-        if (op.action === 'deleted') {
-            const type = await this._type(op.path);
-            if (type) {
-                this._setLocal({ action: 'added', path: op.path, type });
-            }
-        } else if (op.action === 'renamed') {
-            const type = await this._type(op.from);
-            if (type) {
-                this._setLocal({ action: 'renamed', from: op.path, path: op.from, type });
-            }
-        }
-        await this._refreshAll();
+        await this.keepCurrent(uri);
     }
 
     private async _read(folderUri: vscode.Uri, path: string) {

--- a/src/sync/sync-engine.ts
+++ b/src/sync/sync-engine.ts
@@ -21,6 +21,14 @@ type LinkParams = {
     projectId: number;
     branchId: string;
 };
+type LocalOp =
+    | { action: 'added'; path: string; type: 'file' | 'folder' }
+    | { action: 'deleted'; path: string; type: 'file' | 'folder' }
+    | { action: 'renamed'; from: string; path: string; type: 'file' | 'folder' };
+type RemoteOp =
+    | { action: 'created'; path: string; type: 'file' | 'folder'; content: Uint8Array; conflicted?: boolean }
+    | { action: 'deleted'; path: string; conflicted?: boolean }
+    | { action: 'renamed'; from: string; path: string; conflicted?: boolean };
 
 // native git-style sync: observes per-file state (base vs working vs remote)
 // without touching the live realtime path. pull/push land in later parts.
@@ -38,6 +46,10 @@ class NativeSyncEngine extends Linker<LinkParams> {
     private _branchId?: string;
 
     private _status = new Map<string, SyncState>();
+
+    private _local = new Map<string, LocalOp>();
+
+    private _remote = new Map<string, RemoteOp>();
 
     private _merges = new Map<number, { base: string; local: string; remote: string }>();
 
@@ -62,16 +74,191 @@ class NativeSyncEngine extends Linker<LinkParams> {
         return new Map(this._status);
     }
 
+    structuralConflict(target: string | vscode.Uri) {
+        const path = this._path(target);
+        const op = this._remote.get(path);
+        if (!op?.conflicted) {
+            return undefined;
+        }
+        return {
+            action: op.action,
+            path: op.path,
+            from: op.action === 'renamed' ? op.from : undefined
+        };
+    }
+
     baseText(path: string) {
         const file = this._projectManager?.files.get(path);
         if (!file || file.type === 'folder') {
-            return undefined;
+            const op = this._local.get(path);
+            if (op?.action !== 'renamed') {
+                return undefined;
+            }
+            const from = this._projectManager?.files.get(op.from);
+            if (!from || from.type === 'folder') {
+                return undefined;
+            }
+            return this._base.get(from.uniqueId)?.text;
         }
         return this._base.get(file.uniqueId)?.text;
     }
 
-    // remote content (R) for the incoming diff view: live doc when subscribed;
-    // stubs read S3 via REST so a diff click never creates a subscription
+    private _path(target: string | vscode.Uri) {
+        if (typeof target === 'string') {
+            return target;
+        }
+        return this._folderUri ? relativePath(target, this._folderUri) : target.path;
+    }
+
+    private _setLocal(op: LocalOp) {
+        this._local.set(op.path, op);
+        this._status.set(op.path, op.action);
+        this.changed.set((v) => v + 1);
+    }
+
+    private _setRemote(op: RemoteOp, conflicted = false) {
+        this._remote.set(op.path, { ...op, conflicted });
+        this._status.set(op.path, conflicted ? 'conflicted' : 'behind');
+        this.changed.set((v) => v + 1);
+    }
+
+    private _touches(a: string, b: string) {
+        return a === b || a.startsWith(`${b}/`) || b.startsWith(`${a}/`);
+    }
+
+    private _localOpTouches(path: string) {
+        for (const op of this._local.values()) {
+            if (this._touches(op.path, path) || (op.action === 'renamed' && this._touches(op.from, path))) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private _localTouches(path: string) {
+        for (const op of this._local.values()) {
+            if (this._touches(op.path, path) || (op.action === 'renamed' && this._touches(op.from, path))) {
+                return true;
+            }
+        }
+        for (const [p, state] of this._status) {
+            if (this._touches(p, path) && (state === 'modified' || state === 'both' || state === 'conflicted')) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private _dropLocal(...paths: string[]) {
+        for (const [path, op] of Array.from(this._local)) {
+            const touches = paths.some(
+                (p) => this._touches(op.path, p) || (op.action === 'renamed' && this._touches(op.from, p))
+            );
+            if (!touches) {
+                continue;
+            }
+            this._local.delete(path);
+            this._status.delete(path);
+            if (op.action === 'renamed') {
+                this._status.delete(op.from);
+            }
+        }
+        for (const path of paths) {
+            this._status.delete(path);
+        }
+    }
+
+    private async _exists(path: string) {
+        const folderUri = this._folderUri;
+        if (!folderUri) {
+            return false;
+        }
+        const [err] = await tryCatch(async () => vscode.workspace.fs.stat(vscode.Uri.joinPath(folderUri, path)));
+        return !err;
+    }
+
+    private async _type(path: string) {
+        const folderUri = this._folderUri;
+        if (!folderUri) {
+            return undefined;
+        }
+        const [err, stat] = await tryCatch(async () => vscode.workspace.fs.stat(vscode.Uri.joinPath(folderUri, path)));
+        if (err) {
+            return undefined;
+        }
+        return stat.type === vscode.FileType.Directory ? 'folder' : 'file';
+    }
+
+    private _localCreate(path: string, type: 'file' | 'folder') {
+        this._setLocal({ action: 'added', path, type });
+    }
+
+    private _localDelete(path: string, type: 'file' | 'folder') {
+        const op = this._local.get(path);
+        if (op?.action === 'added') {
+            this._local.delete(path);
+            this._status.delete(path);
+            this.changed.set((v) => v + 1);
+            return;
+        }
+        if (op?.action === 'renamed') {
+            this._local.delete(path);
+            this._setLocal({ action: 'deleted', path: op.from, type });
+            return;
+        }
+        this._setLocal({ action: 'deleted', path, type });
+    }
+
+    private _localRename(from: string, path: string, type: 'file' | 'folder') {
+        const op = this._local.get(from);
+        if (op?.action === 'added') {
+            this._local.delete(from);
+            this._status.delete(from);
+            this._setLocal({ action: 'added', path, type });
+            return;
+        }
+        if (op?.action === 'renamed') {
+            this._local.delete(from);
+            this._status.delete(from);
+            this._setLocal({ action: 'renamed', from: op.from, path, type });
+            return;
+        }
+        this._setLocal({ action: 'renamed', from, path, type });
+    }
+
+    private async _remoteCreate(path: string, type: 'file' | 'folder', content: Uint8Array) {
+        if (this._localTouches(path)) {
+            this._setRemote({ action: 'created', path, type, content }, true);
+            return;
+        }
+        const working = type === 'file' ? await this._read(this._folderUri!, path) : undefined;
+        const same = type === 'file' && content.length > 0 && working === norm(buffer.toString(content));
+        this._setRemote({ action: 'created', path, type, content }, working !== undefined && !same);
+    }
+
+    private _remoteDelete(path: string) {
+        this._setRemote({ action: 'deleted', path }, this._localTouches(path));
+    }
+
+    private async _remoteRename(from: string, path: string) {
+        this._status.delete(from);
+        const op = { action: 'renamed' as const, from, path };
+        const conflicted = this._localOpTouches(from) || this._localTouches(path);
+        this._setRemote(op, conflicted);
+        if (!conflicted && (await this._exists(path))) {
+            this._setRemote(op, true);
+        }
+    }
+
+    private async _content(op: RemoteOp & { action: 'created' }) {
+        if (op.type !== 'file' || op.content.length > 0) {
+            return op.content;
+        }
+        const text = await this.remoteText(op.path);
+        return text === undefined ? op.content : buffer.from(text);
+    }
+
+    // remote content for the incoming diff view; stubs are promoted only while read
     async remoteText(path: string) {
         const pm = this._projectManager;
         const file = pm?.files.get(path);
@@ -81,8 +268,13 @@ class NativeSyncEngine extends Linker<LinkParams> {
         if (file.type === 'file') {
             return norm(file.doc.text);
         }
-        const [err, buf] = await tryCatch(async () => pm.fetchContent(file.uniqueId));
-        return err ? undefined : norm(buffer.toString(buf));
+        const [err, promoted] = await tryCatch(async () => pm.subscribe(path));
+        if (err || !promoted || promoted.type !== 'file') {
+            return undefined;
+        }
+        const text = norm(promoted.doc.text);
+        await this._release(path);
+        return text;
     }
 
     // base/local/remote inputs for a conflicted file's 3-way merge editor
@@ -92,6 +284,78 @@ class NativeSyncEngine extends Linker<LinkParams> {
             return undefined;
         }
         return this._merges.get(file.uniqueId);
+    }
+
+    async acceptIncoming(uri: vscode.Uri) {
+        const path = this._path(uri);
+        const op = this._remote.get(path);
+        if (!op) {
+            return;
+        }
+        this._dropLocal(op.path, op.action === 'renamed' ? op.from : op.path);
+        if (op.action === 'created') {
+            if (await this._exists(op.path)) {
+                await this._applyDelete(op.path);
+            }
+            await this._applyCreate(op.path, op.type, await this._content(op));
+        } else if (op.action === 'deleted') {
+            if (await this._exists(op.path)) {
+                await this._applyDelete(op.path);
+            }
+        } else {
+            if (await this._exists(op.path)) {
+                await this._applyDelete(op.path);
+            }
+            if (await this._exists(op.from)) {
+                await this._applyRename(op.from, op.path);
+            }
+        }
+        this._remote.delete(path);
+        await this._refreshAll();
+    }
+
+    async keepCurrent(uri: vscode.Uri) {
+        const path = this._path(uri);
+        const op = this._remote.get(path);
+        if (!op) {
+            return;
+        }
+        this._remote.delete(path);
+        this._dropLocal(op.path, op.action === 'renamed' ? op.from : op.path);
+        if (op.action === 'deleted') {
+            const type = await this._type(op.path);
+            if (type) {
+                this._setLocal({ action: 'added', path: op.path, type });
+            }
+        } else if (op.action === 'renamed') {
+            const type = await this._type(op.from);
+            if (type) {
+                this._setLocal({ action: 'renamed', from: op.path, path: op.from, type });
+            }
+        }
+        await this._refreshAll();
+    }
+
+    async markResolved(uri: vscode.Uri) {
+        const path = this._path(uri);
+        const op = this._remote.get(path);
+        if (!op) {
+            return;
+        }
+        this._remote.delete(path);
+        this._dropLocal(op.path, op.action === 'renamed' ? op.from : op.path);
+        if (op.action === 'deleted') {
+            const type = await this._type(op.path);
+            if (type) {
+                this._setLocal({ action: 'added', path: op.path, type });
+            }
+        } else if (op.action === 'renamed') {
+            const type = await this._type(op.from);
+            if (type) {
+                this._setLocal({ action: 'renamed', from: op.path, path: op.from, type });
+            }
+        }
+        await this._refreshAll();
     }
 
     private async _read(folderUri: vscode.Uri, path: string) {
@@ -109,6 +373,33 @@ class NativeSyncEngine extends Linker<LinkParams> {
         await vscode.workspace.fs.writeFile(vscode.Uri.joinPath(folderUri, path), buffer.from(text));
     }
 
+    private _applyCreate(path: string, type: 'file' | 'folder', content: Uint8Array) {
+        return new Promise<void>((resolve, reject) => {
+            const done = (err?: Error) => (err ? reject(err) : resolve());
+            if (!this._events.emit('sync:file:apply:create', path, type, content, done)) {
+                resolve();
+            }
+        });
+    }
+
+    private _applyDelete(path: string) {
+        return new Promise<void>((resolve, reject) => {
+            const done = (err?: Error) => (err ? reject(err) : resolve());
+            if (!this._events.emit('sync:file:apply:delete', path, done)) {
+                resolve();
+            }
+        });
+    }
+
+    private _applyRename(from: string, path: string) {
+        return new Promise<void>((resolve, reject) => {
+            const done = (err?: Error) => (err ? reject(err) : resolve());
+            if (!this._events.emit('sync:file:apply:rename', from, path, done)) {
+                resolve();
+            }
+        });
+    }
+
     private async _refresh(path: string) {
         const folderUri = this._folderUri;
         const pm = this._projectManager;
@@ -116,6 +407,16 @@ class NativeSyncEngine extends Linker<LinkParams> {
             return;
         }
 
+        const remoteOp = this._remote.get(path);
+        if (remoteOp) {
+            this._status.set(path, remoteOp.conflicted ? 'conflicted' : 'behind');
+            return;
+        }
+        const local = this._local.get(path);
+        if (local) {
+            this._status.set(path, local.action);
+            return;
+        }
         const file = pm.files.get(path);
         if (!file || file.type === 'folder') {
             this._status.delete(path);
@@ -127,35 +428,33 @@ class NativeSyncEngine extends Linker<LinkParams> {
             return; // not on disk yet
         }
 
-        // stubs have no live doc — the replicated S3 hash stands in for R, so
-        // closed files classify without subscribing (projects have >1000s)
-        const remote = file.type === 'file' ? hash(norm(file.doc.text)) : pm.fileHash(path);
-        if (remote === undefined) {
+        if (file.type === 'stub') {
+            let base = this._base.get(file.uniqueId);
+            if (!base) {
+                this._base.set(file.uniqueId, working);
+                base = this._base.get(file.uniqueId);
+            }
+            if (!base) {
+                return;
+            }
+            const state = classify(base.hash, hash(working), base.hash, working);
+            this._status.set(path, state);
+            if (state !== 'conflicted') {
+                this._merges.delete(file.uniqueId);
+            }
             return;
         }
 
-        // seed the base on first sight (provisional until pull/push lands):
-        // live doc text when subscribed; for stubs use disk when it matches
-        // the S3 hash, else fetch S3 so the base can anchor a future merge
         let base = this._base.get(file.uniqueId);
         if (!base) {
-            if (file.type === 'file') {
-                this._base.set(file.uniqueId, norm(file.doc.text));
-            } else if (hash(working) === remote) {
-                this._base.set(file.uniqueId, working);
-            } else {
-                const [err, buf] = await tryCatch(async () => pm.fetchContent(file.uniqueId));
-                if (err) {
-                    return;
-                }
-                this._base.set(file.uniqueId, norm(buffer.toString(buf)));
-            }
+            this._base.set(file.uniqueId, norm(file.doc.text));
             base = this._base.get(file.uniqueId);
         }
         if (!base) {
             return;
         }
 
+        const remote = hash(norm(file.doc.text));
         const state = classify(base.hash, hash(working), remote, working);
         this._status.set(path, state);
         // merge resolved (markers gone) -> drop the stashed merge inputs
@@ -168,6 +467,13 @@ class NativeSyncEngine extends Linker<LinkParams> {
         const pm = this._projectManager;
         if (!pm) {
             return;
+        }
+        this._status.clear();
+        for (const op of this._local.values()) {
+            this._status.set(op.path, op.action);
+        }
+        for (const op of this._remote.values()) {
+            this._status.set(op.path, op.conflicted ? 'conflicted' : 'behind');
         }
         for (const [path, file] of pm.files) {
             if (file.type !== 'folder') {
@@ -221,18 +527,36 @@ class NativeSyncEngine extends Linker<LinkParams> {
             }
         }
 
+        const remoteOps = Array.from(this._remote.values());
+        const created = remoteOps
+            .filter((op): op is RemoteOp & { action: 'created' } => op.action === 'created')
+            .sort((a, b) => a.path.split('/').length - b.path.split('/').length);
+        const renamed = remoteOps.filter((op): op is RemoteOp & { action: 'renamed' } => op.action === 'renamed');
+        const deleted = remoteOps
+            .filter((op): op is RemoteOp & { action: 'deleted' } => op.action === 'deleted')
+            .sort((a, b) => b.path.split('/').length - a.path.split('/').length);
+
+        for (const op of renamed) {
+            await this._applyRename(op.from, op.path);
+            this._remote.delete(op.path);
+        }
+        for (const op of created) {
+            await this._applyCreate(op.path, op.type, await this._content(op));
+            this._remote.delete(op.path);
+        }
+        for (const op of deleted) {
+            await this._applyDelete(op.path);
+            this._remote.delete(op.path);
+        }
+
         const pulled: string[] = [];
         for (const [path, f] of pm.files) {
             if (f.type === 'folder') {
                 continue;
             }
-            // stubs subscribe on demand — only when there is something to pull
+            // pull is an exact remote operation: promote unloaded stubs so R is realtime doc.text
             let file = f;
             if (file.type === 'stub') {
-                const state = this._status.get(path);
-                if (state !== 'behind' && state !== 'both') {
-                    continue;
-                }
                 const promoted = await pm.subscribe(path);
                 if (!promoted) {
                     continue;
@@ -305,6 +629,29 @@ class NativeSyncEngine extends Linker<LinkParams> {
             }
         }
 
+        const ops = Array.from(this._local.values());
+        const added = ops
+            .filter((op): op is LocalOp & { action: 'added' } => op.action === 'added')
+            .sort((a, b) => a.path.split('/').length - b.path.split('/').length);
+        const renamed = ops.filter((op): op is LocalOp & { action: 'renamed' } => op.action === 'renamed');
+        const deleted = ops
+            .filter((op): op is LocalOp & { action: 'deleted' } => op.action === 'deleted')
+            .sort((a, b) => b.path.split('/').length - a.path.split('/').length);
+
+        for (const op of renamed) {
+            await pm.rename(op.from, op.path);
+            this._local.delete(op.path);
+        }
+        for (const op of added) {
+            const content = op.type === 'file' ? buffer.from((await this._read(folderUri, op.path)) ?? '') : undefined;
+            await pm.create(op.path, op.type, content);
+            this._local.delete(op.path);
+        }
+        for (const op of deleted) {
+            await pm.delete(op.path, op.type);
+            this._local.delete(op.path);
+        }
+
         for (const [path, f] of pm.files) {
             if (f.type === 'folder' || this._status.get(path) !== 'modified') {
                 continue;
@@ -334,12 +681,11 @@ class NativeSyncEngine extends Linker<LinkParams> {
             // re-check remote is still unchanged, synchronous with write()'s apply
             // so a remote op can't interleave — went behind mid-push, leave for pull
             if (base && norm(file.doc.text) !== base.text) {
-                // nothing saved, so no ack will release a doc promoted just now
                 if (fresh) {
                     this._promoted.delete(path);
-                    void this._release(path);
+                    await this._release(path);
                 }
-                continue;
+                throw fail`remote has changes — pull before pushing`;
             }
             // write() diffs against the live doc and marks dirty so save() flushes
             await pm.write(path, buffer.from(working));
@@ -383,7 +729,19 @@ class NativeSyncEngine extends Linker<LinkParams> {
 
         const recompute = (path: string) => void this.refresh(path);
         const onUpdate = this._events.on('asset:file:update', recompute);
-        // restatus on promote: R upgrades from the S3 hash to the live doc
+        const onCreate = this._events.on(
+            'asset:file:create',
+            (path, type, content) => void this._remoteCreate(path, type, content)
+        );
+        const onDelete = this._events.on('asset:file:delete', (path) => this._remoteDelete(path));
+        const onRename = this._events.on('asset:file:rename', (from, to) => void this._remoteRename(from, to));
+        const onLocalCreate = this._events.on('sync:file:create', (path, type) => this._localCreate(path, type));
+        const onLocalUpdate = this._events.on('sync:file:update', recompute);
+        const onLocalDelete = this._events.on('sync:file:delete', (path, type) => this._localDelete(path, type));
+        const onLocalRename = this._events.on('sync:file:rename', (from, to, type) =>
+            this._localRename(from, to, type)
+        );
+        // restatus on promote: remote upgrades from stub base to live doc
         const onSubscribed = this._events.on('asset:file:subscribed', recompute);
         const onSave = this._events.on('asset:file:save', (path: string) => {
             void this.refresh(path);
@@ -394,6 +752,13 @@ class NativeSyncEngine extends Linker<LinkParams> {
         });
         this._cleanup.push(async () => {
             this._events.off('asset:file:update', onUpdate);
+            this._events.off('asset:file:create', onCreate);
+            this._events.off('asset:file:delete', onDelete);
+            this._events.off('asset:file:rename', onRename);
+            this._events.off('sync:file:create', onLocalCreate);
+            this._events.off('sync:file:update', onLocalUpdate);
+            this._events.off('sync:file:delete', onLocalDelete);
+            this._events.off('sync:file:rename', onLocalRename);
             this._events.off('asset:file:subscribed', onSubscribed);
             this._events.off('asset:file:save', onSave);
         });
@@ -420,6 +785,8 @@ class NativeSyncEngine extends Linker<LinkParams> {
         this._projectId = undefined;
         this._branchId = undefined;
         this._status.clear();
+        this._local.clear();
+        this._remote.clear();
         this._merges.clear();
         this._promoted.clear();
 

--- a/src/sync/sync-engine.ts
+++ b/src/sync/sync-engine.ts
@@ -8,12 +8,15 @@ import type { EventEmitter } from '../utils/event-emitter';
 import { Linker } from '../utils/linker';
 import { signal } from '../utils/signal';
 import { norm } from '../utils/text';
-import { hash, relativePath, tryCatch } from '../utils/utils';
+import { hash, relativePath, tryCatch, withTimeout } from '../utils/utils';
 
 import { BaseStore } from './base-store';
 import { merge } from './merge';
 import { classify } from './status';
 import type { SyncState } from './status';
+
+const SAVE_TIMEOUT_MS = 30_000;
+const LOCAL_IGNORE_DIRS = new Set(['.pc', '.git', '.hg', '.svn', '.vscode', '.cursor']);
 
 type LinkParams = {
     folderUri: vscode.Uri;
@@ -22,7 +25,7 @@ type LinkParams = {
     branchId: string;
 };
 type LocalOp =
-    | { action: 'added'; path: string; type: 'file' | 'folder' }
+    | { action: 'added'; path: string; type: 'file' | 'folder'; hash?: string }
     | { action: 'deleted'; path: string; type: 'file' | 'folder' }
     | { action: 'renamed'; from: string; path: string; type: 'file' | 'folder' };
 type RemoteOp =
@@ -157,6 +160,23 @@ class NativeSyncEngine extends Linker<LinkParams> {
         return false;
     }
 
+    private _remoteChanged(path: string) {
+        const pm = this._projectManager;
+        if (!pm) {
+            return false;
+        }
+        for (const [p, file] of pm.files) {
+            if (!this._touches(p, path) || file.type !== 'file') {
+                continue;
+            }
+            const base = this._base.get(file.uniqueId);
+            if (base && norm(file.doc.text) !== base.text) {
+                return true;
+            }
+        }
+        return false;
+    }
+
     private _dropLocal(...paths: string[]) {
         for (const [path, op] of Array.from(this._local)) {
             const touches = paths.some(
@@ -246,12 +266,24 @@ class NativeSyncEngine extends Linker<LinkParams> {
         if (this._echo(`create:${type}:${path}`)) {
             return;
         }
+        const local = this._local.get(path);
+        if (local?.action === 'added' && local.type === type) {
+            const same = type === 'folder' || local.hash === hash(norm(buffer.toString(content)));
+            if (same) {
+                this._local.delete(path);
+                this._status.delete(path);
+                this._setRemote({ action: 'created', path, type, content });
+                return;
+            }
+            this._setRemote({ action: 'created', path, type, content }, true);
+            return;
+        }
         if (this._localTouches(path)) {
             this._setRemote({ action: 'created', path, type, content }, true);
             return;
         }
-        const working = type === 'file' ? await this._read(this._folderUri!, path) : undefined;
-        const same = type === 'file' && content.length > 0 && working === norm(buffer.toString(content));
+        const working = type === 'file' ? await this._readDisk(this._folderUri!, path) : undefined;
+        const same = type === 'file' && working === norm(buffer.toString(content));
         this._setRemote({ action: 'created', path, type, content }, working !== undefined && !same);
     }
 
@@ -365,19 +397,42 @@ class NativeSyncEngine extends Linker<LinkParams> {
         await this.keepCurrent(uri);
     }
 
-    private async _read(folderUri: vscode.Uri, path: string) {
-        const uri = vscode.Uri.joinPath(folderUri, path);
-        // prefer the open buffer so status reflects unsaved edits (live)
-        const open = vscode.workspace.textDocuments.find((d) => d.uri.toString() === uri.toString());
-        if (open && !open.isClosed) {
-            return norm(open.getText());
-        }
-        const [err, data] = await tryCatch(async () => vscode.workspace.fs.readFile(uri));
+    private async _readDisk(folderUri: vscode.Uri, path: string) {
+        const [err, data] = await tryCatch(async () =>
+            vscode.workspace.fs.readFile(vscode.Uri.joinPath(folderUri, path))
+        );
         return err ? undefined : norm(buffer.toString(data));
     }
 
-    private async _write(folderUri: vscode.Uri, path: string, text: string) {
-        await vscode.workspace.fs.writeFile(vscode.Uri.joinPath(folderUri, path), buffer.from(text));
+    private async _refreshLocalOnly(folderUri: vscode.Uri, base = '') {
+        const pm = this._projectManager;
+        if (!pm) {
+            return;
+        }
+        const dir = base ? vscode.Uri.joinPath(folderUri, base) : folderUri;
+        const [, entries] = await tryCatch(async () => vscode.workspace.fs.readDirectory(dir));
+        for (const [name, type] of entries ?? []) {
+            const path = base ? `${base}/${name}` : name;
+            if (LOCAL_IGNORE_DIRS.has(path.split('/')[0])) {
+                continue;
+            }
+            const kind = type === vscode.FileType.Directory ? 'folder' : type === vscode.FileType.File ? 'file' : '';
+            if (!kind) {
+                continue;
+            }
+            const text = kind === 'file' ? await this._readDisk(folderUri, path) : undefined;
+            if (!pm.files.has(path) && !this._remote.has(path) && !this._local.has(path)) {
+                this._setLocal({
+                    action: 'added',
+                    path,
+                    type: kind,
+                    hash: text === undefined ? undefined : hash(text)
+                });
+            }
+            if (kind === 'folder') {
+                await this._refreshLocalOnly(folderUri, path);
+            }
+        }
     }
 
     private _applyCreate(path: string, type: 'file' | 'folder', content: Uint8Array) {
@@ -385,6 +440,15 @@ class NativeSyncEngine extends Linker<LinkParams> {
             const done = (err?: Error) => (err ? reject(err) : resolve());
             if (!this._events.emit('sync:file:apply:create', path, type, content, done)) {
                 resolve();
+            }
+        });
+    }
+
+    private _applyUpdate(path: string, text: string) {
+        return new Promise<void>((resolve, reject) => {
+            const done = (err?: Error) => (err ? reject(err) : resolve());
+            if (!this._events.emit('sync:file:apply:update', path, buffer.from(text), done)) {
+                reject(fail`disk apply update handler missing`);
             }
         });
     }
@@ -407,6 +471,34 @@ class NativeSyncEngine extends Linker<LinkParams> {
         });
     }
 
+    private async _save(path: string) {
+        const pm = this._projectManager;
+        if (!pm) {
+            return;
+        }
+        let listener: ((p: string) => void) | undefined;
+        const saved = new Promise<void>((resolve) => {
+            listener = this._events.on('asset:file:save', (p) => {
+                if (p !== path || !listener) {
+                    return;
+                }
+                this._events.off('asset:file:save', listener);
+                listener = undefined;
+                resolve();
+            });
+        });
+        const [err] = await tryCatch(async () => {
+            pm.save(path);
+            await withTimeout(saved, SAVE_TIMEOUT_MS, `save timed out for ${path}`);
+        });
+        if (listener) {
+            this._events.off('asset:file:save', listener);
+        }
+        if (err) {
+            throw err;
+        }
+    }
+
     private async _refresh(path: string) {
         const folderUri = this._folderUri;
         const pm = this._projectManager;
@@ -421,6 +513,10 @@ class NativeSyncEngine extends Linker<LinkParams> {
         }
         const local = this._local.get(path);
         if (local) {
+            if (local.action === 'deleted' && this._remoteChanged(path)) {
+                this._status.set(path, 'conflicted');
+                return;
+            }
             this._status.set(path, local.action);
             return;
         }
@@ -430,9 +526,17 @@ class NativeSyncEngine extends Linker<LinkParams> {
             return;
         }
 
-        const working = await this._read(folderUri, path);
+        const working = await this._readDisk(folderUri, path);
         if (working === undefined) {
-            return; // not on disk yet
+            if (this._localOpTouches(path)) {
+                return;
+            }
+            if (this._base.get(file.uniqueId)) {
+                this._setLocal({ action: 'deleted', path, type: 'file' });
+            } else {
+                this._setRemote({ action: 'created', path, type: 'file', content: new Uint8Array() });
+            }
+            return;
         }
 
         if (file.type === 'stub') {
@@ -472,7 +576,8 @@ class NativeSyncEngine extends Linker<LinkParams> {
 
     private async _refreshAll() {
         const pm = this._projectManager;
-        if (!pm) {
+        const folderUri = this._folderUri;
+        if (!pm || !folderUri) {
             return;
         }
         this._status.clear();
@@ -487,6 +592,7 @@ class NativeSyncEngine extends Linker<LinkParams> {
                 await this._refresh(path);
             }
         }
+        await this._refreshLocalOnly(folderUri);
         this.changed.set((v) => v + 1);
     }
 
@@ -525,8 +631,6 @@ class NativeSyncEngine extends Linker<LinkParams> {
             return;
         }
 
-        // flush open buffers so merges write to disk and reload cleanly
-        await vscode.workspace.saveAll(false);
         await this._refreshAll();
         for (const state of this._status.values()) {
             if (state === 'conflicted') {
@@ -574,7 +678,7 @@ class NativeSyncEngine extends Linker<LinkParams> {
             if (file.type !== 'file') {
                 continue;
             }
-            const working = await this._read(folderUri, path);
+            const working = await this._readDisk(folderUri, path);
             if (working === undefined) {
                 continue;
             }
@@ -584,7 +688,7 @@ class NativeSyncEngine extends Linker<LinkParams> {
             // unseen, or no local divergence -> fast-forward to remote
             if (!base || working === base.text) {
                 if (remote !== working) {
-                    await this._write(folderUri, path, remote);
+                    await this._applyUpdate(path, remote);
                 }
                 this._base.set(file.uniqueId, remote);
                 continue;
@@ -605,7 +709,7 @@ class NativeSyncEngine extends Linker<LinkParams> {
                 // stash the three sides for the merge editor (base advances below)
                 this._merges.set(file.uniqueId, { base: base.text, local: working, remote });
             }
-            await this._write(folderUri, path, result.text);
+            await this._applyUpdate(path, result.text);
             this._base.set(file.uniqueId, remote);
         }
 
@@ -627,8 +731,6 @@ class NativeSyncEngine extends Linker<LinkParams> {
             return;
         }
 
-        // flush open buffers so the pushed content matches the editor
-        await vscode.workspace.saveAll(false);
         await this._refreshAll();
         for (const state of this._status.values()) {
             if (state === 'behind' || state === 'both' || state === 'conflicted') {
@@ -646,6 +748,9 @@ class NativeSyncEngine extends Linker<LinkParams> {
             .sort((a, b) => b.path.split('/').length - a.path.split('/').length);
 
         for (const op of renamed) {
+            if (this._remoteChanged(op.from)) {
+                throw fail`remote has changes — pull before pushing`;
+            }
             const key = `rename:${op.from}:${op.path}`;
             this._echoes.add(key);
             const [err] = await tryCatch(() => pm.rename(op.from, op.path));
@@ -656,7 +761,8 @@ class NativeSyncEngine extends Linker<LinkParams> {
             this._local.delete(op.path);
         }
         for (const op of added) {
-            const content = op.type === 'file' ? buffer.from((await this._read(folderUri, op.path)) ?? '') : undefined;
+            const content =
+                op.type === 'file' ? buffer.from((await this._readDisk(folderUri, op.path)) ?? '') : undefined;
             const key = `create:${op.type}:${op.path}`;
             this._echoes.add(key);
             const [err] = await tryCatch(() => pm.create(op.path, op.type, content));
@@ -667,6 +773,9 @@ class NativeSyncEngine extends Linker<LinkParams> {
             this._local.delete(op.path);
         }
         for (const op of deleted) {
+            if (this._remoteChanged(op.path)) {
+                throw fail`remote has changes — pull before pushing`;
+            }
             const key = `delete:${op.path}`;
             this._echoes.add(key);
             const [err] = await tryCatch(() => pm.delete(op.path, op.type));
@@ -681,7 +790,7 @@ class NativeSyncEngine extends Linker<LinkParams> {
             if (f.type === 'folder' || this._status.get(path) !== 'modified') {
                 continue;
             }
-            const working = await this._read(folderUri, path);
+            const working = await this._readDisk(folderUri, path);
             if (working === undefined) {
                 continue;
             }
@@ -714,7 +823,7 @@ class NativeSyncEngine extends Linker<LinkParams> {
             }
             // write() diffs against the live doc and marks dirty so save() flushes
             await pm.write(path, buffer.from(working));
-            pm.save(path);
+            await this._save(path);
             this._base.set(file.uniqueId, working);
         }
 
@@ -733,7 +842,7 @@ class NativeSyncEngine extends Linker<LinkParams> {
         if (base === undefined) {
             return;
         }
-        await this._write(folderUri, path, base);
+        await this._applyUpdate(path, base);
         await this._refreshAll();
     }
 

--- a/src/sync/sync-engine.ts
+++ b/src/sync/sync-engine.ts
@@ -12,6 +12,7 @@ import { norm } from '../utils/text';
 import { hash, relativePath, tryCatch, withTimeout } from '../utils/utils';
 
 import { BaseStore } from './base-store';
+import { hasConflictMarkers } from './markers';
 import { merge } from './merge';
 import { classify } from './status';
 import type { SyncState } from './status';
@@ -53,8 +54,6 @@ class NativeSyncEngine extends Linker<LinkParams> {
     private _local = new Map<string, LocalOp>();
 
     private _remote = new Map<string, RemoteOp>();
-
-    private _merges = new Map<number, { base: string; local: string; remote: string }>();
 
     // push-promoted stubs awaiting their flush ack before release
     private _promoted = new Set<string>();
@@ -339,10 +338,10 @@ class NativeSyncEngine extends Linker<LinkParams> {
     // base/local/remote inputs for a conflicted file's 3-way merge editor
     mergeInputs(path: string) {
         const file = this._projectManager?.files.get(path);
-        if (!file || file.type !== 'file') {
+        if (!file || file.type === 'folder') {
             return undefined;
         }
-        return this._merges.get(file.uniqueId);
+        return this._base.conflict(file.uniqueId);
     }
 
     async acceptIncoming(uri: vscode.Uri) {
@@ -610,11 +609,16 @@ class NativeSyncEngine extends Linker<LinkParams> {
             if (!base) {
                 return;
             }
+            const conflict = this._base.conflict(file.uniqueId);
+            if (conflict) {
+                if (hasConflictMarkers(working)) {
+                    this._status.set(path, 'conflicted');
+                    return;
+                }
+                this._base.deleteConflict(file.uniqueId);
+            }
             const state = classify(base.hash, hash(working), base.hash, working);
             this._status.set(path, state);
-            if (state !== 'conflicted') {
-                this._merges.delete(file.uniqueId);
-            }
             return;
         }
 
@@ -627,13 +631,17 @@ class NativeSyncEngine extends Linker<LinkParams> {
             return;
         }
 
+        const conflict = this._base.conflict(file.uniqueId);
+        if (conflict) {
+            if (hasConflictMarkers(working)) {
+                this._status.set(path, 'conflicted');
+                return;
+            }
+            this._base.deleteConflict(file.uniqueId);
+        }
         const remote = hash(norm(file.doc.text));
         const state = classify(base.hash, hash(working), remote, working);
         this._status.set(path, state);
-        // merge resolved (markers gone) -> drop the stashed merge inputs
-        if (state !== 'conflicted') {
-            this._merges.delete(file.uniqueId);
-        }
     }
 
     private async _refreshAll() {
@@ -769,7 +777,7 @@ class NativeSyncEngine extends Linker<LinkParams> {
             const result = merge(base.text, working, remote);
             if (result.conflicted) {
                 // stash the three sides for the merge editor (base advances below)
-                this._merges.set(file.uniqueId, { base: base.text, local: working, remote });
+                this._base.setConflict(file.uniqueId, { base: base.text, local: working, remote });
             }
             await this._applyUpdate(path, result.text);
             this._base.set(file.uniqueId, remote);
@@ -989,7 +997,6 @@ class NativeSyncEngine extends Linker<LinkParams> {
         this._status.clear();
         this._local.clear();
         this._remote.clear();
-        this._merges.clear();
         this._promoted.clear();
         this._echoes.clear();
         this._ignoring = (_uri: vscode.Uri) => false;

--- a/src/sync/sync-engine.ts
+++ b/src/sync/sync-engine.ts
@@ -852,7 +852,7 @@ class NativeSyncEngine extends Linker<LinkParams> {
         }
         await super.unlink();
 
-        await this._base.load(projectId, branchId);
+        await this._base.load(projectId, branchId, hash(folderUri.toString()));
 
         this._folderUri = folderUri;
         this._projectManager = projectManager;

--- a/src/sync/sync-engine.ts
+++ b/src/sync/sync-engine.ts
@@ -72,6 +72,20 @@ class NativeSyncEngine extends Linker<LinkParams> {
         return this._status.get(path) ?? 'clean';
     }
 
+    decorationStatus(path: string) {
+        const op = this._remote.get(path);
+        if (!op || op.conflicted) {
+            return this.status(path);
+        }
+        if (op.action === 'created') {
+            return 'added';
+        }
+        if (op.action === 'deleted') {
+            return 'deleted';
+        }
+        return 'renamed';
+    }
+
     statuses() {
         return new Map(this._status);
     }

--- a/src/sync/sync-engine.ts
+++ b/src/sync/sync-engine.ts
@@ -56,6 +56,8 @@ class NativeSyncEngine extends Linker<LinkParams> {
     // push-promoted stubs awaiting their flush ack before release
     private _promoted = new Set<string>();
 
+    private _echoes = new Set<string>();
+
     error = signal<Error | undefined>(undefined);
 
     changed = signal(0);
@@ -218,7 +220,18 @@ class NativeSyncEngine extends Linker<LinkParams> {
         this._setLocal({ action: 'renamed', from, path, type });
     }
 
+    private _echo(key: string) {
+        if (!this._echoes.has(key)) {
+            return false;
+        }
+        this._echoes.delete(key);
+        return true;
+    }
+
     private async _remoteCreate(path: string, type: 'file' | 'folder', content: Uint8Array) {
+        if (this._echo(`create:${type}:${path}`)) {
+            return;
+        }
         if (this._localTouches(path)) {
             this._setRemote({ action: 'created', path, type, content }, true);
             return;
@@ -229,10 +242,16 @@ class NativeSyncEngine extends Linker<LinkParams> {
     }
 
     private _remoteDelete(path: string) {
+        if (this._echo(`delete:${path}`)) {
+            return;
+        }
         this._setRemote({ action: 'deleted', path }, this._localTouches(path));
     }
 
     private async _remoteRename(from: string, path: string) {
+        if (this._echo(`rename:${from}:${path}`)) {
+            return;
+        }
         this._status.delete(from);
         const op = { action: 'renamed' as const, from, path };
         const conflicted = this._localOpTouches(from) || this._localTouches(path);
@@ -613,16 +632,34 @@ class NativeSyncEngine extends Linker<LinkParams> {
             .sort((a, b) => b.path.split('/').length - a.path.split('/').length);
 
         for (const op of renamed) {
-            await pm.rename(op.from, op.path);
+            const key = `rename:${op.from}:${op.path}`;
+            this._echoes.add(key);
+            const [err] = await tryCatch(() => pm.rename(op.from, op.path));
+            this._echoes.delete(key);
+            if (err) {
+                throw err;
+            }
             this._local.delete(op.path);
         }
         for (const op of added) {
             const content = op.type === 'file' ? buffer.from((await this._read(folderUri, op.path)) ?? '') : undefined;
-            await pm.create(op.path, op.type, content);
+            const key = `create:${op.type}:${op.path}`;
+            this._echoes.add(key);
+            const [err] = await tryCatch(() => pm.create(op.path, op.type, content));
+            this._echoes.delete(key);
+            if (err) {
+                throw err;
+            }
             this._local.delete(op.path);
         }
         for (const op of deleted) {
-            await pm.delete(op.path, op.type);
+            const key = `delete:${op.path}`;
+            this._echoes.add(key);
+            const [err] = await tryCatch(() => pm.delete(op.path, op.type));
+            this._echoes.delete(key);
+            if (err) {
+                throw err;
+            }
             this._local.delete(op.path);
         }
 
@@ -763,6 +800,7 @@ class NativeSyncEngine extends Linker<LinkParams> {
         this._remote.clear();
         this._merges.clear();
         this._promoted.clear();
+        this._echoes.clear();
 
         this._log.info(`unlinked ${folderUri.toString()}`);
         return { folderUri, projectManager, projectId, branchId };

--- a/src/sync/sync-engine.ts
+++ b/src/sync/sync-engine.ts
@@ -551,26 +551,40 @@ class NativeSyncEngine extends Linker<LinkParams> {
             this._promoted.add(path);
             fresh = true;
         }
+        // release a freshly-promoted stub on any exit that won't flush; the happy
+        // path leaves it for the save ack (releasing before flush races the save)
+        const releaseFresh = async () => {
+            if (fresh) {
+                this._promoted.delete(path);
+                await this._release(path);
+            }
+        };
         if (file.type !== 'file') {
+            await releaseFresh();
             return;
         }
         const base = this._base.get(file.uniqueId);
         // re-check remote is still unchanged, synchronous with write()'s apply
         // so a remote op can't interleave — went behind mid-push, leave for pull
         if (base && norm(file.doc.text) !== base.text) {
-            if (fresh) {
-                this._promoted.delete(path);
-                await this._release(path);
-            }
+            await releaseFresh();
             throw fail`remote has changes — pull before pushing`;
         }
         if (norm(file.doc.text) === working) {
             this._base.set(file.uniqueId, working);
+            await releaseFresh();
             return;
         }
-        // write() diffs against the live doc and marks dirty so save() flushes
-        await pm.write(path, buffer.from(working));
-        await this._save(path);
+        // write() diffs against the live doc and marks dirty so save() flushes;
+        // release on failure too — base isn't advanced, so the next push redoes it
+        const [err] = await tryCatch(async () => {
+            await pm.write(path, buffer.from(working));
+            await this._save(path);
+        });
+        if (err) {
+            await releaseFresh();
+            throw err;
+        }
         this._base.set(file.uniqueId, working);
     }
 

--- a/src/sync/sync-engine.ts
+++ b/src/sync/sync-engine.ts
@@ -1207,7 +1207,9 @@ class NativeSyncEngine extends Linker<LinkParams> {
                 continue;
             }
             await this._sendRestOp({ type: 'update_text', id: item.id, text });
-            await this._refreshAll();
+            // per-path refresh, not a full rescan — the modified set is a fixed snapshot
+            // and these ops don't touch other paths; one full refresh follows below
+            await this.refresh(path);
         }
 
         await this._base.flush();

--- a/src/sync/sync-engine.ts
+++ b/src/sync/sync-engine.ts
@@ -41,6 +41,8 @@ class NativeSyncEngine extends Linker<LinkParams> {
 
     error = signal<Error | undefined>(undefined);
 
+    changed = signal(0);
+
     constructor({ events, storageUri }: { events: EventEmitter<EventMap>; storageUri: vscode.Uri }) {
         super();
         this._events = events;
@@ -54,6 +56,24 @@ class NativeSyncEngine extends Linker<LinkParams> {
     statuses() {
         return new Map(this._status);
     }
+
+    baseText(path: string) {
+        const file = this._projectManager?.files.get(path);
+        if (!file || file.type !== 'file') {
+            return undefined;
+        }
+        return this._base.get(file.uniqueId)?.text;
+    }
+
+    // live remote content (R) for the incoming diff view
+    remoteText(path: string) {
+        const file = this._projectManager?.files.get(path);
+        if (!file || file.type !== 'file') {
+            return undefined;
+        }
+        return norm(file.doc.text);
+    }
+
 
     private async _read(folderUri: vscode.Uri, path: string) {
         const uri = vscode.Uri.joinPath(folderUri, path);
@@ -108,6 +128,7 @@ class NativeSyncEngine extends Linker<LinkParams> {
                 await this._refresh(path);
             }
         }
+        this.changed.set((v) => v + 1);
     }
 
     // recompute all tracked files (used after external changes)

--- a/src/sync/sync-engine.ts
+++ b/src/sync/sync-engine.ts
@@ -152,10 +152,8 @@ class NativeSyncEngine extends Linker<LinkParams> {
     }
 
     private _localTouches(path: string) {
-        for (const op of this._local.values()) {
-            if (this._touches(op.path, path) || (op.action === 'renamed' && this._touches(op.from, path))) {
-                return true;
-            }
+        if (this._localOpTouches(path)) {
+            return true;
         }
         for (const [p, state] of this._status) {
             if (this._touches(p, path) && (state === 'modified' || state === 'both' || state === 'conflicted')) {
@@ -348,11 +346,15 @@ class NativeSyncEngine extends Linker<LinkParams> {
         return this._base.conflict(file.uniqueId);
     }
 
-    async acceptIncoming(uri: vscode.Uri) {
-        const [err] = (await this._mutex.atomic(['sync'], () => tryCatch(() => this._acceptIncoming(uri)))) ?? [];
+    private async _locked(fn: () => Promise<void>) {
+        const [err] = (await this._mutex.atomic(['sync'], () => tryCatch(fn))) ?? [];
         if (err) {
             throw err;
         }
+    }
+
+    async acceptIncoming(uri: vscode.Uri) {
+        return this._locked(() => this._acceptIncoming(uri));
     }
 
     private async _acceptIncoming(uri: vscode.Uri) {
@@ -384,10 +386,7 @@ class NativeSyncEngine extends Linker<LinkParams> {
     }
 
     async keepCurrent(uri: vscode.Uri) {
-        const [err] = (await this._mutex.atomic(['sync'], () => tryCatch(() => this._keepCurrent(uri)))) ?? [];
-        if (err) {
-            throw err;
-        }
+        return this._locked(() => this._keepCurrent(uri));
     }
 
     private async _keepCurrent(uri: vscode.Uri) {
@@ -410,10 +409,6 @@ class NativeSyncEngine extends Linker<LinkParams> {
             }
         }
         await this._refreshAll();
-    }
-
-    async markResolved(uri: vscode.Uri) {
-        await this.keepCurrent(uri);
     }
 
     private async _readDisk(folderUri: vscode.Uri, path: string) {
@@ -712,10 +707,7 @@ class NativeSyncEngine extends Linker<LinkParams> {
     }
 
     async pull() {
-        const [err] = (await this._mutex.atomic(['sync'], () => tryCatch(() => this._pull()))) ?? [];
-        if (err) {
-            throw err;
-        }
+        return this._locked(() => this._pull());
     }
 
     // fetch + 3-way merge: bring remote changes into the working tree.
@@ -821,10 +813,7 @@ class NativeSyncEngine extends Linker<LinkParams> {
     // push: submit local edits as OT ops + flush to S3. fast-forward only —
     // rejected if any file is behind/conflicted (no force push; pull first).
     async push() {
-        const [err] = (await this._mutex.atomic(['sync'], () => tryCatch(() => this._push()))) ?? [];
-        if (err) {
-            throw err;
-        }
+        return this._locked(() => this._push());
     }
 
     private async _push() {
@@ -907,10 +896,7 @@ class NativeSyncEngine extends Linker<LinkParams> {
 
     // revert a file's working copy to the base (git restore). destructive.
     async discard(uri: vscode.Uri) {
-        const [err] = (await this._mutex.atomic(['sync'], () => tryCatch(() => this._discard(uri)))) ?? [];
-        if (err) {
-            throw err;
-        }
+        return this._locked(() => this._discard(uri));
     }
 
     private async _discard(uri: vscode.Uri) {

--- a/src/sync/sync-engine.ts
+++ b/src/sync/sync-engine.ts
@@ -1,11 +1,9 @@
 import * as vscode from 'vscode';
 
-import type { Rest, SyncItem, SyncPullResponse, SyncPushOp } from '../connections/rest';
 import { Disk } from '../disk';
 import type { ProjectManager } from '../project-manager';
 import type { EventMap } from '../typings/event-map';
 import * as buffer from '../utils/buffer';
-import { Debouncer } from '../utils/debouncer';
 import { fail } from '../utils/error';
 import type { EventEmitter } from '../utils/event-emitter';
 import { Linker } from '../utils/linker';
@@ -21,14 +19,12 @@ import { classify } from './status';
 import type { SyncState } from './status';
 
 const SAVE_TIMEOUT_MS = 30_000;
-const REMOTE_REFRESH_DELAY = 500;
 
 type LinkParams = {
     folderUri: vscode.Uri;
     projectManager: ProjectManager;
     projectId: number;
     branchId: string;
-    rest?: Rest;
 };
 type LocalOp =
     | { action: 'added'; path: string; type: 'file' | 'folder'; hash?: string }
@@ -53,12 +49,6 @@ class NativeSyncEngine extends Linker<LinkParams> {
     private _projectId?: number;
 
     private _branchId?: string;
-
-    private _rest?: Rest;
-
-    private _remoteSnapshot?: SyncPullResponse;
-
-    private _refreshRemoteDebouncer = new Debouncer<void>(REMOTE_REFRESH_DELAY);
 
     private _status = new Map<string, SyncState>();
 
@@ -114,9 +104,6 @@ class NativeSyncEngine extends Linker<LinkParams> {
     }
 
     baseText(path: string) {
-        if (this._restMode()) {
-            return this._base.byPath(path)?.text;
-        }
         const file = this._projectManager?.files.get(path);
         if (!file || file.type === 'folder') {
             const op = this._local.get(path);
@@ -137,77 +124,6 @@ class NativeSyncEngine extends Linker<LinkParams> {
             return target;
         }
         return this._folderUri ? relativePath(target, this._folderUri) : target.path;
-    }
-
-    private _restMode() {
-        return !!this._rest && this._projectId !== undefined && this._branchId !== undefined;
-    }
-
-    private _remoteItem(path: string) {
-        return this._remoteSnapshot?.items.find((item) => item.path === path);
-    }
-
-    private _remoteItemById(id: number) {
-        return this._remoteSnapshot?.items.find((item) => item.id === id);
-    }
-
-    private _remoteText(item: SyncItem) {
-        return norm(item.type === 'file' ? (item.text ?? '') : '');
-    }
-
-    private _allRestPaths() {
-        const paths = new Set<string>();
-        for (const item of this._remoteSnapshot?.items ?? []) {
-            paths.add(item.path);
-        }
-        for (const item of this._base.items()) {
-            if (item.path) {
-                paths.add(item.path);
-                const remote = item.id === undefined ? undefined : this._remoteItemById(item.id);
-                if (remote) {
-                    paths.add(remote.path);
-                }
-            }
-        }
-        for (const op of this._local.values()) {
-            paths.add(op.path);
-            if (op.action === 'renamed') {
-                paths.add(op.from);
-            }
-        }
-        return paths;
-    }
-
-    private async _fetchRemote() {
-        const rest = this._rest;
-        const projectId = this._projectId;
-        const branchId = this._branchId;
-        if (!rest || projectId === undefined || branchId === undefined) {
-            return;
-        }
-        this._remoteSnapshot = await rest.syncPull(projectId, branchId);
-    }
-
-    private async _queueRemoteRefresh() {
-        if (!this._restMode()) {
-            return;
-        }
-        // serialize with pull/push so a concurrent fetch+refresh can't swap
-        // _remoteSnapshot mid-pull and advance the base past disk
-        await tryCatch(
-            this._refreshRemoteDebouncer.debounce('remote', async () => {
-                const [err] =
-                    (await this._mutex.atomic(['sync'], () =>
-                        tryCatch(async () => {
-                            await this._fetchRemote();
-                            await this._refreshAll();
-                        })
-                    )) ?? [];
-                if (err) {
-                    this.error.set(() => err);
-                }
-            })
-        );
     }
 
     private _setLocal(op: LocalOp) {
@@ -406,10 +322,6 @@ class NativeSyncEngine extends Linker<LinkParams> {
 
     // remote content for the incoming diff view; stubs are promoted only while read
     async remoteText(path: string) {
-        if (this._restMode()) {
-            const item = this._remoteItem(path);
-            return item?.type === 'file' ? this._remoteText(item) : undefined;
-        }
         const pm = this._projectManager;
         const file = pm?.files.get(path);
         if (!pm || !file || file.type === 'folder') {
@@ -429,10 +341,6 @@ class NativeSyncEngine extends Linker<LinkParams> {
 
     // base/local/remote inputs for a conflicted file's 3-way merge editor
     mergeInputs(path: string) {
-        if (this._restMode()) {
-            const item = this._base.byPath(path);
-            return item?.id === undefined ? undefined : this._base.conflict(item.id);
-        }
         const file = this._projectManager?.files.get(path);
         if (!file || file.type === 'folder') {
             return undefined;
@@ -544,7 +452,7 @@ class NativeSyncEngine extends Linker<LinkParams> {
                 continue;
             }
             const text = kind === 'file' ? await this._readDisk(folderUri, path) : undefined;
-            const tracked = this._restMode() ? this._base.byPath(path) || this._remoteItem(path) : pm.files.has(path);
+            const tracked = pm.files.has(path);
             if (!tracked && !this._remote.has(path) && !this._local.has(path)) {
                 this._setLocal({
                     action: 'added',
@@ -671,124 +579,7 @@ class NativeSyncEngine extends Linker<LinkParams> {
         this._base.set(file.uniqueId, working);
     }
 
-    private async _refreshRest(path: string) {
-        const folderUri = this._folderUri;
-        if (!folderUri) {
-            return;
-        }
-
-        const local = this._local.get(path);
-        const base = this._base.byPath(path);
-        const remote = this._remoteItem(path);
-        const moved = base?.id === undefined ? undefined : this._remoteItemById(base.id);
-        const remoteBase = remote ? this._base.get(remote.id) : undefined;
-
-        if (remoteBase?.path && remoteBase.path !== remote?.path) {
-            return;
-        }
-
-        if (moved && base?.path && moved.path !== base.path) {
-            this._status.delete(base.path);
-            const from = await this._readDisk(folderUri, base.path);
-            const to = await this._readDisk(folderUri, moved.path);
-            const conflicted =
-                this._localOpTouches(base.path) ||
-                this._localTouches(moved.path) ||
-                from !== base.text ||
-                to !== undefined;
-            this._setRemote({ action: 'renamed', from: base.path, path: moved.path }, conflicted);
-            return;
-        }
-
-        if (local) {
-            if (local.action === 'deleted' && remote && base && this._remoteText(remote) !== base.text) {
-                // server edited a file you deleted: the edit wins as an incoming restore —
-                // pull brings it back (visible); re-delete + push if you still want it gone
-                const content = remote.type === 'file' ? buffer.from(this._remoteText(remote)) : new Uint8Array();
-                this._setRemote({ action: 'created', path, type: remote.type, content });
-                return;
-            }
-            this._status.set(path, local.action);
-            return;
-        }
-
-        const working = await this._readDisk(folderUri, path);
-        if (!base && !remote) {
-            this._status.delete(path);
-            return;
-        }
-
-        if (remote && !base) {
-            if (remote.type === 'folder') {
-                if (await this._exists(path)) {
-                    this._base.setItem(remote);
-                    this._status.delete(path);
-                } else {
-                    this._setRemote({ action: 'created', path, type: 'folder', content: new Uint8Array() });
-                }
-                return;
-            }
-            const text = this._remoteText(remote);
-            if (working === undefined) {
-                this._setRemote({ action: 'created', path, type: 'file', content: buffer.from(text) });
-                return;
-            }
-            this._base.setItem(remote);
-            this._status.set(path, working === text ? 'clean' : 'modified');
-            return;
-        }
-
-        if (base && !remote) {
-            if (working !== undefined && working !== base.text) {
-                this._status.set(path, 'conflicted');
-            } else {
-                this._setRemote({ action: 'deleted', path });
-            }
-            return;
-        }
-
-        if (!base || !remote || remote.type === 'folder') {
-            this._status.delete(path);
-            return;
-        }
-
-        if (working === undefined) {
-            if (this._remoteText(remote) !== base.text) {
-                // server edited a file that's gone locally — restore it on pull, not a blind conflict
-                this._setRemote({
-                    action: 'created',
-                    path,
-                    type: 'file',
-                    content: buffer.from(this._remoteText(remote))
-                });
-                return;
-            }
-            this._setLocal({ action: 'deleted', path, type: 'file' });
-            return;
-        }
-
-        const conflict = base.id === undefined ? undefined : this._base.conflict(base.id);
-        if (conflict) {
-            if (hasConflictMarkers(working)) {
-                this._status.set(path, 'conflicted');
-                return;
-            }
-            if (base.id !== undefined) {
-                this._base.deleteConflict(base.id);
-            }
-        }
-
-        const remoteText = this._remoteText(remote);
-        const state = classify(base.hash, hash(working), hash(remoteText), working);
-        this._status.set(path, state);
-    }
-
     private async _refresh(path: string) {
-        if (this._restMode()) {
-            await this._refreshRest(path);
-            return;
-        }
-
         const folderUri = this._folderUri;
         const pm = this._projectManager;
         if (!folderUri || !pm) {
@@ -878,17 +669,6 @@ class NativeSyncEngine extends Linker<LinkParams> {
         if (!pm || !folderUri) {
             return;
         }
-        if (this._restMode()) {
-            this._status.clear();
-            this._remote.clear();
-            for (const path of this._allRestPaths()) {
-                await this._refreshRest(path);
-            }
-            await this._refreshLocalOnly(folderUri);
-            this.changed.set((v) => v + 1);
-            return;
-        }
-
         this._status.clear();
         for (const op of this._local.values()) {
             this._status.set(op.path, op.action);
@@ -931,95 +711,16 @@ class NativeSyncEngine extends Linker<LinkParams> {
         await tryCatch(async () => pm.unsubscribe(path));
     }
 
-    // fetch + 3-way merge: bring remote changes into the working tree.
-    // refuses while a previous merge is unresolved (git-like).
-    private async _pullRest() {
-        const folderUri = this._folderUri;
-        if (!folderUri) {
-            return;
-        }
-
-        await this._fetchRemote();
-        await this._refreshAll();
-        for (const state of this._status.values()) {
-            if (state === 'conflicted') {
-                throw fail`resolve conflicts before pulling`;
-            }
-        }
-
-        const remoteOps = Array.from(this._remote.values());
-        const created = remoteOps
-            .filter((op): op is RemoteOp & { action: 'created' } => op.action === 'created')
-            .sort((a, b) => a.path.split('/').length - b.path.split('/').length);
-        const renamed = remoteOps.filter((op): op is RemoteOp & { action: 'renamed' } => op.action === 'renamed');
-        const deleted = remoteOps
-            .filter((op): op is RemoteOp & { action: 'deleted' } => op.action === 'deleted')
-            .sort((a, b) => b.path.split('/').length - a.path.split('/').length);
-
-        for (const op of renamed) {
-            await this._applyRename(op.from, op.path);
-            this._remote.delete(op.path);
-        }
-        for (const op of created) {
-            await this._applyCreate(op.path, op.type, await this._content(op));
-            this._remote.delete(op.path);
-            // a restore over a path you deleted locally supersedes that delete
-            this._local.delete(op.path);
-        }
-        for (const op of deleted) {
-            await this._applyDelete(op.path);
-            this._remote.delete(op.path);
-        }
-
-        const conflicts: [number, { base: string; local: string; remote: string }][] = [];
-        for (const item of this._remoteSnapshot?.items ?? []) {
-            if (item.type !== 'file') {
-                continue;
-            }
-            const remote = this._remoteText(item);
-            const working = await this._readDisk(folderUri, item.path);
-            const base = this._base.byPath(item.path);
-            if (working === undefined) {
-                continue;
-            }
-            if (!base || working === base.text) {
-                if (remote !== working) {
-                    await this._applyUpdate(item.path, remote);
-                }
-                continue;
-            }
-            if (remote === base.text) {
-                continue;
-            }
-
-            const result = merge(base.text, working, remote);
-            if (result.conflicted) {
-                conflicts.push([item.id, { base: base.text, local: working, remote }]);
-            }
-            await this._applyUpdate(item.path, result.text);
-        }
-
-        if (this._remoteSnapshot) {
-            this._base.setSnapshot(this._remoteSnapshot);
-            for (const [id, conflict] of conflicts) {
-                this._base.setConflict(id, conflict);
-            }
-        }
-        await this._base.flush();
-        await this._refreshAll();
-    }
-
     async pull() {
-        const [err] =
-            (await this._mutex.atomic(['sync'], () =>
-                tryCatch(() => (this._restMode() ? this._pullRest() : this._pullLive()))
-            )) ?? [];
+        const [err] = (await this._mutex.atomic(['sync'], () => tryCatch(() => this._pull()))) ?? [];
         if (err) {
             throw err;
         }
     }
 
-    private async _pullLive() {
+    // fetch + 3-way merge: bring remote changes into the working tree.
+    // refuses while a previous merge is unresolved (git-like).
+    private async _pull() {
         const folderUri = this._folderUri;
         const pm = this._projectManager;
         if (!folderUri || !pm) {
@@ -1117,118 +818,16 @@ class NativeSyncEngine extends Linker<LinkParams> {
         await this._refreshAll();
     }
 
-    private async _sendRestOp(op: SyncPushOp) {
-        const rest = this._rest;
-        const projectId = this._projectId;
-        const branchId = this._branchId;
-        if (!rest || projectId === undefined || branchId === undefined) {
-            return;
-        }
-        const seq = this._base.seq + 1;
-        const snapshot = await rest.syncPush(projectId, branchId, {
-            clientId: this._base.clientId,
-            seq,
-            base: this._base.base,
-            ops: [op]
-        });
-        this._base.setSeq(seq);
-        this._base.setSnapshot(snapshot);
-        this._remoteSnapshot = snapshot;
-        // persist seq+base per op so a crash mid-batch resumes instead of
-        // deadlocking on a stale seq the server already consumed
-        await this._base.flush();
-    }
-
-    private async _pushRest() {
-        const folderUri = this._folderUri;
-        if (!folderUri) {
-            return;
-        }
-
-        await this._fetchRemote();
-        if (!this._base.base && this._remoteSnapshot) {
-            this._base.setBase(this._remoteSnapshot.base);
-        }
-        await this._refreshAll();
-        for (const state of this._status.values()) {
-            if (state === 'behind' || state === 'both' || state === 'conflicted') {
-                throw fail`remote has changes — pull before pushing`;
-            }
-        }
-
-        const ops = Array.from(this._local.values());
-        const added = ops
-            .filter((op): op is LocalOp & { action: 'added' } => op.action === 'added')
-            .sort((a, b) => a.path.split('/').length - b.path.split('/').length);
-        const renamed = ops.filter((op): op is LocalOp & { action: 'renamed' } => op.action === 'renamed');
-        const deleted = ops
-            .filter((op): op is LocalOp & { action: 'deleted' } => op.action === 'deleted')
-            .sort((a, b) => b.path.split('/').length - a.path.split('/').length);
-
-        for (const op of renamed) {
-            const item = this._base.byPath(op.from);
-            if (item?.id === undefined) {
-                throw fail`missing base item for ${op.from}`;
-            }
-            await this._sendRestOp({ type: 'rename', id: item.id, path: op.path });
-            this._local.delete(op.path);
-            await this._refreshAll();
-        }
-        for (const op of added) {
-            if (op.type === 'folder') {
-                await this._sendRestOp({ type: 'create_folder', path: op.path });
-            } else {
-                await this._sendRestOp({
-                    type: 'create_file',
-                    path: op.path,
-                    text: (await this._readDisk(folderUri, op.path)) ?? ''
-                });
-            }
-            this._local.delete(op.path);
-            await this._refreshAll();
-        }
-        for (const op of deleted) {
-            const item = this._base.byPath(op.path);
-            if (item?.id === undefined) {
-                throw fail`missing base item for ${op.path}`;
-            }
-            await this._sendRestOp({ type: 'delete', id: item.id });
-            this._local.delete(op.path);
-            await this._refreshAll();
-        }
-
-        for (const [path, state] of Array.from(this._status)) {
-            if (state !== 'modified') {
-                continue;
-            }
-            const item = this._base.byPath(path);
-            const text = await this._readDisk(folderUri, path);
-            if (item?.id === undefined || item.type !== 'file' || text === undefined) {
-                continue;
-            }
-            await this._sendRestOp({ type: 'update_text', id: item.id, text });
-            // per-path refresh, not a full rescan — the modified set is a fixed snapshot
-            // and these ops don't touch other paths; one full refresh follows below
-            await this.refresh(path);
-        }
-
-        await this._base.flush();
-        await this._refreshAll();
-    }
-
     // push: submit local edits as OT ops + flush to S3. fast-forward only —
     // rejected if any file is behind/conflicted (no force push; pull first).
     async push() {
-        const [err] =
-            (await this._mutex.atomic(['sync'], () =>
-                tryCatch(() => (this._restMode() ? this._pushRest() : this._pushLive()))
-            )) ?? [];
+        const [err] = (await this._mutex.atomic(['sync'], () => tryCatch(() => this._push()))) ?? [];
         if (err) {
             throw err;
         }
     }
 
-    private async _pushLive() {
+    private async _push() {
         const folderUri = this._folderUri;
         const pm = this._projectManager;
         if (!folderUri || !pm) {
@@ -1362,7 +961,7 @@ class NativeSyncEngine extends Linker<LinkParams> {
         await this._refreshAll();
     }
 
-    async link({ folderUri, projectManager, projectId, branchId, rest }: LinkParams) {
+    async link({ folderUri, projectManager, projectId, branchId }: LinkParams) {
         if (this._folderUri !== undefined) {
             throw this.error.set(() => fail`already linked`);
         }
@@ -1374,32 +973,18 @@ class NativeSyncEngine extends Linker<LinkParams> {
         this._projectManager = projectManager;
         this._projectId = projectId;
         this._branchId = branchId;
-        this._rest = rest;
         this._ignoring = Disk.ignoreMatcher(await this._ignoreText(folderUri), folderUri);
-        if (rest) {
-            await this._fetchRemote();
-            if (!this._base.base && this._remoteSnapshot) {
-                this._base.setBase(this._remoteSnapshot.base);
-            }
-        }
 
         await this._refreshAll();
 
         const recompute = (path: string) => void this.refresh(path);
-        const refreshRemote = () => void this._queueRemoteRefresh();
-        const onUpdate = this._events.on('asset:file:update', rest ? refreshRemote : recompute);
+        const onUpdate = this._events.on('asset:file:update', recompute);
         const onCreate = this._events.on(
             'asset:file:create',
-            rest ? refreshRemote : (path, type, content) => void this._remoteCreate(path, type, content)
+            (path, type, content) => void this._remoteCreate(path, type, content)
         );
-        const onDelete = this._events.on(
-            'asset:file:delete',
-            rest ? refreshRemote : (path) => this._remoteDelete(path)
-        );
-        const onRename = this._events.on(
-            'asset:file:rename',
-            rest ? refreshRemote : (from, to) => void this._remoteRename(from, to)
-        );
+        const onDelete = this._events.on('asset:file:delete', (path) => this._remoteDelete(path));
+        const onRename = this._events.on('asset:file:rename', (from, to) => void this._remoteRename(from, to));
         const onLocalCreate = this._events.on('sync:file:create', (path, type) => this._localCreate(path, type));
         const onLocalUpdate = this._events.on('sync:file:update', recompute);
         const onLocalDelete = this._events.on('sync:file:delete', (path, type) => this._localDelete(path, type));
@@ -1438,7 +1023,6 @@ class NativeSyncEngine extends Linker<LinkParams> {
         const projectManager = this._projectManager;
         const projectId = this._projectId;
         const branchId = this._branchId;
-        const rest = this._rest;
         if (!folderUri || !projectManager || projectId === undefined || branchId === undefined) {
             throw this.error.set(() => fail`unlink called before link`);
         }
@@ -1450,18 +1034,15 @@ class NativeSyncEngine extends Linker<LinkParams> {
         this._projectManager = undefined;
         this._projectId = undefined;
         this._branchId = undefined;
-        this._rest = undefined;
-        this._remoteSnapshot = undefined;
         this._status.clear();
         this._local.clear();
         this._remote.clear();
         this._promoted.clear();
         this._echoes.clear();
         this._ignoring = (_uri: vscode.Uri) => false;
-        this._refreshRemoteDebouncer.clear();
 
         this._log.info(`unlinked ${folderUri.toString()}`);
-        return { folderUri, projectManager, projectId, branchId, rest };
+        return { folderUri, projectManager, projectId, branchId };
     }
 }
 

--- a/src/sync/sync-engine.ts
+++ b/src/sync/sync-engine.ts
@@ -441,6 +441,14 @@ class NativeSyncEngine extends Linker<LinkParams> {
     }
 
     async acceptIncoming(uri: vscode.Uri) {
+        const [err] =
+            (await this._mutex.atomic(['sync'], () => tryCatch(() => this._acceptIncoming(uri)))) ?? [];
+        if (err) {
+            throw err;
+        }
+    }
+
+    private async _acceptIncoming(uri: vscode.Uri) {
         const path = this._path(uri);
         const op = this._remote.get(path);
         if (!op) {
@@ -469,6 +477,14 @@ class NativeSyncEngine extends Linker<LinkParams> {
     }
 
     async keepCurrent(uri: vscode.Uri) {
+        const [err] =
+            (await this._mutex.atomic(['sync'], () => tryCatch(() => this._keepCurrent(uri)))) ?? [];
+        if (err) {
+            throw err;
+        }
+    }
+
+    private async _keepCurrent(uri: vscode.Uri) {
         const path = this._path(uri);
         const op = this._remote.get(path);
         if (!op) {
@@ -1281,6 +1297,14 @@ class NativeSyncEngine extends Linker<LinkParams> {
 
     // revert a file's working copy to the base (git restore). destructive.
     async discard(uri: vscode.Uri) {
+        const [err] =
+            (await this._mutex.atomic(['sync'], () => tryCatch(() => this._discard(uri)))) ?? [];
+        if (err) {
+            throw err;
+        }
+    }
+
+    private async _discard(uri: vscode.Uri) {
         const folderUri = this._folderUri;
         if (!folderUri) {
             return;

--- a/src/sync/sync-engine.ts
+++ b/src/sync/sync-engine.ts
@@ -1,9 +1,11 @@
 import * as vscode from 'vscode';
 
+import type { Rest, SyncItem, SyncPullResponse, SyncPushOp } from '../connections/rest';
 import { Disk } from '../disk';
 import type { ProjectManager } from '../project-manager';
 import type { EventMap } from '../typings/event-map';
 import * as buffer from '../utils/buffer';
+import { Debouncer } from '../utils/debouncer';
 import { fail } from '../utils/error';
 import type { EventEmitter } from '../utils/event-emitter';
 import { Linker } from '../utils/linker';
@@ -18,12 +20,14 @@ import { classify } from './status';
 import type { SyncState } from './status';
 
 const SAVE_TIMEOUT_MS = 30_000;
+const REMOTE_REFRESH_DELAY = 500;
 
 type LinkParams = {
     folderUri: vscode.Uri;
     projectManager: ProjectManager;
     projectId: number;
     branchId: string;
+    rest?: Rest;
 };
 type LocalOp =
     | { action: 'added'; path: string; type: 'file' | 'folder'; hash?: string }
@@ -48,6 +52,12 @@ class NativeSyncEngine extends Linker<LinkParams> {
     private _projectId?: number;
 
     private _branchId?: string;
+
+    private _rest?: Rest;
+
+    private _remoteSnapshot?: SyncPullResponse;
+
+    private _refreshRemoteDebouncer = new Debouncer<void>(REMOTE_REFRESH_DELAY);
 
     private _status = new Map<string, SyncState>();
 
@@ -100,6 +110,9 @@ class NativeSyncEngine extends Linker<LinkParams> {
     }
 
     baseText(path: string) {
+        if (this._restMode()) {
+            return this._base.byPath(path)?.text;
+        }
         const file = this._projectManager?.files.get(path);
         if (!file || file.type === 'folder') {
             const op = this._local.get(path);
@@ -120,6 +133,70 @@ class NativeSyncEngine extends Linker<LinkParams> {
             return target;
         }
         return this._folderUri ? relativePath(target, this._folderUri) : target.path;
+    }
+
+    private _restMode() {
+        return !!this._rest && this._projectId !== undefined && this._branchId !== undefined;
+    }
+
+    private _remoteItem(path: string) {
+        return this._remoteSnapshot?.items.find((item) => item.path === path);
+    }
+
+    private _remoteItemById(id: number) {
+        return this._remoteSnapshot?.items.find((item) => item.id === id);
+    }
+
+    private _remoteText(item: SyncItem) {
+        return norm(item.type === 'file' ? (item.text ?? '') : '');
+    }
+
+    private _allRestPaths() {
+        const paths = new Set<string>();
+        for (const item of this._remoteSnapshot?.items ?? []) {
+            paths.add(item.path);
+        }
+        for (const item of this._base.items()) {
+            if (item.path) {
+                paths.add(item.path);
+                const remote = item.id === undefined ? undefined : this._remoteItemById(item.id);
+                if (remote) {
+                    paths.add(remote.path);
+                }
+            }
+        }
+        for (const op of this._local.values()) {
+            paths.add(op.path);
+            if (op.action === 'renamed') {
+                paths.add(op.from);
+            }
+        }
+        return paths;
+    }
+
+    private async _fetchRemote() {
+        const rest = this._rest;
+        const projectId = this._projectId;
+        const branchId = this._branchId;
+        if (!rest || projectId === undefined || branchId === undefined) {
+            return;
+        }
+        this._remoteSnapshot = await rest.syncPull(projectId, branchId);
+    }
+
+    private async _queueRemoteRefresh() {
+        if (!this._restMode()) {
+            return;
+        }
+        const [err] = await tryCatch(
+            this._refreshRemoteDebouncer.debounce('remote', async () => {
+                await this._fetchRemote();
+                await this._refreshAll();
+            })
+        );
+        if (err) {
+            this.error.set(() => err);
+        }
     }
 
     private _setLocal(op: LocalOp) {
@@ -318,6 +395,10 @@ class NativeSyncEngine extends Linker<LinkParams> {
 
     // remote content for the incoming diff view; stubs are promoted only while read
     async remoteText(path: string) {
+        if (this._restMode()) {
+            const item = this._remoteItem(path);
+            return item?.type === 'file' ? this._remoteText(item) : undefined;
+        }
         const pm = this._projectManager;
         const file = pm?.files.get(path);
         if (!pm || !file || file.type === 'folder') {
@@ -337,6 +418,10 @@ class NativeSyncEngine extends Linker<LinkParams> {
 
     // base/local/remote inputs for a conflicted file's 3-way merge editor
     mergeInputs(path: string) {
+        if (this._restMode()) {
+            const item = this._base.byPath(path);
+            return item?.id === undefined ? undefined : this._base.conflict(item.id);
+        }
         const file = this._projectManager?.files.get(path);
         if (!file || file.type === 'folder') {
             return undefined;
@@ -434,7 +519,8 @@ class NativeSyncEngine extends Linker<LinkParams> {
                 continue;
             }
             const text = kind === 'file' ? await this._readDisk(folderUri, path) : undefined;
-            if (!pm.files.has(path) && !this._remote.has(path) && !this._local.has(path)) {
+            const tracked = this._restMode() ? this._base.byPath(path) || this._remoteItem(path) : pm.files.has(path);
+            if (!tracked && !this._remote.has(path) && !this._local.has(path)) {
                 this._setLocal({
                     action: 'added',
                     path,
@@ -560,7 +646,115 @@ class NativeSyncEngine extends Linker<LinkParams> {
         this._base.set(file.uniqueId, working);
     }
 
+    private async _refreshRest(path: string) {
+        const folderUri = this._folderUri;
+        if (!folderUri) {
+            return;
+        }
+
+        const local = this._local.get(path);
+        const base = this._base.byPath(path);
+        const remote = this._remoteItem(path);
+        const moved = base?.id === undefined ? undefined : this._remoteItemById(base.id);
+        const remoteBase = remote ? this._base.get(remote.id) : undefined;
+
+        if (remoteBase?.path && remoteBase.path !== remote?.path) {
+            return;
+        }
+
+        if (moved && base?.path && moved.path !== base.path) {
+            this._status.delete(base.path);
+            const from = await this._readDisk(folderUri, base.path);
+            const to = await this._readDisk(folderUri, moved.path);
+            const conflicted =
+                this._localOpTouches(base.path) ||
+                this._localTouches(moved.path) ||
+                from !== base.text ||
+                to !== undefined;
+            this._setRemote({ action: 'renamed', from: base.path, path: moved.path }, conflicted);
+            return;
+        }
+
+        if (local) {
+            if (local.action === 'deleted' && remote && base && this._remoteText(remote) !== base.text) {
+                this._status.set(path, 'conflicted');
+                return;
+            }
+            this._status.set(path, local.action);
+            return;
+        }
+
+        const working = await this._readDisk(folderUri, path);
+        if (!base && !remote) {
+            this._status.delete(path);
+            return;
+        }
+
+        if (remote && !base) {
+            if (remote.type === 'folder') {
+                if (await this._exists(path)) {
+                    this._base.setItem(remote);
+                    this._status.delete(path);
+                } else {
+                    this._setRemote({ action: 'created', path, type: 'folder', content: new Uint8Array() });
+                }
+                return;
+            }
+            const text = this._remoteText(remote);
+            if (working === undefined) {
+                this._setRemote({ action: 'created', path, type: 'file', content: buffer.from(text) });
+                return;
+            }
+            this._base.setItem(remote);
+            this._status.set(path, working === text ? 'clean' : 'modified');
+            return;
+        }
+
+        if (base && !remote) {
+            if (working !== undefined && working !== base.text) {
+                this._status.set(path, 'conflicted');
+            } else {
+                this._setRemote({ action: 'deleted', path });
+            }
+            return;
+        }
+
+        if (!base || !remote || remote.type === 'folder') {
+            this._status.delete(path);
+            return;
+        }
+
+        if (working === undefined) {
+            if (this._remoteText(remote) !== base.text) {
+                this._status.set(path, 'conflicted');
+                return;
+            }
+            this._setLocal({ action: 'deleted', path, type: 'file' });
+            return;
+        }
+
+        const conflict = base.id === undefined ? undefined : this._base.conflict(base.id);
+        if (conflict) {
+            if (hasConflictMarkers(working)) {
+                this._status.set(path, 'conflicted');
+                return;
+            }
+            if (base.id !== undefined) {
+                this._base.deleteConflict(base.id);
+            }
+        }
+
+        const remoteText = this._remoteText(remote);
+        const state = classify(base.hash, hash(working), hash(remoteText), working);
+        this._status.set(path, state);
+    }
+
     private async _refresh(path: string) {
+        if (this._restMode()) {
+            await this._refreshRest(path);
+            return;
+        }
+
         const folderUri = this._folderUri;
         const pm = this._projectManager;
         if (!folderUri || !pm) {
@@ -650,6 +844,17 @@ class NativeSyncEngine extends Linker<LinkParams> {
         if (!pm || !folderUri) {
             return;
         }
+        if (this._restMode()) {
+            this._status.clear();
+            this._remote.clear();
+            for (const path of this._allRestPaths()) {
+                await this._refreshRest(path);
+            }
+            await this._refreshLocalOnly(folderUri);
+            this.changed.set((v) => v + 1);
+            return;
+        }
+
         this._status.clear();
         for (const op of this._local.values()) {
             this._status.set(op.path, op.action);
@@ -694,7 +899,86 @@ class NativeSyncEngine extends Linker<LinkParams> {
 
     // fetch + 3-way merge: bring remote changes into the working tree.
     // refuses while a previous merge is unresolved (git-like).
+    private async _pullRest() {
+        const folderUri = this._folderUri;
+        if (!folderUri) {
+            return;
+        }
+
+        await this._fetchRemote();
+        await this._refreshAll();
+        for (const state of this._status.values()) {
+            if (state === 'conflicted') {
+                throw fail`resolve conflicts before pulling`;
+            }
+        }
+
+        const remoteOps = Array.from(this._remote.values());
+        const created = remoteOps
+            .filter((op): op is RemoteOp & { action: 'created' } => op.action === 'created')
+            .sort((a, b) => a.path.split('/').length - b.path.split('/').length);
+        const renamed = remoteOps.filter((op): op is RemoteOp & { action: 'renamed' } => op.action === 'renamed');
+        const deleted = remoteOps
+            .filter((op): op is RemoteOp & { action: 'deleted' } => op.action === 'deleted')
+            .sort((a, b) => b.path.split('/').length - a.path.split('/').length);
+
+        for (const op of renamed) {
+            await this._applyRename(op.from, op.path);
+            this._remote.delete(op.path);
+        }
+        for (const op of created) {
+            await this._applyCreate(op.path, op.type, await this._content(op));
+            this._remote.delete(op.path);
+        }
+        for (const op of deleted) {
+            await this._applyDelete(op.path);
+            this._remote.delete(op.path);
+        }
+
+        const conflicts: [number, { base: string; local: string; remote: string }][] = [];
+        for (const item of this._remoteSnapshot?.items ?? []) {
+            if (item.type !== 'file') {
+                continue;
+            }
+            const remote = this._remoteText(item);
+            const working = await this._readDisk(folderUri, item.path);
+            const base = this._base.byPath(item.path);
+            if (working === undefined) {
+                continue;
+            }
+            if (!base || working === base.text) {
+                if (remote !== working) {
+                    await this._applyUpdate(item.path, remote);
+                }
+                continue;
+            }
+            if (remote === base.text) {
+                continue;
+            }
+
+            const result = merge(base.text, working, remote);
+            if (result.conflicted) {
+                conflicts.push([item.id, { base: base.text, local: working, remote }]);
+            }
+            await this._applyUpdate(item.path, result.text);
+        }
+
+        if (this._remoteSnapshot) {
+            this._base.setSnapshot(this._remoteSnapshot);
+            for (const [id, conflict] of conflicts) {
+                this._base.setConflict(id, conflict);
+            }
+        }
+        await this._base.flush();
+        await this._refreshAll();
+    }
+
     async pull() {
+        if (this._restMode()) {
+            await this._pullRest();
+            return;
+        }
+
         const folderUri = this._folderUri;
         const pm = this._projectManager;
         if (!folderUri || !pm) {
@@ -792,9 +1076,108 @@ class NativeSyncEngine extends Linker<LinkParams> {
         await this._refreshAll();
     }
 
+    private async _sendRestOp(op: SyncPushOp) {
+        const rest = this._rest;
+        const projectId = this._projectId;
+        const branchId = this._branchId;
+        if (!rest || projectId === undefined || branchId === undefined) {
+            return;
+        }
+        const seq = this._base.seq + 1;
+        const snapshot = await rest.syncPush(projectId, branchId, {
+            clientId: this._base.clientId,
+            seq,
+            base: this._base.base,
+            ops: [op]
+        });
+        this._base.setSeq(seq);
+        this._base.setSnapshot(snapshot);
+        this._remoteSnapshot = snapshot;
+    }
+
+    private async _pushRest() {
+        const folderUri = this._folderUri;
+        if (!folderUri) {
+            return;
+        }
+
+        await this._fetchRemote();
+        if (!this._base.base && this._remoteSnapshot) {
+            this._base.setBase(this._remoteSnapshot.base);
+        }
+        await this._refreshAll();
+        for (const state of this._status.values()) {
+            if (state === 'behind' || state === 'both' || state === 'conflicted') {
+                throw fail`remote has changes — pull before pushing`;
+            }
+        }
+
+        const ops = Array.from(this._local.values());
+        const added = ops
+            .filter((op): op is LocalOp & { action: 'added' } => op.action === 'added')
+            .sort((a, b) => a.path.split('/').length - b.path.split('/').length);
+        const renamed = ops.filter((op): op is LocalOp & { action: 'renamed' } => op.action === 'renamed');
+        const deleted = ops
+            .filter((op): op is LocalOp & { action: 'deleted' } => op.action === 'deleted')
+            .sort((a, b) => b.path.split('/').length - a.path.split('/').length);
+
+        for (const op of renamed) {
+            const item = this._base.byPath(op.from);
+            if (item?.id === undefined) {
+                throw fail`missing base item for ${op.from}`;
+            }
+            await this._sendRestOp({ type: 'rename', id: item.id, path: op.path });
+            this._local.delete(op.path);
+            await this._refreshAll();
+        }
+        for (const op of added) {
+            if (op.type === 'folder') {
+                await this._sendRestOp({ type: 'create_folder', path: op.path });
+            } else {
+                await this._sendRestOp({
+                    type: 'create_file',
+                    path: op.path,
+                    text: (await this._readDisk(folderUri, op.path)) ?? ''
+                });
+            }
+            this._local.delete(op.path);
+            await this._refreshAll();
+        }
+        for (const op of deleted) {
+            const item = this._base.byPath(op.path);
+            if (item?.id === undefined) {
+                throw fail`missing base item for ${op.path}`;
+            }
+            await this._sendRestOp({ type: 'delete', id: item.id });
+            this._local.delete(op.path);
+            await this._refreshAll();
+        }
+
+        for (const [path, state] of Array.from(this._status)) {
+            if (state !== 'modified') {
+                continue;
+            }
+            const item = this._base.byPath(path);
+            const text = await this._readDisk(folderUri, path);
+            if (item?.id === undefined || item.type !== 'file' || text === undefined) {
+                continue;
+            }
+            await this._sendRestOp({ type: 'update_text', id: item.id, text });
+            await this._refreshAll();
+        }
+
+        await this._base.flush();
+        await this._refreshAll();
+    }
+
     // push: submit local edits as OT ops + flush to S3. fast-forward only —
     // rejected if any file is behind/conflicted (no force push; pull first).
     async push() {
+        if (this._restMode()) {
+            await this._pushRest();
+            return;
+        }
+
         const folderUri = this._folderUri;
         const pm = this._projectManager;
         if (!folderUri || !pm) {
@@ -921,7 +1304,7 @@ class NativeSyncEngine extends Linker<LinkParams> {
         await this._refreshAll();
     }
 
-    async link({ folderUri, projectManager, projectId, branchId }: LinkParams) {
+    async link({ folderUri, projectManager, projectId, branchId, rest }: LinkParams) {
         if (this._folderUri !== undefined) {
             throw this.error.set(() => fail`already linked`);
         }
@@ -933,18 +1316,32 @@ class NativeSyncEngine extends Linker<LinkParams> {
         this._projectManager = projectManager;
         this._projectId = projectId;
         this._branchId = branchId;
+        this._rest = rest;
         this._ignoring = Disk.ignoreMatcher(await this._ignoreText(folderUri), folderUri);
+        if (rest) {
+            await this._fetchRemote();
+            if (!this._base.base && this._remoteSnapshot) {
+                this._base.setBase(this._remoteSnapshot.base);
+            }
+        }
 
         await this._refreshAll();
 
         const recompute = (path: string) => void this.refresh(path);
-        const onUpdate = this._events.on('asset:file:update', recompute);
+        const refreshRemote = () => void this._queueRemoteRefresh();
+        const onUpdate = this._events.on('asset:file:update', rest ? refreshRemote : recompute);
         const onCreate = this._events.on(
             'asset:file:create',
-            (path, type, content) => void this._remoteCreate(path, type, content)
+            rest ? refreshRemote : (path, type, content) => void this._remoteCreate(path, type, content)
         );
-        const onDelete = this._events.on('asset:file:delete', (path) => this._remoteDelete(path));
-        const onRename = this._events.on('asset:file:rename', (from, to) => void this._remoteRename(from, to));
+        const onDelete = this._events.on(
+            'asset:file:delete',
+            rest ? refreshRemote : (path) => this._remoteDelete(path)
+        );
+        const onRename = this._events.on(
+            'asset:file:rename',
+            rest ? refreshRemote : (from, to) => void this._remoteRename(from, to)
+        );
         const onLocalCreate = this._events.on('sync:file:create', (path, type) => this._localCreate(path, type));
         const onLocalUpdate = this._events.on('sync:file:update', recompute);
         const onLocalDelete = this._events.on('sync:file:delete', (path, type) => this._localDelete(path, type));
@@ -983,6 +1380,7 @@ class NativeSyncEngine extends Linker<LinkParams> {
         const projectManager = this._projectManager;
         const projectId = this._projectId;
         const branchId = this._branchId;
+        const rest = this._rest;
         if (!folderUri || !projectManager || projectId === undefined || branchId === undefined) {
             throw this.error.set(() => fail`unlink called before link`);
         }
@@ -994,15 +1392,18 @@ class NativeSyncEngine extends Linker<LinkParams> {
         this._projectManager = undefined;
         this._projectId = undefined;
         this._branchId = undefined;
+        this._rest = undefined;
+        this._remoteSnapshot = undefined;
         this._status.clear();
         this._local.clear();
         this._remote.clear();
         this._promoted.clear();
         this._echoes.clear();
         this._ignoring = (_uri: vscode.Uri) => false;
+        this._refreshRemoteDebouncer.clear();
 
         this._log.info(`unlinked ${folderUri.toString()}`);
-        return { folderUri, projectManager, projectId, branchId };
+        return { folderUri, projectManager, projectId, branchId, rest };
     }
 }
 

--- a/src/sync/sync-engine.ts
+++ b/src/sync/sync-engine.ts
@@ -11,6 +11,7 @@ import { norm } from '../utils/text';
 import { hash, tryCatch } from '../utils/utils';
 
 import { BaseStore } from './base-store';
+import { merge } from './merge';
 import { classify } from './status';
 import type { SyncState } from './status';
 
@@ -60,6 +61,10 @@ class NativeSyncEngine extends Linker<LinkParams> {
         return err ? undefined : norm(buffer.toString(data));
     }
 
+    private async _write(folderUri: vscode.Uri, path: string, text: string) {
+        await vscode.workspace.fs.writeFile(vscode.Uri.joinPath(folderUri, path), buffer.from(text));
+    }
+
     private async _refresh(path: string) {
         const folderUri = this._folderUri;
         const pm = this._projectManager;
@@ -107,6 +112,59 @@ class NativeSyncEngine extends Linker<LinkParams> {
 
     // recompute all tracked files (used after external changes)
     async refresh() {
+        await this._refreshAll();
+    }
+
+    // fetch + 3-way merge: bring remote changes into the working tree.
+    // refuses while a previous merge is unresolved (git-like).
+    async pull() {
+        const folderUri = this._folderUri;
+        const pm = this._projectManager;
+        if (!folderUri || !pm) {
+            return;
+        }
+
+        await this._refreshAll();
+        for (const state of this._status.values()) {
+            if (state === 'conflicted') {
+                throw fail`resolve conflicts before pulling`;
+            }
+        }
+
+        for (const [path, file] of pm.files) {
+            if (file.type !== 'file') {
+                continue;
+            }
+            const working = await this._read(folderUri, path);
+            if (working === undefined) {
+                continue;
+            }
+            const remote = norm(file.doc.text);
+            const base = this._base.get(file.uniqueId);
+
+            // unseen, or no local divergence -> fast-forward to remote
+            if (!base || working === base.text) {
+                if (remote !== working) {
+                    await this._write(folderUri, path, remote);
+                }
+                this._base.set(file.uniqueId, remote);
+                continue;
+            }
+
+            // remote unchanged since base -> nothing to pull
+            if (remote === base.text) {
+                continue;
+            }
+
+            // both diverged -> 3-way merge into the working tree
+            const result = merge(base.text, working, remote);
+            await this._write(folderUri, path, result.text);
+            if (!result.conflicted) {
+                this._base.set(file.uniqueId, remote);
+            }
+        }
+
+        await this._base.flush();
         await this._refreshAll();
     }
 

--- a/src/sync/sync-engine.ts
+++ b/src/sync/sync-engine.ts
@@ -1,5 +1,6 @@
 import * as vscode from 'vscode';
 
+import { Disk } from '../disk';
 import type { ProjectManager } from '../project-manager';
 import type { EventMap } from '../typings/event-map';
 import * as buffer from '../utils/buffer';
@@ -16,7 +17,6 @@ import { classify } from './status';
 import type { SyncState } from './status';
 
 const SAVE_TIMEOUT_MS = 30_000;
-const LOCAL_IGNORE_DIRS = new Set(['.pc', '.git', '.hg', '.svn', '.vscode', '.cursor']);
 
 type LinkParams = {
     folderUri: vscode.Uri;
@@ -60,6 +60,8 @@ class NativeSyncEngine extends Linker<LinkParams> {
     private _promoted = new Set<string>();
 
     private _echoes = new Set<string>();
+
+    private _ignoring = (_uri: vscode.Uri) => false;
 
     error = signal<Error | undefined>(undefined);
 
@@ -404,6 +406,17 @@ class NativeSyncEngine extends Linker<LinkParams> {
         return err ? undefined : norm(buffer.toString(data));
     }
 
+    private async _ignoreText(folderUri: vscode.Uri) {
+        const file = this._projectManager?.files.get(Disk.IGNORE_FILE);
+        if (file?.type === 'file') {
+            return file.doc.text;
+        }
+        if (file?.type === 'stub') {
+            return (await this._readDisk(folderUri, Disk.IGNORE_FILE)) ?? '';
+        }
+        return '';
+    }
+
     private async _refreshLocalOnly(folderUri: vscode.Uri, base = '') {
         const pm = this._projectManager;
         if (!pm) {
@@ -413,7 +426,8 @@ class NativeSyncEngine extends Linker<LinkParams> {
         const [, entries] = await tryCatch(async () => vscode.workspace.fs.readDirectory(dir));
         for (const [name, type] of entries ?? []) {
             const path = base ? `${base}/${name}` : name;
-            if (LOCAL_IGNORE_DIRS.has(path.split('/')[0])) {
+            const uri = vscode.Uri.joinPath(folderUri, path);
+            if (this._ignoring(uri) || path === Disk.TYPE_DIR || path.startsWith(`${Disk.TYPE_DIR}/`)) {
                 continue;
             }
             const kind = type === vscode.FileType.Directory ? 'folder' : type === vscode.FileType.File ? 'file' : '';
@@ -911,6 +925,7 @@ class NativeSyncEngine extends Linker<LinkParams> {
         this._projectManager = projectManager;
         this._projectId = projectId;
         this._branchId = branchId;
+        this._ignoring = Disk.ignoreMatcher(await this._ignoreText(folderUri), folderUri);
 
         await this._refreshAll();
 
@@ -977,6 +992,7 @@ class NativeSyncEngine extends Linker<LinkParams> {
         this._merges.clear();
         this._promoted.clear();
         this._echoes.clear();
+        this._ignoring = (_uri: vscode.Uri) => false;
 
         this._log.info(`unlinked ${folderUri.toString()}`);
         return { folderUri, projectManager, projectId, branchId };

--- a/src/sync/sync-engine.ts
+++ b/src/sync/sync-engine.ts
@@ -39,6 +39,8 @@ class NativeSyncEngine extends Linker<LinkParams> {
 
     private _status = new Map<string, SyncState>();
 
+    private _merges = new Map<number, { base: string; local: string; remote: string }>();
+
     error = signal<Error | undefined>(undefined);
 
     changed = signal(0);
@@ -72,6 +74,15 @@ class NativeSyncEngine extends Linker<LinkParams> {
             return undefined;
         }
         return norm(file.doc.text);
+    }
+
+    // base/local/remote inputs for a conflicted file's 3-way merge editor
+    mergeInputs(path: string) {
+        const file = this._projectManager?.files.get(path);
+        if (!file || file.type !== 'file') {
+            return undefined;
+        }
+        return this._merges.get(file.uniqueId);
     }
 
     private async _read(folderUri: vscode.Uri, path: string) {
@@ -119,7 +130,12 @@ class NativeSyncEngine extends Linker<LinkParams> {
             return;
         }
 
-        this._status.set(path, classify(base.hash, hash(working), hash(remote), working));
+        const state = classify(base.hash, hash(working), hash(remote), working);
+        this._status.set(path, state);
+        // merge resolved (markers gone) -> drop the stashed merge inputs
+        if (state !== 'conflicted') {
+            this._merges.delete(file.uniqueId);
+        }
     }
 
     private async _refreshAll() {
@@ -188,12 +204,18 @@ class NativeSyncEngine extends Linker<LinkParams> {
                 continue;
             }
 
-            // both diverged -> 3-way merge into the working tree
+            // both diverged -> 3-way merge into the working tree. advance base to
+            // remote even on conflict: the merge incorporated remote, so the working
+            // tree (markers until resolved) is now our local-ahead work. markers keep
+            // status 'conflicted' (push-blocked); once resolved it becomes 'modified'
+            // and is pushable — otherwise the file is stuck both behind and ahead.
             const result = merge(base.text, working, remote);
-            await this._write(folderUri, path, result.text);
-            if (!result.conflicted) {
-                this._base.set(file.uniqueId, remote);
+            if (result.conflicted) {
+                // stash the three sides for the merge editor (base advances below)
+                this._merges.set(file.uniqueId, { base: base.text, local: working, remote });
             }
+            await this._write(folderUri, path, result.text);
+            this._base.set(file.uniqueId, remote);
         }
 
         await this._base.flush();
@@ -302,6 +324,7 @@ class NativeSyncEngine extends Linker<LinkParams> {
         this._projectId = undefined;
         this._branchId = undefined;
         this._status.clear();
+        this._merges.clear();
 
         this._log.info(`unlinked ${folderUri.toString()}`);
         return { folderUri, projectManager, projectId, branchId };

--- a/src/sync/sync-engine.ts
+++ b/src/sync/sync-engine.ts
@@ -168,6 +168,46 @@ class NativeSyncEngine extends Linker<LinkParams> {
         await this._refreshAll();
     }
 
+    // push: submit local edits as OT ops + flush to S3. fast-forward only —
+    // rejected if any file is behind/conflicted (no force push; pull first).
+    async push() {
+        const folderUri = this._folderUri;
+        const pm = this._projectManager;
+        if (!folderUri || !pm) {
+            return;
+        }
+
+        await this._refreshAll();
+        for (const state of this._status.values()) {
+            if (state === 'behind' || state === 'both' || state === 'conflicted') {
+                throw fail`remote has changes — pull before pushing`;
+            }
+        }
+
+        for (const [path, file] of pm.files) {
+            if (file.type !== 'file' || this._status.get(path) !== 'modified') {
+                continue;
+            }
+            const working = await this._read(folderUri, path);
+            if (working === undefined) {
+                continue;
+            }
+            const base = this._base.get(file.uniqueId);
+            // re-check remote is still unchanged, synchronous with write()'s apply
+            // so a remote op can't interleave — went behind mid-push, leave for pull
+            if (base && norm(file.doc.text) !== base.text) {
+                continue;
+            }
+            // write() diffs against the live doc and marks dirty so save() flushes
+            await pm.write(path, buffer.from(working));
+            pm.save(path);
+            this._base.set(file.uniqueId, working);
+        }
+
+        await this._base.flush();
+        await this._refreshAll();
+    }
+
     async link({ folderUri, projectManager, projectId, branchId }: LinkParams) {
         if (this._folderUri !== undefined) {
             throw this.error.set(() => fail`already linked`);

--- a/src/sync/sync-engine.ts
+++ b/src/sync/sync-engine.ts
@@ -838,7 +838,41 @@ class NativeSyncEngine extends Linker<LinkParams> {
             return;
         }
         const path = relativePath(uri, folderUri);
+        const op = this._local.get(path);
         const base = this.baseText(path);
+
+        if (op?.action === 'added') {
+            await this._applyDelete(path);
+            this._local.delete(path);
+            this._status.delete(path);
+            await this._refreshAll();
+            return;
+        }
+
+        if (op?.action === 'deleted') {
+            if (op.type === 'folder') {
+                await this._applyCreate(path, 'folder', new Uint8Array());
+            } else if (base !== undefined) {
+                await this._applyCreate(path, 'file', buffer.from(base));
+            }
+            this._local.delete(path);
+            this._status.delete(path);
+            await this._refreshAll();
+            return;
+        }
+
+        if (op?.action === 'renamed') {
+            await this._applyRename(op.path, op.from);
+            this._local.delete(path);
+            this._status.delete(path);
+            this._status.delete(op.from);
+            if (op.type === 'file' && base !== undefined) {
+                await this._applyUpdate(op.from, base);
+            }
+            await this._refreshAll();
+            return;
+        }
+
         if (base === undefined) {
             return;
         }

--- a/src/sync/sync-engine.ts
+++ b/src/sync/sync-engine.ts
@@ -9,6 +9,7 @@ import { Debouncer } from '../utils/debouncer';
 import { fail } from '../utils/error';
 import type { EventEmitter } from '../utils/event-emitter';
 import { Linker } from '../utils/linker';
+import { Mutex } from '../utils/mutex';
 import { signal } from '../utils/signal';
 import { norm } from '../utils/text';
 import { hash, relativePath, tryCatch, withTimeout } from '../utils/utils';
@@ -69,6 +70,9 @@ class NativeSyncEngine extends Linker<LinkParams> {
     private _promoted = new Set<string>();
 
     private _echoes = new Set<string>();
+
+    // serializes push/pull so concurrent runs never race on seq/base
+    private _mutex = new Mutex<[Error, null] | [null, void]>();
 
     private _ignoring = (_uri: vscode.Uri) => false;
 
@@ -974,11 +978,16 @@ class NativeSyncEngine extends Linker<LinkParams> {
     }
 
     async pull() {
-        if (this._restMode()) {
-            await this._pullRest();
-            return;
+        const [err] =
+            (await this._mutex.atomic(['sync'], () =>
+                tryCatch(() => (this._restMode() ? this._pullRest() : this._pullLive()))
+            )) ?? [];
+        if (err) {
+            throw err;
         }
+    }
 
+    private async _pullLive() {
         const folderUri = this._folderUri;
         const pm = this._projectManager;
         if (!folderUri || !pm) {
@@ -1093,6 +1102,9 @@ class NativeSyncEngine extends Linker<LinkParams> {
         this._base.setSeq(seq);
         this._base.setSnapshot(snapshot);
         this._remoteSnapshot = snapshot;
+        // persist seq+base per op so a crash mid-batch resumes instead of
+        // deadlocking on a stale seq the server already consumed
+        await this._base.flush();
     }
 
     private async _pushRest() {
@@ -1173,11 +1185,16 @@ class NativeSyncEngine extends Linker<LinkParams> {
     // push: submit local edits as OT ops + flush to S3. fast-forward only —
     // rejected if any file is behind/conflicted (no force push; pull first).
     async push() {
-        if (this._restMode()) {
-            await this._pushRest();
-            return;
+        const [err] =
+            (await this._mutex.atomic(['sync'], () =>
+                tryCatch(() => (this._restMode() ? this._pushRest() : this._pushLive()))
+            )) ?? [];
+        if (err) {
+            throw err;
         }
+    }
 
+    private async _pushLive() {
         const folderUri = this._folderUri;
         const pm = this._projectManager;
         if (!folderUri || !pm) {

--- a/src/sync/sync-engine.ts
+++ b/src/sync/sync-engine.ts
@@ -441,8 +441,7 @@ class NativeSyncEngine extends Linker<LinkParams> {
     }
 
     async acceptIncoming(uri: vscode.Uri) {
-        const [err] =
-            (await this._mutex.atomic(['sync'], () => tryCatch(() => this._acceptIncoming(uri)))) ?? [];
+        const [err] = (await this._mutex.atomic(['sync'], () => tryCatch(() => this._acceptIncoming(uri)))) ?? [];
         if (err) {
             throw err;
         }
@@ -477,8 +476,7 @@ class NativeSyncEngine extends Linker<LinkParams> {
     }
 
     async keepCurrent(uri: vscode.Uri) {
-        const [err] =
-            (await this._mutex.atomic(['sync'], () => tryCatch(() => this._keepCurrent(uri)))) ?? [];
+        const [err] = (await this._mutex.atomic(['sync'], () => tryCatch(() => this._keepCurrent(uri)))) ?? [];
         if (err) {
             throw err;
         }
@@ -704,7 +702,10 @@ class NativeSyncEngine extends Linker<LinkParams> {
 
         if (local) {
             if (local.action === 'deleted' && remote && base && this._remoteText(remote) !== base.text) {
-                this._status.set(path, 'conflicted');
+                // server edited a file you deleted: the edit wins as an incoming restore —
+                // pull brings it back (visible); re-delete + push if you still want it gone
+                const content = remote.type === 'file' ? buffer.from(this._remoteText(remote)) : new Uint8Array();
+                this._setRemote({ action: 'created', path, type: remote.type, content });
                 return;
             }
             this._status.set(path, local.action);
@@ -753,7 +754,13 @@ class NativeSyncEngine extends Linker<LinkParams> {
 
         if (working === undefined) {
             if (this._remoteText(remote) !== base.text) {
-                this._status.set(path, 'conflicted');
+                // server edited a file that's gone locally — restore it on pull, not a blind conflict
+                this._setRemote({
+                    action: 'created',
+                    path,
+                    type: 'file',
+                    content: buffer.from(this._remoteText(remote))
+                });
                 return;
             }
             this._setLocal({ action: 'deleted', path, type: 'file' });
@@ -956,6 +963,8 @@ class NativeSyncEngine extends Linker<LinkParams> {
         for (const op of created) {
             await this._applyCreate(op.path, op.type, await this._content(op));
             this._remote.delete(op.path);
+            // a restore over a path you deleted locally supersedes that delete
+            this._local.delete(op.path);
         }
         for (const op of deleted) {
             await this._applyDelete(op.path);
@@ -1297,8 +1306,7 @@ class NativeSyncEngine extends Linker<LinkParams> {
 
     // revert a file's working copy to the base (git restore). destructive.
     async discard(uri: vscode.Uri) {
-        const [err] =
-            (await this._mutex.atomic(['sync'], () => tryCatch(() => this._discard(uri)))) ?? [];
+        const [err] = (await this._mutex.atomic(['sync'], () => tryCatch(() => this._discard(uri)))) ?? [];
         if (err) {
             throw err;
         }

--- a/src/sync/sync-engine.ts
+++ b/src/sync/sync-engine.ts
@@ -1,0 +1,164 @@
+import * as vscode from 'vscode';
+
+import type { ProjectManager } from '../project-manager';
+import type { EventMap } from '../typings/event-map';
+import * as buffer from '../utils/buffer';
+import { fail } from '../utils/error';
+import type { EventEmitter } from '../utils/event-emitter';
+import { Linker } from '../utils/linker';
+import { signal } from '../utils/signal';
+import { norm } from '../utils/text';
+import { hash, tryCatch } from '../utils/utils';
+
+import { BaseStore } from './base-store';
+import { classify } from './status';
+import type { SyncState } from './status';
+
+type LinkParams = {
+    folderUri: vscode.Uri;
+    projectManager: ProjectManager;
+    projectId: number;
+    branchId: string;
+};
+
+// native git-style sync: observes per-file state (base vs working vs remote)
+// without touching the live realtime path. pull/push land in later parts.
+class NativeSyncEngine extends Linker<LinkParams> {
+    private _events: EventEmitter<EventMap>;
+
+    private _base: BaseStore;
+
+    private _folderUri?: vscode.Uri;
+
+    private _projectManager?: ProjectManager;
+
+    private _projectId?: number;
+
+    private _branchId?: string;
+
+    private _status = new Map<string, SyncState>();
+
+    error = signal<Error | undefined>(undefined);
+
+    constructor({ events, storageUri }: { events: EventEmitter<EventMap>; storageUri: vscode.Uri }) {
+        super();
+        this._events = events;
+        this._base = new BaseStore({ storageUri });
+    }
+
+    status(path: string) {
+        return this._status.get(path) ?? 'clean';
+    }
+
+    statuses() {
+        return new Map(this._status);
+    }
+
+    private async _read(folderUri: vscode.Uri, path: string) {
+        const uri = vscode.Uri.joinPath(folderUri, path);
+        const [err, data] = await tryCatch(async () => vscode.workspace.fs.readFile(uri));
+        return err ? undefined : norm(buffer.toString(data));
+    }
+
+    private async _refresh(path: string) {
+        const folderUri = this._folderUri;
+        const pm = this._projectManager;
+        if (!folderUri || !pm) {
+            return;
+        }
+
+        const file = pm.files.get(path);
+        if (!file || file.type !== 'file') {
+            this._status.delete(path);
+            return;
+        }
+
+        const working = await this._read(folderUri, path);
+        if (working === undefined) {
+            return; // not on disk yet
+        }
+        const remote = norm(file.doc.text);
+
+        // seed the base on first sight: treat the current server state as the
+        // last-pulled ancestor. provisional until pull/push lands.
+        let base = this._base.get(file.uniqueId);
+        if (!base) {
+            this._base.set(file.uniqueId, remote);
+            base = this._base.get(file.uniqueId);
+        }
+        if (!base) {
+            return;
+        }
+
+        this._status.set(path, classify(base.hash, hash(working), hash(remote), working));
+    }
+
+    private async _refreshAll() {
+        const pm = this._projectManager;
+        if (!pm) {
+            return;
+        }
+        for (const [path, file] of pm.files) {
+            if (file.type === 'file') {
+                await this._refresh(path);
+            }
+        }
+    }
+
+    // recompute all tracked files (used after external changes)
+    async refresh() {
+        await this._refreshAll();
+    }
+
+    async link({ folderUri, projectManager, projectId, branchId }: LinkParams) {
+        if (this._folderUri !== undefined) {
+            throw this.error.set(() => fail`already linked`);
+        }
+        await super.unlink();
+
+        await this._base.load(projectId, branchId);
+
+        this._folderUri = folderUri;
+        this._projectManager = projectManager;
+        this._projectId = projectId;
+        this._branchId = branchId;
+
+        await this._refreshAll();
+
+        const recompute = () => void this.refresh();
+        const onUpdate = this._events.on('asset:file:update', recompute);
+        const onSave = this._events.on('asset:file:save', recompute);
+        this._cleanup.push(async () => {
+            this._events.off('asset:file:update', onUpdate);
+            this._events.off('asset:file:save', onSave);
+        });
+
+        await this._base.flush();
+
+        this._log.info(`linked ${folderUri.toString()} (${this._status.size} files tracked)`);
+    }
+
+    async unlink() {
+        const folderUri = this._folderUri;
+        const projectManager = this._projectManager;
+        const projectId = this._projectId;
+        const branchId = this._branchId;
+        if (!folderUri || !projectManager || projectId === undefined || branchId === undefined) {
+            throw this.error.set(() => fail`unlink called before link`);
+        }
+
+        await this._base.flush();
+        await super.unlink();
+
+        this._folderUri = undefined;
+        this._projectManager = undefined;
+        this._projectId = undefined;
+        this._branchId = undefined;
+        this._status.clear();
+
+        this._log.info(`unlinked ${folderUri.toString()}`);
+        return { folderUri, projectManager, projectId, branchId };
+    }
+}
+
+export { NativeSyncEngine };

--- a/src/sync/sync-engine.ts
+++ b/src/sync/sync-engine.ts
@@ -318,7 +318,7 @@ class NativeSyncEngine extends Linker<LinkParams> {
         return text === undefined ? op.content : buffer.from(text);
     }
 
-    // remote content for the incoming diff view; stubs are promoted only while read
+    // remote content for the incoming diff view: realtime doc if open, saved (S3) if closed
     async remoteText(path: string) {
         const pm = this._projectManager;
         const file = pm?.files.get(path);
@@ -328,13 +328,8 @@ class NativeSyncEngine extends Linker<LinkParams> {
         if (file.type === 'file') {
             return norm(file.doc.text);
         }
-        const [err, promoted] = await tryCatch(async () => pm.subscribe(path));
-        if (err || !promoted || promoted.type !== 'file') {
-            return undefined;
-        }
-        const text = norm(promoted.doc.text);
-        await this._release(path);
-        return text;
+        // closed file — saved content, matching what pull applies; no subscription
+        return pm.savedContent?.(path);
     }
 
     // base/local/remote inputs for a conflicted file's 3-way merge editor
@@ -629,9 +624,12 @@ class NativeSyncEngine extends Linker<LinkParams> {
         }
 
         if (file.type === 'stub') {
+            const savedHash = pm.savedHash?.(path);
             let base = this._base.get(file.uniqueId);
             if (!base) {
-                this._base.set(file.uniqueId, working);
+                // first sight: adopt current disk as the in-sync baseline (fetch-free);
+                // a later local edit makes ahead true, so pull can't blind-clobber
+                this._base.set(file.uniqueId, working, savedHash);
                 base = this._base.get(file.uniqueId);
             }
             if (!base) {
@@ -645,14 +643,16 @@ class NativeSyncEngine extends Linker<LinkParams> {
                 }
                 this._base.deleteConflict(file.uniqueId);
             }
-            const state = classify(base.hash, hash(working), base.hash, working);
-            this._status.set(path, state);
+            // closed file — saved granularity: ahead vs base content, behind vs base savedHash
+            const ahead = hash(working) !== base.hash;
+            const behind = savedHash !== undefined && base.savedHash !== undefined && savedHash !== base.savedHash;
+            this._status.set(path, ahead && behind ? 'both' : ahead ? 'modified' : behind ? 'behind' : 'clean');
             return;
         }
 
         let base = this._base.get(file.uniqueId);
         if (!base) {
-            this._base.set(file.uniqueId, norm(file.doc.text));
+            this._base.set(file.uniqueId, norm(file.doc.text), pm.savedHash?.(path));
             base = this._base.get(file.uniqueId);
         }
         if (!base) {
@@ -762,37 +762,38 @@ class NativeSyncEngine extends Linker<LinkParams> {
             this._remote.delete(op.path);
         }
 
-        const pulled: string[] = [];
         for (const [path, f] of pm.files) {
             if (f.type === 'folder') {
-                continue;
-            }
-            // pull is an exact remote operation: promote unloaded stubs so R is realtime doc.text
-            let file = f;
-            if (file.type === 'stub') {
-                const promoted = await pm.subscribe(path);
-                if (!promoted) {
-                    continue;
-                }
-                file = promoted;
-                pulled.push(path);
-            }
-            if (file.type !== 'file') {
                 continue;
             }
             const working = await this._readDisk(folderUri, path);
             if (working === undefined) {
                 continue;
             }
-            const remote = norm(file.doc.text);
-            const base = this._base.get(file.uniqueId);
+            const base = this._base.get(f.uniqueId);
+            const savedHash = pm.savedHash?.(path);
+
+            // remote content: realtime doc if open, saved (S3) content if closed — no subscribe
+            let remote: string | undefined;
+            if (f.type === 'file') {
+                remote = norm(f.doc.text);
+            } else {
+                // closed & saved unchanged since base -> nothing to pull, no fetch
+                if (base && savedHash === base.savedHash) {
+                    continue;
+                }
+                remote = await pm.savedContent?.(path);
+            }
+            if (remote === undefined) {
+                continue;
+            }
 
             // unseen, or no local divergence -> fast-forward to remote
             if (!base || working === base.text) {
                 if (remote !== working) {
                     await this._applyUpdate(path, remote);
                 }
-                this._base.set(file.uniqueId, remote);
+                this._base.set(f.uniqueId, remote, savedHash);
                 continue;
             }
 
@@ -802,22 +803,14 @@ class NativeSyncEngine extends Linker<LinkParams> {
             }
 
             // both diverged -> 3-way merge into the working tree. advance base to
-            // remote even on conflict: the merge incorporated remote, so the working
-            // tree (markers until resolved) is now our local-ahead work. markers keep
-            // status 'conflicted' (push-blocked); once resolved it becomes 'modified'
-            // and is pushable — otherwise the file is stuck both behind and ahead.
+            // remote even on conflict; markers keep status conflicted (push-blocked)
+            // until resolved, then it becomes modified and pushable
             const result = merge(base.text, working, remote);
             if (result.conflicted) {
-                // stash the three sides for the merge editor (base advances below)
-                this._base.setConflict(file.uniqueId, { base: base.text, local: working, remote });
+                this._base.setConflict(f.uniqueId, { base: base.text, local: working, remote });
             }
             await this._applyUpdate(path, result.text);
-            this._base.set(file.uniqueId, remote);
-        }
-
-        // pull never leaves ops pending — release promoted docs right away
-        for (const path of pulled) {
-            await this._release(path);
+            this._base.set(f.uniqueId, remote, savedHash);
         }
 
         await this._base.flush();
@@ -991,8 +984,11 @@ class NativeSyncEngine extends Linker<LinkParams> {
         const onLocalRename = this._events.on('sync:file:rename', (from, to, type) =>
             this._localRename(from, to, type)
         );
-        // restatus on promote: remote upgrades from stub base to live doc
+        // restatus on open (promote to live doc) / close (demote to stub)
         const onSubscribed = this._events.on('asset:file:subscribed', recompute);
+        const onUnsubscribed = this._events.on('asset:file:unsubscribed', recompute);
+        // closed-file remote change: asset saved hash moved (no subscription)
+        const onHash = this._events.on('asset:file:hash', recompute);
         const onSave = this._events.on('asset:file:save', (path: string) => {
             void this.refresh(path);
             // flush landed — release a push-promoted doc
@@ -1010,6 +1006,8 @@ class NativeSyncEngine extends Linker<LinkParams> {
             this._events.off('sync:file:delete', onLocalDelete);
             this._events.off('sync:file:rename', onLocalRename);
             this._events.off('asset:file:subscribed', onSubscribed);
+            this._events.off('asset:file:unsubscribed', onUnsubscribed);
+            this._events.off('asset:file:hash', onHash);
             this._events.off('asset:file:save', onSave);
         });
 

--- a/src/sync/sync-engine.ts
+++ b/src/sync/sync-engine.ts
@@ -41,6 +41,9 @@ class NativeSyncEngine extends Linker<LinkParams> {
 
     private _merges = new Map<number, { base: string; local: string; remote: string }>();
 
+    // push-promoted stubs awaiting their flush ack before release
+    private _promoted = new Set<string>();
+
     error = signal<Error | undefined>(undefined);
 
     changed = signal(0);
@@ -61,19 +64,25 @@ class NativeSyncEngine extends Linker<LinkParams> {
 
     baseText(path: string) {
         const file = this._projectManager?.files.get(path);
-        if (!file || file.type !== 'file') {
+        if (!file || file.type === 'folder') {
             return undefined;
         }
         return this._base.get(file.uniqueId)?.text;
     }
 
-    // live remote content (R) for the incoming diff view
-    remoteText(path: string) {
-        const file = this._projectManager?.files.get(path);
-        if (!file || file.type !== 'file') {
+    // remote content (R) for the incoming diff view: live doc when subscribed;
+    // stubs read S3 via REST so a diff click never creates a subscription
+    async remoteText(path: string) {
+        const pm = this._projectManager;
+        const file = pm?.files.get(path);
+        if (!pm || !file || file.type === 'folder') {
             return undefined;
         }
-        return norm(file.doc.text);
+        if (file.type === 'file') {
+            return norm(file.doc.text);
+        }
+        const [err, buf] = await tryCatch(async () => pm.fetchContent(file.uniqueId));
+        return err ? undefined : norm(buffer.toString(buf));
     }
 
     // base/local/remote inputs for a conflicted file's 3-way merge editor
@@ -108,7 +117,7 @@ class NativeSyncEngine extends Linker<LinkParams> {
         }
 
         const file = pm.files.get(path);
-        if (!file || file.type !== 'file') {
+        if (!file || file.type === 'folder') {
             this._status.delete(path);
             return;
         }
@@ -117,20 +126,37 @@ class NativeSyncEngine extends Linker<LinkParams> {
         if (working === undefined) {
             return; // not on disk yet
         }
-        const remote = norm(file.doc.text);
 
-        // seed the base on first sight: treat the current server state as the
-        // last-pulled ancestor. provisional until pull/push lands.
+        // stubs have no live doc — the replicated S3 hash stands in for R, so
+        // closed files classify without subscribing (projects have >1000s)
+        const remote = file.type === 'file' ? hash(norm(file.doc.text)) : pm.fileHash(path);
+        if (remote === undefined) {
+            return;
+        }
+
+        // seed the base on first sight (provisional until pull/push lands):
+        // live doc text when subscribed; for stubs use disk when it matches
+        // the S3 hash, else fetch S3 so the base can anchor a future merge
         let base = this._base.get(file.uniqueId);
         if (!base) {
-            this._base.set(file.uniqueId, remote);
+            if (file.type === 'file') {
+                this._base.set(file.uniqueId, norm(file.doc.text));
+            } else if (hash(working) === remote) {
+                this._base.set(file.uniqueId, working);
+            } else {
+                const [err, buf] = await tryCatch(async () => pm.fetchContent(file.uniqueId));
+                if (err) {
+                    return;
+                }
+                this._base.set(file.uniqueId, norm(buffer.toString(buf)));
+            }
             base = this._base.get(file.uniqueId);
         }
         if (!base) {
             return;
         }
 
-        const state = classify(base.hash, hash(working), hash(remote), working);
+        const state = classify(base.hash, hash(working), remote, working);
         this._status.set(path, state);
         // merge resolved (markers gone) -> drop the stashed merge inputs
         if (state !== 'conflicted') {
@@ -144,7 +170,7 @@ class NativeSyncEngine extends Linker<LinkParams> {
             return;
         }
         for (const [path, file] of pm.files) {
-            if (file.type === 'file') {
+            if (file.type !== 'folder') {
                 await this._refresh(path);
             }
         }
@@ -159,6 +185,22 @@ class NativeSyncEngine extends Linker<LinkParams> {
         }
         await this._refresh(path);
         this.changed.set((v) => v + 1);
+    }
+
+    // release an engine-initiated subscription so standing docs stay limited
+    // to open editors. skipped if the user opened the file meanwhile
+    private async _release(path: string) {
+        const folderUri = this._folderUri;
+        const pm = this._projectManager;
+        if (!folderUri || !pm) {
+            return;
+        }
+        const uri = vscode.Uri.joinPath(folderUri, path);
+        const open = vscode.workspace.textDocuments.some((d) => !d.isClosed && d.uri.toString() === uri.toString());
+        if (open) {
+            return;
+        }
+        await tryCatch(async () => pm.unsubscribe(path));
     }
 
     // fetch + 3-way merge: bring remote changes into the working tree.
@@ -179,7 +221,25 @@ class NativeSyncEngine extends Linker<LinkParams> {
             }
         }
 
-        for (const [path, file] of pm.files) {
+        const pulled: string[] = [];
+        for (const [path, f] of pm.files) {
+            if (f.type === 'folder') {
+                continue;
+            }
+            // stubs subscribe on demand — only when there is something to pull
+            let file = f;
+            if (file.type === 'stub') {
+                const state = this._status.get(path);
+                if (state !== 'behind' && state !== 'both') {
+                    continue;
+                }
+                const promoted = await pm.subscribe(path);
+                if (!promoted) {
+                    continue;
+                }
+                file = promoted;
+                pulled.push(path);
+            }
             if (file.type !== 'file') {
                 continue;
             }
@@ -218,6 +278,11 @@ class NativeSyncEngine extends Linker<LinkParams> {
             this._base.set(file.uniqueId, remote);
         }
 
+        // pull never leaves ops pending — release promoted docs right away
+        for (const path of pulled) {
+            await this._release(path);
+        }
+
         await this._base.flush();
         await this._refreshAll();
     }
@@ -240,18 +305,40 @@ class NativeSyncEngine extends Linker<LinkParams> {
             }
         }
 
-        for (const [path, file] of pm.files) {
-            if (file.type !== 'file' || this._status.get(path) !== 'modified') {
+        for (const [path, f] of pm.files) {
+            if (f.type === 'folder' || this._status.get(path) !== 'modified') {
                 continue;
             }
             const working = await this._read(folderUri, path);
             if (working === undefined) {
                 continue;
             }
+            // closed-file local edits live on stubs — subscribe to submit.
+            // released on the flush ack (asset:file:save), not here: the doc
+            // has pending ops until then and an early close races the save
+            let file = f;
+            let fresh = false;
+            if (file.type === 'stub') {
+                const promoted = await pm.subscribe(path);
+                if (!promoted) {
+                    continue;
+                }
+                file = promoted;
+                this._promoted.add(path);
+                fresh = true;
+            }
+            if (file.type !== 'file') {
+                continue;
+            }
             const base = this._base.get(file.uniqueId);
             // re-check remote is still unchanged, synchronous with write()'s apply
             // so a remote op can't interleave — went behind mid-push, leave for pull
             if (base && norm(file.doc.text) !== base.text) {
+                // nothing saved, so no ack will release a doc promoted just now
+                if (fresh) {
+                    this._promoted.delete(path);
+                    void this._release(path);
+                }
                 continue;
             }
             // write() diffs against the live doc and marks dirty so save() flushes
@@ -296,9 +383,18 @@ class NativeSyncEngine extends Linker<LinkParams> {
 
         const recompute = (path: string) => void this.refresh(path);
         const onUpdate = this._events.on('asset:file:update', recompute);
-        const onSave = this._events.on('asset:file:save', recompute);
+        // restatus on promote: R upgrades from the S3 hash to the live doc
+        const onSubscribed = this._events.on('asset:file:subscribed', recompute);
+        const onSave = this._events.on('asset:file:save', (path: string) => {
+            void this.refresh(path);
+            // flush landed — release a push-promoted doc
+            if (this._promoted.delete(path)) {
+                void this._release(path);
+            }
+        });
         this._cleanup.push(async () => {
             this._events.off('asset:file:update', onUpdate);
+            this._events.off('asset:file:subscribed', onSubscribed);
             this._events.off('asset:file:save', onSave);
         });
 
@@ -325,6 +421,7 @@ class NativeSyncEngine extends Linker<LinkParams> {
         this._branchId = undefined;
         this._status.clear();
         this._merges.clear();
+        this._promoted.clear();
 
         this._log.info(`unlinked ${folderUri.toString()}`);
         return { folderUri, projectManager, projectId, branchId };

--- a/src/sync/sync-engine.ts
+++ b/src/sync/sync-engine.ts
@@ -192,15 +192,22 @@ class NativeSyncEngine extends Linker<LinkParams> {
         if (!this._restMode()) {
             return;
         }
-        const [err] = await tryCatch(
+        // serialize with pull/push so a concurrent fetch+refresh can't swap
+        // _remoteSnapshot mid-pull and advance the base past disk
+        await tryCatch(
             this._refreshRemoteDebouncer.debounce('remote', async () => {
-                await this._fetchRemote();
-                await this._refreshAll();
+                const [err] =
+                    (await this._mutex.atomic(['sync'], () =>
+                        tryCatch(async () => {
+                            await this._fetchRemote();
+                            await this._refreshAll();
+                        })
+                    )) ?? [];
+                if (err) {
+                    this.error.set(() => err);
+                }
             })
         );
-        if (err) {
-            this.error.set(() => err);
-        }
     }
 
     private _setLocal(op: LocalOp) {

--- a/src/sync/sync-engine.ts
+++ b/src/sync/sync-engine.ts
@@ -76,6 +76,11 @@ class NativeSyncEngine extends Linker<LinkParams> {
 
     private async _read(folderUri: vscode.Uri, path: string) {
         const uri = vscode.Uri.joinPath(folderUri, path);
+        // prefer the open buffer so status reflects unsaved edits (live)
+        const open = vscode.workspace.textDocuments.find((d) => d.uri.toString() === uri.toString());
+        if (open && !open.isClosed) {
+            return norm(open.getText());
+        }
         const [err, data] = await tryCatch(async () => vscode.workspace.fs.readFile(uri));
         return err ? undefined : norm(buffer.toString(data));
     }
@@ -130,9 +135,14 @@ class NativeSyncEngine extends Linker<LinkParams> {
         this.changed.set((v) => v + 1);
     }
 
-    // recompute all tracked files (used after external changes)
-    async refresh() {
-        await this._refreshAll();
+    // recompute status — a single file (cheap, for live edits) or all
+    async refresh(path?: string) {
+        if (path === undefined) {
+            await this._refreshAll();
+            return;
+        }
+        await this._refresh(path);
+        this.changed.set((v) => v + 1);
     }
 
     // fetch + 3-way merge: bring remote changes into the working tree.
@@ -144,6 +154,8 @@ class NativeSyncEngine extends Linker<LinkParams> {
             return;
         }
 
+        // flush open buffers so merges write to disk and reload cleanly
+        await vscode.workspace.saveAll(false);
         await this._refreshAll();
         for (const state of this._status.values()) {
             if (state === 'conflicted') {
@@ -197,6 +209,8 @@ class NativeSyncEngine extends Linker<LinkParams> {
             return;
         }
 
+        // flush open buffers so the pushed content matches the editor
+        await vscode.workspace.saveAll(false);
         await this._refreshAll();
         for (const state of this._status.values()) {
             if (state === 'behind' || state === 'both' || state === 'conflicted') {
@@ -258,7 +272,7 @@ class NativeSyncEngine extends Linker<LinkParams> {
 
         await this._refreshAll();
 
-        const recompute = () => void this.refresh();
+        const recompute = (path: string) => void this.refresh(path);
         const onUpdate = this._events.on('asset:file:update', recompute);
         const onSave = this._events.on('asset:file:save', recompute);
         this._cleanup.push(async () => {

--- a/src/sync/sync-engine.ts
+++ b/src/sync/sync-engine.ts
@@ -8,7 +8,7 @@ import type { EventEmitter } from '../utils/event-emitter';
 import { Linker } from '../utils/linker';
 import { signal } from '../utils/signal';
 import { norm } from '../utils/text';
-import { hash, tryCatch } from '../utils/utils';
+import { hash, relativePath, tryCatch } from '../utils/utils';
 
 import { BaseStore } from './base-store';
 import { merge } from './merge';
@@ -73,7 +73,6 @@ class NativeSyncEngine extends Linker<LinkParams> {
         }
         return norm(file.doc.text);
     }
-
 
     private async _read(folderUri: vscode.Uri, path: string) {
         const uri = vscode.Uri.joinPath(folderUri, path);
@@ -226,6 +225,21 @@ class NativeSyncEngine extends Linker<LinkParams> {
         }
 
         await this._base.flush();
+        await this._refreshAll();
+    }
+
+    // revert a file's working copy to the base (git restore). destructive.
+    async discard(uri: vscode.Uri) {
+        const folderUri = this._folderUri;
+        if (!folderUri) {
+            return;
+        }
+        const path = relativePath(uri, folderUri);
+        const base = this.baseText(path);
+        if (base === undefined) {
+            return;
+        }
+        await this._write(folderUri, path, base);
         await this._refreshAll();
     }
 

--- a/src/test/suite/utils.test.ts
+++ b/src/test/suite/utils.test.ts
@@ -1243,6 +1243,49 @@ suite('sync/sync-engine', () => {
         assert.strictEqual((files.get('a.js') as { type: string }).type, 'stub', 'released after flush ack');
     });
 
+    test('push - releases a promoted stub when the flush fails', async () => {
+        await writeFile('a.js', 'x\n');
+        const doc = {
+            text: 'x\n',
+            apply(op: ShareDbTextOp) {
+                doc.text = ottext.apply(doc.text, op) as string;
+            }
+        };
+        const file = { type: 'file', uniqueId: 1, doc, dirty: false };
+        const files = new Map<string, unknown>([['a.js', { type: 'stub', uniqueId: 1, dirty: false }]]);
+        const pm = {
+            files,
+            subscribe: async (p: string) => {
+                files.set(p, file);
+                return file;
+            },
+            write: async (_p: string, content: Uint8Array) => {
+                const op = delta(doc.text, norm(buffer.toString(content)));
+                if (op) {
+                    doc.apply(op);
+                }
+            },
+            save: () => {
+                throw new Error('flush failed');
+            },
+            unsubscribe: async (p: string) => {
+                files.set(p, { type: 'stub', uniqueId: 1, dirty: file.dirty });
+            }
+        } as unknown as ProjectManager;
+        const events = new EventEmitter<EventMap>();
+        const e = new NativeSyncEngine({ events, storageUri: storage });
+        await e.link({ folderUri: work, projectManager: pm, projectId: 1, branchId: 'main' });
+        await writeFile('a.js', 'x\nlocal\n');
+        await e.refresh();
+        const [err] = await tryCatch(() => e.push());
+        assert.ok(err, 'push rejects when the flush fails');
+        assert.strictEqual(
+            (files.get('a.js') as { type: string }).type,
+            'stub',
+            'promoted stub released after a failed flush, not leaked'
+        );
+    });
+
     test('push - subscribes a modified stub and submits', async () => {
         await writeFile('a.js', 'x\n');
         const events = new EventEmitter<EventMap>();

--- a/src/test/suite/utils.test.ts
+++ b/src/test/suite/utils.test.ts
@@ -705,6 +705,57 @@ suite('sync/sync-engine', () => {
         assert.strictEqual(e.status('a.js'), 'clean');
     });
 
+    test('rest push - persists seq per op so a mid-batch failure keeps the acked op', async () => {
+        await writeFile('a.js', 'x\n');
+        await writeFile('b.js', 'y\n');
+        const pushes: SyncPushRequest[] = [];
+        let current: SyncPullResponse = {
+            base: 'base-0',
+            items: [syncItem(10, 'a.js', 'x\n'), syncItem(20, 'b.js', 'y\n')]
+        };
+        const rest = {
+            syncPull: async () => current,
+            syncPush: async (_p: number, _b: string, body: SyncPushRequest) => {
+                pushes.push(body);
+                // drop the connection on the second op
+                if (pushes.length === 2) {
+                    throw new Error('network drop mid-batch');
+                }
+                const op = body.ops[0];
+                current = {
+                    base: `base-${pushes.length}`,
+                    items: current.items.map((item) =>
+                        op.type === 'update_text' && item.id === op.id ? { ...item, text: op.text } : item
+                    )
+                };
+                return current;
+            }
+        } as unknown as Rest;
+
+        const e = engine();
+        await e.link({
+            folderUri: work,
+            projectManager: pmWith({ text: 'ignored\n' }),
+            projectId: 1,
+            branchId: 'main',
+            rest
+        });
+
+        await writeFile('a.js', 'x\nlocal\n');
+        await writeFile('b.js', 'y\nlocal\n');
+        await e.refresh();
+
+        const [err] = await tryCatch(() => e.push());
+        assert.ok(err, 'push rejects when an op fails mid-batch');
+        assert.strictEqual(pushes.length, 2);
+
+        // op #1 was acked; its seq must survive on disk so the next push resumes
+        // instead of deadlocking on a stale seq the server already consumed
+        const reloaded = new BaseStore({ storageUri: storage });
+        await reloaded.load(1, 'main', hash(work.toString()));
+        assert.strictEqual(reloaded.seq, 1);
+    });
+
     test('rest incoming - collaborator event refreshes incoming snapshot', async () => {
         await writeFile('a.js', 'x\n');
         const events = new EventEmitter<EventMap>();

--- a/src/test/suite/utils.test.ts
+++ b/src/test/suite/utils.test.ts
@@ -4,11 +4,16 @@ import * as os from 'os';
 import { type as ottext } from 'ot-text';
 import * as vscode from 'vscode';
 
+import type { ProjectManager } from '../../project-manager';
 import { BaseStore } from '../../sync/base-store';
 import { hasConflictMarkers } from '../../sync/markers';
 import { merge } from '../../sync/merge';
 import { classify } from '../../sync/status';
+import { NativeSyncEngine } from '../../sync/sync-engine';
+import type { EventMap } from '../../typings/event-map';
 import type { Project } from '../../typings/models';
+import * as buffer from '../../utils/buffer';
+import { EventEmitter } from '../../utils/event-emitter';
 import { delta } from '../../utils/text';
 import { sanitizeName, projectToName, hash, tryCatch } from '../../utils/utils';
 
@@ -239,5 +244,88 @@ suite('sync/base-store', () => {
         const b = new BaseStore({ storageUri: dir });
         await b.load(1, 'dev');
         assert.strictEqual(b.get(1), undefined);
+    });
+});
+
+suite('sync/sync-engine', () => {
+    const root = vscode.Uri.joinPath(vscode.Uri.file(os.tmpdir()), 'pc-sync-engine-test');
+    const storage = vscode.Uri.joinPath(root, 'storage');
+    const work = vscode.Uri.joinPath(root, 'work');
+
+    const clean = async () => {
+        await tryCatch(async () => vscode.workspace.fs.delete(root, { recursive: true, useTrash: false }));
+    };
+
+    setup(clean);
+    suiteTeardown(clean);
+
+    const writeFile = async (name: string, text: string) => {
+        await vscode.workspace.fs.createDirectory(work);
+        await vscode.workspace.fs.writeFile(vscode.Uri.joinPath(work, name), buffer.from(text));
+    };
+
+    const engine = () => new NativeSyncEngine({ events: new EventEmitter<EventMap>(), storageUri: storage });
+
+    const pmWith = (doc: { text: string }) => {
+        const files = new Map([['a.js', { type: 'file', uniqueId: 1, doc, dirty: false }]]);
+        return { files } as unknown as ProjectManager;
+    };
+
+    test('clean when working equals remote', async () => {
+        await writeFile('a.js', 'x\n');
+        const e = engine();
+        await e.link({ folderUri: work, projectManager: pmWith({ text: 'x\n' }), projectId: 1, branchId: 'main' });
+        assert.strictEqual(e.status('a.js'), 'clean');
+    });
+
+    test('modified when working diverges from base', async () => {
+        await writeFile('a.js', 'x\n');
+        const e = engine();
+        await e.link({ folderUri: work, projectManager: pmWith({ text: 'x\n' }), projectId: 1, branchId: 'main' });
+        await writeFile('a.js', 'x\nlocal\n');
+        await e.refresh();
+        assert.strictEqual(e.status('a.js'), 'modified');
+    });
+
+    test('behind when remote advances past base', async () => {
+        await writeFile('a.js', 'x\n');
+        const doc = { text: 'x\n' };
+        const e = engine();
+        await e.link({ folderUri: work, projectManager: pmWith(doc), projectId: 1, branchId: 'main' });
+        doc.text = 'x\nremote\n';
+        await e.refresh();
+        assert.strictEqual(e.status('a.js'), 'behind');
+    });
+
+    test('both when working and remote diverge', async () => {
+        await writeFile('a.js', 'x\n');
+        const doc = { text: 'x\n' };
+        const e = engine();
+        await e.link({ folderUri: work, projectManager: pmWith(doc), projectId: 1, branchId: 'main' });
+        await writeFile('a.js', 'x\nlocal\n');
+        doc.text = 'x\nremote\n';
+        await e.refresh();
+        assert.strictEqual(e.status('a.js'), 'both');
+    });
+
+    test('conflicted when working has markers', async () => {
+        await writeFile('a.js', 'x\n');
+        const e = engine();
+        await e.link({ folderUri: work, projectManager: pmWith({ text: 'x\n' }), projectId: 1, branchId: 'main' });
+        await writeFile('a.js', 'x\n<<<<<<< Working (your changes)\na\n=======\nb\n>>>>>>> Server (origin)\n');
+        await e.refresh();
+        assert.strictEqual(e.status('a.js'), 'conflicted');
+    });
+
+    test('base persists across relink', async () => {
+        await writeFile('a.js', 'x\n');
+        const e1 = engine();
+        await e1.link({ folderUri: work, projectManager: pmWith({ text: 'x\n' }), projectId: 1, branchId: 'main' });
+        await e1.unlink();
+
+        await writeFile('a.js', 'x\nlocal\n');
+        const e2 = engine();
+        await e2.link({ folderUri: work, projectManager: pmWith({ text: 'x\n' }), projectId: 1, branchId: 'main' });
+        assert.strictEqual(e2.status('a.js'), 'modified');
     });
 });

--- a/src/test/suite/utils.test.ts
+++ b/src/test/suite/utils.test.ts
@@ -209,13 +209,6 @@ suite('sync/base-store', () => {
         assert.strictEqual(store.get(1)?.hash, hash('a\nb'));
     });
 
-    test('delete removes entry', () => {
-        const store = new BaseStore({ storageUri: dir });
-        store.set(1, 'x');
-        store.delete(1);
-        assert.strictEqual(store.get(1), undefined);
-    });
-
     test('persists across reload', async () => {
         const a = new BaseStore({ storageUri: dir });
         await a.load(7, 'main');

--- a/src/test/suite/utils.test.ts
+++ b/src/test/suite/utils.test.ts
@@ -552,6 +552,23 @@ suite('sync/sync-engine', () => {
         assert.strictEqual(e.status('local-only.js'), 'clean');
     });
 
+    test('link ignores pre-existing local-only files matched by pcignore', async () => {
+        const files = new Map<string, unknown>([
+            ['.pcignore', { type: 'file', uniqueId: 1, doc: { text: 'ignored*.js\n' }, dirty: false }]
+        ]);
+        await writeFile('ignored_file.js', 'local\n');
+        const e = engine();
+        await e.link({
+            folderUri: work,
+            projectManager: { files } as unknown as ProjectManager,
+            projectId: 1,
+            branchId: 'main'
+        });
+
+        assert.strictEqual(e.status('ignored_file.js'), 'clean');
+        assert.strictEqual(e.statuses().has('ignored_file.js'), false);
+    });
+
     test('pull - fast-forward when no local edits', async () => {
         await writeFile('a.js', 'x\n');
         const doc = { text: 'x\n' };

--- a/src/test/suite/utils.test.ts
+++ b/src/test/suite/utils.test.ts
@@ -5,10 +5,11 @@ import { type as ottext } from 'ot-text';
 import * as vscode from 'vscode';
 
 import type { ProjectManager } from '../../project-manager';
+import { DecorationProvider } from '../../providers/decoration-provider';
 import { BaseStore } from '../../sync/base-store';
 import { hasConflictMarkers } from '../../sync/markers';
 import { merge } from '../../sync/merge';
-import { scmDecoration } from '../../sync/scm';
+import { SCM_SCHEME, scmUri } from '../../sync/scm';
 import { classify } from '../../sync/status';
 import { NativeSyncEngine } from '../../sync/sync-engine';
 import type { EventMap } from '../../typings/event-map';
@@ -185,15 +186,30 @@ suite('sync/status', () => {
 });
 
 suite('sync/scm', () => {
-    test('uses git-style letters for resource states', () => {
-        assert.strictEqual(scmDecoration('modified').letter, 'M');
-        assert.strictEqual(scmDecoration('behind').letter, 'M');
-        assert.strictEqual(scmDecoration('both').letter, 'M');
-        assert.strictEqual(scmDecoration('added').letter, 'A');
-        assert.strictEqual(scmDecoration('deleted').letter, 'D');
-        assert.strictEqual(scmDecoration('renamed').letter, 'R');
-        assert.strictEqual(scmDecoration('conflicted').letter, '!');
-        assert.strictEqual(scmDecoration('deleted').decorations.strikeThrough, true);
+    test('uses private uris for scoped row decorations', () => {
+        const uri = vscode.Uri.file('/tmp/a.js');
+        const scm = scmUri(uri);
+        assert.strictEqual(scm.scheme, SCM_SCHEME);
+        assert.strictEqual(scm.path, uri.path);
+    });
+});
+
+suite('decoration-provider', () => {
+    const dir = vscode.Uri.joinPath(vscode.Uri.file(os.tmpdir()), 'pc-decoration-provider-test');
+
+    test('badges pullpush scm uris without decorating real files', async () => {
+        const sync = {
+            changed: { get: () => 0 },
+            status: (path: string) => (path === 'new.js' ? 'added' : 'clean')
+        } as unknown as NativeSyncEngine;
+        const provider = new DecorationProvider({ events: new EventEmitter<EventMap>(), syncEngine: sync });
+        await provider.link({ folderUri: dir, projectManager: { files: new Map() } as unknown as ProjectManager });
+
+        const real = vscode.Uri.joinPath(dir, 'new.js');
+        assert.strictEqual(provider.provideFileDecoration(scmUri(real))?.badge, 'A');
+        assert.strictEqual(provider.provideFileDecoration(real), undefined);
+
+        await provider.unlink();
     });
 });
 

--- a/src/test/suite/utils.test.ts
+++ b/src/test/suite/utils.test.ts
@@ -8,6 +8,7 @@ import type { ProjectManager } from '../../project-manager';
 import { BaseStore } from '../../sync/base-store';
 import { hasConflictMarkers } from '../../sync/markers';
 import { merge } from '../../sync/merge';
+import { scmDecoration } from '../../sync/scm';
 import { classify } from '../../sync/status';
 import { NativeSyncEngine } from '../../sync/sync-engine';
 import type { EventMap } from '../../typings/event-map';
@@ -180,6 +181,19 @@ suite('sync/status', () => {
 
     test('conflicted overrides when markers present', () => {
         assert.strictEqual(classify(B, W, R, 'a\n<<<<<<< Working (your changes)\nb'), 'conflicted');
+    });
+});
+
+suite('sync/scm', () => {
+    test('uses git-style letters for resource states', () => {
+        assert.strictEqual(scmDecoration('modified').letter, 'M');
+        assert.strictEqual(scmDecoration('behind').letter, 'M');
+        assert.strictEqual(scmDecoration('both').letter, 'M');
+        assert.strictEqual(scmDecoration('added').letter, 'A');
+        assert.strictEqual(scmDecoration('deleted').letter, 'D');
+        assert.strictEqual(scmDecoration('renamed').letter, 'R');
+        assert.strictEqual(scmDecoration('conflicted').letter, '!');
+        assert.strictEqual(scmDecoration('deleted').decorations.strikeThrough, true);
     });
 });
 

--- a/src/test/suite/utils.test.ts
+++ b/src/test/suite/utils.test.ts
@@ -1458,6 +1458,120 @@ suite('sync/sync-engine', () => {
         assert.strictEqual(e.status('b.js'), 'clean');
     });
 
+    test('push - renames and submits edited content', async () => {
+        const events = new EventEmitter<EventMap>();
+        const renamed: [string, string][] = [];
+        const written: [string, string][] = [];
+        const saved: string[] = [];
+        const doc = {
+            text: 'x\n',
+            apply(op: ShareDbTextOp) {
+                doc.text = ottext.apply(doc.text, op) as string;
+            }
+        };
+        const file = { type: 'file', uniqueId: 1, doc, dirty: false };
+        const files = new Map<string, unknown>([['a.js', file]]);
+        const pm = {
+            files,
+            rename: async (from: string, to: string) => {
+                renamed.push([from, to]);
+                files.set(to, files.get(from));
+                files.delete(from);
+            },
+            write: async (path: string, content: Uint8Array) => {
+                const text = norm(buffer.toString(content));
+                const op = delta(doc.text, text);
+                written.push([path, text]);
+                if (op) {
+                    doc.apply(op);
+                    file.dirty = true;
+                }
+            },
+            save: (path: string) => {
+                saved.push(path);
+                events.emit('asset:file:save', path);
+            }
+        } as unknown as ProjectManager;
+        await writeFile('a.js', 'x\n');
+        const e = new NativeSyncEngine({ events, storageUri: storage });
+        await e.link({ folderUri: work, projectManager: pm, projectId: 1, branchId: 'main' });
+        await vscode.workspace.fs.rename(vscode.Uri.joinPath(work, 'a.js'), vscode.Uri.joinPath(work, 'b.js'));
+        await writeFile('b.js', 'x\nlocal\n');
+        events.emit('sync:file:rename', 'a.js', 'b.js', 'file');
+
+        await e.push();
+
+        assert.deepStrictEqual(renamed, [['a.js', 'b.js']]);
+        assert.deepStrictEqual(written, [['b.js', 'x\nlocal\n']]);
+        assert.deepStrictEqual(saved, ['b.js']);
+        assert.strictEqual(doc.text, 'x\nlocal\n');
+        assert.strictEqual(e.status('b.js'), 'clean');
+    });
+
+    test('push - retries rename edit as content after write failure', async () => {
+        const events = new EventEmitter<EventMap>();
+        const renamed: [string, string][] = [];
+        const written: [string, string][] = [];
+        const saved: string[] = [];
+        const doc = {
+            text: 'x\n',
+            apply(op: ShareDbTextOp) {
+                doc.text = ottext.apply(doc.text, op) as string;
+            }
+        };
+        const file = { type: 'file', uniqueId: 1, doc, dirty: false };
+        const files = new Map<string, unknown>([['a.js', file]]);
+        let failWrite = true;
+        const pm = {
+            files,
+            rename: async (from: string, to: string) => {
+                renamed.push([from, to]);
+                files.set(to, files.get(from));
+                files.delete(from);
+            },
+            write: async (path: string, content: Uint8Array) => {
+                const text = norm(buffer.toString(content));
+                written.push([path, text]);
+                if (failWrite) {
+                    failWrite = false;
+                    throw new Error('write failed');
+                }
+                const op = delta(doc.text, text);
+                if (op) {
+                    doc.apply(op);
+                    file.dirty = true;
+                }
+            },
+            save: (path: string) => {
+                saved.push(path);
+                events.emit('asset:file:save', path);
+            }
+        } as unknown as ProjectManager;
+        await writeFile('a.js', 'x\n');
+        const e = new NativeSyncEngine({ events, storageUri: storage });
+        await e.link({ folderUri: work, projectManager: pm, projectId: 1, branchId: 'main' });
+        await vscode.workspace.fs.rename(vscode.Uri.joinPath(work, 'a.js'), vscode.Uri.joinPath(work, 'b.js'));
+        await writeFile('b.js', 'x\nlocal\n');
+        events.emit('sync:file:rename', 'a.js', 'b.js', 'file');
+
+        const [err] = await tryCatch(() => e.push());
+        assert.ok(err, 'first push should fail after rename');
+        assert.deepStrictEqual(renamed, [['a.js', 'b.js']]);
+        assert.deepStrictEqual(saved, []);
+        assert.strictEqual(e.status('b.js'), 'modified');
+
+        await e.push();
+
+        assert.deepStrictEqual(renamed, [['a.js', 'b.js']]);
+        assert.deepStrictEqual(written, [
+            ['b.js', 'x\nlocal\n'],
+            ['b.js', 'x\nlocal\n']
+        ]);
+        assert.deepStrictEqual(saved, ['b.js']);
+        assert.strictEqual(doc.text, 'x\nlocal\n');
+        assert.strictEqual(e.status('b.js'), 'clean');
+    });
+
     test('push - rejects local rename when remote changed', async () => {
         const events = new EventEmitter<EventMap>();
         const renamed: [string, string][] = [];

--- a/src/test/suite/utils.test.ts
+++ b/src/test/suite/utils.test.ts
@@ -339,6 +339,21 @@ suite('sync/base-store', () => {
         await b.load(1, 'dev');
         assert.strictEqual(b.get(1), undefined);
     });
+
+    test('separate folder ids are isolated', async () => {
+        const a = new BaseStore({ storageUri: dir });
+        await a.load(1, 'main', 'folder-a');
+        a.set(1, 'from-a');
+        await a.flush();
+
+        const b = new BaseStore({ storageUri: dir });
+        await b.load(1, 'main', 'folder-b');
+        assert.strictEqual(b.get(1), undefined);
+
+        const c = new BaseStore({ storageUri: dir });
+        await c.load(1, 'main', 'folder-a');
+        assert.strictEqual(c.get(1)?.text, 'from-a');
+    });
 });
 
 suite('sync/sync-engine', () => {

--- a/src/test/suite/utils.test.ts
+++ b/src/test/suite/utils.test.ts
@@ -4,7 +4,6 @@ import * as os from 'os';
 import { type as ottext } from 'ot-text';
 import * as vscode from 'vscode';
 
-import type { Rest, SyncItem, SyncPullResponse, SyncPushRequest } from '../../connections/rest';
 import { Disk } from '../../disk';
 import type { ProjectManager } from '../../project-manager';
 import { DecorationProvider } from '../../providers/decoration-provider';
@@ -323,30 +322,6 @@ suite('sync/base-store', () => {
         assert.strictEqual(b.get(2)?.text, 'second');
     });
 
-    test('persists sync metadata across reload', async () => {
-        const a = new BaseStore({ storageUri: dir });
-        await a.load(7, 'main');
-        a.setBase('base-1');
-        a.setSeq(5);
-        a.setItem({
-            kind: 'asset',
-            id: 10,
-            path: 'a.js',
-            type: 'file',
-            modifiedAt: '2026-06-25T00:00:00.000Z',
-            text: 'x\n'
-        });
-        const clientId = a.clientId;
-        await a.flush();
-
-        const b = new BaseStore({ storageUri: dir });
-        await b.load(7, 'main');
-        assert.strictEqual(b.base, 'base-1');
-        assert.strictEqual(b.seq, 5);
-        assert.strictEqual(b.clientId, clientId);
-        assert.strictEqual(b.byPath('a.js')?.text, 'x\n');
-    });
-
     test('load clears entries when no file exists', async () => {
         const store = new BaseStore({ storageUri: dir });
         store.set(99, 'stale');
@@ -471,62 +446,6 @@ suite('sync/sync-engine', () => {
             }
         } as unknown as ProjectManager;
         return { events, pm, doc, applied, saved };
-    };
-
-    const syncItem = (id: number, path: string, text = '', type: 'file' | 'folder' = 'file'): SyncItem => ({
-        kind: 'asset',
-        id,
-        path,
-        type,
-        modifiedAt: '2026-06-25T00:00:00.000Z',
-        text: type === 'file' ? text : undefined
-    });
-
-    const syncRest = (initial: SyncPullResponse) => {
-        let current = initial;
-        const pushes: SyncPushRequest[] = [];
-        const rest = {
-            syncPull: async () => current,
-            syncPush: async (_projectId: number, _branchId: string, body: SyncPushRequest) => {
-                pushes.push(body);
-                const op = body.ops[0];
-                const items = current.items.slice();
-                if (op.type === 'update_text') {
-                    current = {
-                        base: `base-${pushes.length}`,
-                        items: items.map((item) => (item.id === op.id ? { ...item, text: op.text } : item))
-                    };
-                } else if (op.type === 'create_file') {
-                    current = {
-                        base: `base-${pushes.length}`,
-                        items: items.concat(syncItem(100 + pushes.length, op.path, op.text))
-                    };
-                } else if (op.type === 'create_folder') {
-                    current = {
-                        base: `base-${pushes.length}`,
-                        items: items.concat(syncItem(100 + pushes.length, op.path, '', 'folder'))
-                    };
-                } else if (op.type === 'rename') {
-                    current = {
-                        base: `base-${pushes.length}`,
-                        items: items.map((item) => (item.id === op.id ? { ...item, path: op.path } : item))
-                    };
-                } else {
-                    current = {
-                        base: `base-${pushes.length}`,
-                        items: items.filter((item) => item.id !== op.id)
-                    };
-                }
-                return current;
-            }
-        } as unknown as Rest;
-        return {
-            rest,
-            pushes,
-            set(snapshot: SyncPullResponse) {
-                current = snapshot;
-            }
-        };
     };
 
     test('clean when working equals remote', async () => {
@@ -659,144 +578,6 @@ suite('sync/sync-engine', () => {
         await e.pull();
         assert.strictEqual(await readFile('a.js'), 'x\ny\n');
         assert.strictEqual(e.status('a.js'), 'clean');
-    });
-
-    test('rest pull - fast-forwards from remote snapshot', async () => {
-        await writeFile('a.js', 'x\n');
-        const api = syncRest({ base: 'base-0', items: [syncItem(10, 'a.js', 'x\n')] });
-        const e = engine();
-        await e.link({
-            folderUri: work,
-            projectManager: pmWith({ text: 'ignored\n' }),
-            projectId: 1,
-            branchId: 'main',
-            rest: api.rest
-        });
-
-        api.set({ base: 'base-1', items: [syncItem(10, 'a.js', 'x\nremote\n')] });
-        await e.pull();
-
-        assert.strictEqual(await readFile('a.js'), 'x\nremote\n');
-        assert.strictEqual(e.status('a.js'), 'clean');
-        assert.strictEqual(await e.remoteText('a.js'), 'x\nremote\n');
-    });
-
-    test('rest push - sends update_text with client seq and base', async () => {
-        await writeFile('a.js', 'x\n');
-        const api = syncRest({ base: 'base-0', items: [syncItem(10, 'a.js', 'x\n')] });
-        const e = engine();
-        await e.link({
-            folderUri: work,
-            projectManager: pmWith({ text: 'ignored\n' }),
-            projectId: 1,
-            branchId: 'main',
-            rest: api.rest
-        });
-
-        await writeFile('a.js', 'x\nlocal\n');
-        await e.refresh();
-        await e.push();
-
-        assert.strictEqual(api.pushes.length, 1);
-        assert.strictEqual(api.pushes[0].base, 'base-0');
-        assert.strictEqual(api.pushes[0].seq, 1);
-        assert.strictEqual(typeof api.pushes[0].clientId, 'string');
-        assert.deepStrictEqual(api.pushes[0].ops, [{ type: 'update_text', id: 10, text: 'x\nlocal\n' }]);
-        assert.strictEqual(e.status('a.js'), 'clean');
-    });
-
-    test('rest push - persists seq per op so a mid-batch failure keeps the acked op', async () => {
-        await writeFile('a.js', 'x\n');
-        await writeFile('b.js', 'y\n');
-        const pushes: SyncPushRequest[] = [];
-        let current: SyncPullResponse = {
-            base: 'base-0',
-            items: [syncItem(10, 'a.js', 'x\n'), syncItem(20, 'b.js', 'y\n')]
-        };
-        const rest = {
-            syncPull: async () => current,
-            syncPush: async (_p: number, _b: string, body: SyncPushRequest) => {
-                pushes.push(body);
-                // drop the connection on the second op
-                if (pushes.length === 2) {
-                    throw new Error('network drop mid-batch');
-                }
-                const op = body.ops[0];
-                current = {
-                    base: `base-${pushes.length}`,
-                    items: current.items.map((item) =>
-                        op.type === 'update_text' && item.id === op.id ? { ...item, text: op.text } : item
-                    )
-                };
-                return current;
-            }
-        } as unknown as Rest;
-
-        const e = engine();
-        await e.link({
-            folderUri: work,
-            projectManager: pmWith({ text: 'ignored\n' }),
-            projectId: 1,
-            branchId: 'main',
-            rest
-        });
-
-        await writeFile('a.js', 'x\nlocal\n');
-        await writeFile('b.js', 'y\nlocal\n');
-        await e.refresh();
-
-        const [err] = await tryCatch(() => e.push());
-        assert.ok(err, 'push rejects when an op fails mid-batch');
-        assert.strictEqual(pushes.length, 2);
-
-        // op #1 was acked; its seq must survive on disk so the next push resumes
-        // instead of deadlocking on a stale seq the server already consumed
-        const reloaded = new BaseStore({ storageUri: storage });
-        await reloaded.load(1, 'main', hash(work.toString()));
-        assert.strictEqual(reloaded.seq, 1);
-    });
-
-    test('rest incoming - collaborator event refreshes incoming snapshot', async () => {
-        await writeFile('a.js', 'x\n');
-        const events = new EventEmitter<EventMap>();
-        const api = syncRest({ base: 'base-0', items: [syncItem(10, 'a.js', 'x\n')] });
-        const e = engine(events);
-        await e.link({
-            folderUri: work,
-            projectManager: pmWith({ text: 'ignored\n' }),
-            projectId: 1,
-            branchId: 'main',
-            rest: api.rest
-        });
-
-        api.set({ base: 'base-1', items: [syncItem(10, 'a.js', 'x\nremote\n')] });
-        events.emit('asset:file:update', 'a.js', [], 'x\nremote\n', 'x\n');
-        for (let i = 0; i < 80 && e.status('a.js') !== 'behind'; i++) {
-            await wait(10);
-        }
-
-        assert.strictEqual(e.status('a.js'), 'behind');
-        assert.strictEqual(await e.remoteText('a.js'), 'x\nremote\n');
-    });
-
-    test('rest pull - applies remote rename as one structural change', async () => {
-        await writeFile('a.js', 'x\n');
-        const api = syncRest({ base: 'base-0', items: [syncItem(10, 'a.js', 'x\n')] });
-        const e = engine();
-        await e.link({
-            folderUri: work,
-            projectManager: pmWith({ text: 'ignored\n' }),
-            projectId: 1,
-            branchId: 'main',
-            rest: api.rest
-        });
-
-        api.set({ base: 'base-1', items: [syncItem(10, 'b.js', 'x\n')] });
-        await e.pull();
-
-        assert.strictEqual(await exists('a.js'), false);
-        assert.strictEqual(await readFile('b.js'), 'x\n');
-        assert.strictEqual(e.status('b.js'), 'clean');
     });
 
     test('pull - applies content update through disk apply event', async () => {

--- a/src/test/suite/utils.test.ts
+++ b/src/test/suite/utils.test.ts
@@ -1,10 +1,16 @@
 import * as assert from 'assert';
+import * as os from 'os';
 
 import { type as ottext } from 'ot-text';
+import * as vscode from 'vscode';
 
+import { BaseStore } from '../../sync/base-store';
+import { hasConflictMarkers } from '../../sync/markers';
+import { merge } from '../../sync/merge';
+import { classify } from '../../sync/status';
 import type { Project } from '../../typings/models';
 import { delta } from '../../utils/text';
-import { sanitizeName, projectToName } from '../../utils/utils';
+import { sanitizeName, projectToName, hash, tryCatch } from '../../utils/utils';
 
 suite('utils', () => {
     test('sanitize name - preserves spaces', () => {
@@ -75,5 +81,163 @@ suite('delta', () => {
         assert.ok(op);
         assert.doesNotThrow(() => ottext.semanticInvert('ABC', op));
         assert.strictEqual(ottext.apply('ABC', op), 'BC');
+    });
+});
+
+suite('sync/markers', () => {
+    test('detects start marker', () => {
+        assert.strictEqual(hasConflictMarkers('foo\n<<<<<<< Working (your changes)\nbar'), true);
+    });
+
+    test('detects separator and end markers', () => {
+        assert.strictEqual(hasConflictMarkers('a\n=======\nb'), true);
+        assert.strictEqual(hasConflictMarkers('a\n>>>>>>> Server (origin)'), true);
+    });
+
+    test('clean text has no markers', () => {
+        assert.strictEqual(hasConflictMarkers('const x = 1;\n// a <= b comparison\n'), false);
+    });
+
+    test('does not false-positive on shorter runs', () => {
+        assert.strictEqual(hasConflictMarkers('a <<<< b\n====\n'), false);
+    });
+});
+
+suite('sync/merge', () => {
+    test('no changes returns base, not conflicted', () => {
+        const r = merge('a\nb\n', 'a\nb\n', 'a\nb\n');
+        assert.strictEqual(r.conflicted, false);
+        assert.strictEqual(r.text, 'a\nb\n');
+    });
+
+    test('local-only change is kept (remote unchanged)', () => {
+        const r = merge('a\nb\nc\n', 'a\nB\nc\n', 'a\nb\nc\n');
+        assert.strictEqual(r.conflicted, false);
+        assert.strictEqual(r.text, 'a\nB\nc\n');
+    });
+
+    test('remote-only change is kept (local unchanged)', () => {
+        const r = merge('a\nb\nc\n', 'a\nb\nc\n', 'a\nb\nC\n');
+        assert.strictEqual(r.conflicted, false);
+        assert.strictEqual(r.text, 'a\nb\nC\n');
+    });
+
+    test('non-overlapping changes merge cleanly', () => {
+        const r = merge('one\ntwo\nthree\nfour\n', 'ONE\ntwo\nthree\nfour\n', 'one\ntwo\nthree\nFOUR\n');
+        assert.strictEqual(r.conflicted, false);
+        assert.strictEqual(r.text, 'ONE\ntwo\nthree\nFOUR\n');
+    });
+
+    test('identical changes converge without conflict', () => {
+        const r = merge('a\nb\n', 'a\nX\n', 'a\nX\n');
+        assert.strictEqual(r.conflicted, false);
+        assert.strictEqual(r.text, 'a\nX\n');
+    });
+
+    test('overlapping changes produce conflict markers', () => {
+        const r = merge('a\nb\nc\n', 'a\nLOCAL\nc\n', 'a\nREMOTE\nc\n');
+        assert.strictEqual(r.conflicted, true);
+        assert.ok(r.text.includes('<<<<<<< Working (your changes)'), 'has start marker');
+        assert.ok(r.text.includes('LOCAL'), 'has local side');
+        assert.ok(r.text.includes('======='), 'has separator');
+        assert.ok(r.text.includes('REMOTE'), 'has remote side');
+        assert.ok(r.text.includes('>>>>>>> Server (origin)'), 'has end marker');
+    });
+
+    test('normalizes CRLF before merging', () => {
+        const r = merge('a\r\nb\r\n', 'a\r\nb\r\n', 'a\r\nB\r\n');
+        assert.strictEqual(r.conflicted, false);
+        assert.strictEqual(r.text, 'a\nB\n');
+    });
+});
+
+suite('sync/status', () => {
+    const B = hash('base');
+    const W = hash('work');
+    const R = hash('remote');
+
+    test('clean when all equal', () => {
+        assert.strictEqual(classify(B, B, B, 'base'), 'clean');
+    });
+
+    test('modified when only working differs', () => {
+        assert.strictEqual(classify(B, W, B, 'work'), 'modified');
+    });
+
+    test('behind when only remote differs', () => {
+        assert.strictEqual(classify(B, B, R, 'base'), 'behind');
+    });
+
+    test('both when working and remote differ', () => {
+        assert.strictEqual(classify(B, W, R, 'work'), 'both');
+    });
+
+    test('conflicted overrides when markers present', () => {
+        assert.strictEqual(classify(B, W, R, 'a\n<<<<<<< Working (your changes)\nb'), 'conflicted');
+    });
+});
+
+suite('sync/base-store', () => {
+    const dir = vscode.Uri.joinPath(vscode.Uri.file(os.tmpdir()), 'pc-base-store-test');
+
+    const clean = async () => {
+        await tryCatch(async () => vscode.workspace.fs.delete(dir, { recursive: true, useTrash: false }));
+    };
+
+    setup(clean);
+    suiteTeardown(clean);
+
+    test('set and get round-trip with hash', () => {
+        const store = new BaseStore({ storageUri: dir });
+        store.set(1, 'hello\nworld\n');
+        const entry = store.get(1);
+        assert.ok(entry);
+        assert.strictEqual(entry.text, 'hello\nworld\n');
+        assert.strictEqual(entry.hash, hash('hello\nworld\n'));
+    });
+
+    test('set normalizes CRLF before hashing', () => {
+        const store = new BaseStore({ storageUri: dir });
+        store.set(1, 'a\r\nb');
+        assert.strictEqual(store.get(1)?.text, 'a\nb');
+        assert.strictEqual(store.get(1)?.hash, hash('a\nb'));
+    });
+
+    test('delete removes entry', () => {
+        const store = new BaseStore({ storageUri: dir });
+        store.set(1, 'x');
+        store.delete(1);
+        assert.strictEqual(store.get(1), undefined);
+    });
+
+    test('persists across reload', async () => {
+        const a = new BaseStore({ storageUri: dir });
+        await a.load(7, 'main');
+        a.set(1, 'first');
+        a.set(2, 'second');
+        await a.flush();
+
+        const b = new BaseStore({ storageUri: dir });
+        await b.load(7, 'main');
+        assert.strictEqual(b.get(1)?.text, 'first');
+        assert.strictEqual(b.get(2)?.text, 'second');
+    });
+
+    test('load clears entries when no file exists', async () => {
+        const store = new BaseStore({ storageUri: dir });
+        store.set(99, 'stale');
+        await store.load(123, 'branch-x');
+        assert.strictEqual(store.get(99), undefined);
+    });
+
+    test('separate project+branch keys are isolated', async () => {
+        const a = new BaseStore({ storageUri: dir });
+        await a.load(1, 'main');
+        a.set(1, 'on-main');
+        await a.flush();
+
+        const b = new BaseStore({ storageUri: dir });
+        await b.load(1, 'dev');
+        assert.strictEqual(b.get(1), undefined);
     });
 });

--- a/src/test/suite/utils.test.ts
+++ b/src/test/suite/utils.test.ts
@@ -181,8 +181,8 @@ suite('sync/status', () => {
         assert.strictEqual(classify(B, W, R, 'work'), 'both');
     });
 
-    test('conflicted overrides when markers present', () => {
-        assert.strictEqual(classify(B, W, R, 'a\n<<<<<<< Working (your changes)\nb'), 'conflicted');
+    test('marker text alone does not create a conflict', () => {
+        assert.strictEqual(classify(B, W, R, 'a\n<<<<<<< Working (your changes)\nb'), 'both');
     });
 });
 
@@ -485,13 +485,13 @@ suite('sync/sync-engine', () => {
         assert.strictEqual(e.status('a.js'), 'both');
     });
 
-    test('conflicted when working has markers', async () => {
+    test('marker text alone stays modified', async () => {
         await writeFile('a.js', 'x\n');
         const e = engine();
         await e.link({ folderUri: work, projectManager: pmWith({ text: 'x\n' }), projectId: 1, branchId: 'main' });
         await writeFile('a.js', 'x\n<<<<<<< Working (your changes)\na\n=======\nb\n>>>>>>> Server (origin)\n');
         await e.refresh();
-        assert.strictEqual(e.status('a.js'), 'conflicted');
+        assert.strictEqual(e.status('a.js'), 'modified');
     });
 
     test('base persists across relink', async () => {
@@ -1773,5 +1773,26 @@ suite('sync/sync-engine', () => {
         await writeFile('a.js', 'a\nRESOLVED\nc\n');
         await e.refresh();
         assert.strictEqual(e.mergeInputs('a.js'), undefined, 'cleared after resolve');
+    });
+
+    test('mergeInputs survives relink while conflict markers remain', async () => {
+        const doc = { text: 'a\nb\nc\n' };
+        await writeFile('a.js', 'a\nb\nc\n');
+        const e1 = engine();
+        await e1.link({ folderUri: work, projectManager: pmWith(doc), projectId: 1, branchId: 'main' });
+        await writeFile('a.js', 'a\nLOCAL\nc\n');
+        doc.text = 'a\nREMOTE\nc\n';
+        await e1.pull();
+        await e1.unlink();
+
+        const e2 = engine();
+        await e2.link({ folderUri: work, projectManager: pmWith(doc), projectId: 1, branchId: 'main' });
+
+        assert.strictEqual(e2.status('a.js'), 'conflicted');
+        const m = e2.mergeInputs('a.js');
+        assert.ok(m, 'merge inputs persisted');
+        assert.strictEqual(m.base, 'a\nb\nc\n');
+        assert.strictEqual(m.local, 'a\nLOCAL\nc\n');
+        assert.strictEqual(m.remote, 'a\nREMOTE\nc\n');
     });
 });

--- a/src/test/suite/utils.test.ts
+++ b/src/test/suite/utils.test.ts
@@ -4,6 +4,7 @@ import * as os from 'os';
 import { type as ottext } from 'ot-text';
 import * as vscode from 'vscode';
 
+import { Disk } from '../../disk';
 import type { ProjectManager } from '../../project-manager';
 import { DecorationProvider } from '../../providers/decoration-provider';
 import { BaseStore } from '../../sync/base-store';
@@ -18,7 +19,7 @@ import type { ShareDbTextOp } from '../../typings/sharedb';
 import * as buffer from '../../utils/buffer';
 import { EventEmitter } from '../../utils/event-emitter';
 import { delta, norm } from '../../utils/text';
-import { sanitizeName, projectToName, hash, tryCatch } from '../../utils/utils';
+import { sanitizeName, projectToName, hash, tryCatch, wait } from '../../utils/utils';
 
 suite('utils', () => {
     test('sanitize name - preserves spaces', () => {
@@ -213,6 +214,75 @@ suite('decoration-provider', () => {
     });
 });
 
+suite('disk/pullpush', () => {
+    const root = vscode.Uri.joinPath(vscode.Uri.file(os.tmpdir()), 'pc-disk-pullpush-test');
+    const fresh = vscode.Uri.joinPath(root, 'fresh');
+    const existing = vscode.Uri.joinPath(root, 'existing');
+    const types = {
+        globals: buffer.from('declare namespace pc {}\n'),
+        module: buffer.from('declare module "playcanvas" { export = pc; }\n'),
+        version: 'test',
+        fallback: false
+    };
+
+    const clean = async () => {
+        await tryCatch(async () => vscode.workspace.fs.delete(root, { recursive: true, useTrash: false }));
+    };
+
+    const pm = () =>
+        ({
+            files: new Map([
+                ['kept.js', { type: 'file', uniqueId: 1, doc: { text: 'kept\n' }, dirty: false }],
+                ['remote.js', { type: 'file', uniqueId: 2, doc: { text: 'remote\n' }, dirty: false }]
+            ])
+        }) as unknown as ProjectManager;
+
+    const exists = async (uri: vscode.Uri) => {
+        const [err] = await tryCatch(async () => vscode.workspace.fs.stat(uri));
+        return !err;
+    };
+
+    const disk = () => {
+        const d = new Disk({ events: new EventEmitter<EventMap>(), pullPush: true });
+        const quiet = d as unknown as {
+            _watchEvents: () => () => void;
+            _watchDocument: () => () => void;
+            _watchDisk: () => () => void;
+            _watchUndoRedo: () => () => void;
+            _writeTypeFiles: () => Promise<void>;
+        };
+        quiet._watchEvents = () => () => undefined;
+        quiet._watchDocument = () => () => undefined;
+        quiet._watchDisk = () => () => undefined;
+        quiet._watchUndoRedo = () => () => undefined;
+        quiet._writeTypeFiles = async () => undefined;
+        return d;
+    };
+
+    setup(clean);
+
+    suiteTeardown(clean);
+
+    test('materializes remote files only on first checkout', async () => {
+        await vscode.workspace.fs.createDirectory(fresh);
+        const first = disk();
+        await first.link({ folderUri: fresh, projectManager: pm(), types });
+        const freshExists = await exists(vscode.Uri.joinPath(fresh, 'remote.js'));
+
+        await vscode.workspace.fs.createDirectory(existing);
+        await vscode.workspace.fs.writeFile(vscode.Uri.joinPath(existing, 'kept.js'), buffer.from('kept\n'));
+        await vscode.workspace.fs.writeFile(vscode.Uri.joinPath(existing, 'local-only.js'), buffer.from('local\n'));
+        const second = disk();
+        await second.link({ folderUri: existing, projectManager: pm(), types });
+        const existingExists = await exists(vscode.Uri.joinPath(existing, 'remote.js'));
+        const localOnlyExists = await exists(vscode.Uri.joinPath(existing, 'local-only.js'));
+
+        assert.strictEqual(freshExists, true);
+        assert.strictEqual(existingExists, false);
+        assert.strictEqual(localOnlyExists, true);
+    });
+});
+
 suite('sync/base-store', () => {
     const dir = vscode.Uri.joinPath(vscode.Uri.file(os.tmpdir()), 'pc-base-store-test');
 
@@ -296,7 +366,14 @@ suite('sync/sync-engine', () => {
         return !err;
     };
 
-    const engine = () => new NativeSyncEngine({ events: new EventEmitter<EventMap>(), storageUri: storage });
+    const engine = (events = new EventEmitter<EventMap>()) => {
+        events.on('sync:file:apply:update', (path, content, done) => {
+            void tryCatch(async () => writeFile(path, norm(buffer.toString(content)))).then(([err]) =>
+                done(err ?? undefined)
+            );
+        });
+        return new NativeSyncEngine({ events, storageUri: storage });
+    };
 
     const pmWith = (doc: { text: string }) => {
         const files = new Map([['a.js', { type: 'file', uniqueId: 1, doc, dirty: false }]]);
@@ -305,6 +382,7 @@ suite('sync/sync-engine', () => {
 
     // pm whose doc records submitted ops and applies them (simulating the server)
     const pushPm = () => {
+        const events = new EventEmitter<EventMap>();
         const applied: ShareDbTextOp[] = [];
         const saved: string[] = [];
         const doc = {
@@ -327,9 +405,12 @@ suite('sync/sync-engine', () => {
                 doc.apply(op);
                 file.dirty = true;
             },
-            save: (p: string) => saved.push(p)
+            save: (p: string) => {
+                saved.push(p);
+                events.emit('asset:file:save', p);
+            }
         } as unknown as ProjectManager;
-        return { pm, doc, applied, saved };
+        return { events, pm, doc, applied, saved };
     };
 
     test('clean when working equals remote', async () => {
@@ -390,6 +471,52 @@ suite('sync/sync-engine', () => {
         assert.strictEqual(e2.status('a.js'), 'modified');
     });
 
+    test('link keeps missing based files as local deletes', async () => {
+        await writeFile('a.js', 'x\n');
+        const e1 = engine();
+        await e1.link({ folderUri: work, projectManager: pmWith({ text: 'x\n' }), projectId: 1, branchId: 'main' });
+        await e1.unlink();
+        await vscode.workspace.fs.delete(vscode.Uri.joinPath(work, 'a.js'), { recursive: false, useTrash: false });
+
+        const e2 = engine();
+        await e2.link({ folderUri: work, projectManager: pmWith({ text: 'x\n' }), projectId: 1, branchId: 'main' });
+        assert.strictEqual(e2.status('a.js'), 'deleted');
+    });
+
+    test('link keeps missing unbased files as incoming adds', async () => {
+        await vscode.workspace.fs.createDirectory(work);
+        const e = engine();
+        await e.link({ folderUri: work, projectManager: pmWith({ text: 'x\n' }), projectId: 1, branchId: 'main' });
+        assert.strictEqual(e.status('a.js'), 'behind');
+        assert.strictEqual(e.decorationStatus('a.js'), 'added');
+    });
+
+    test('link keeps pre-existing local-only files as local adds', async () => {
+        const created: [string, 'file' | 'folder', string][] = [];
+        const files = new Map<string, unknown>();
+        const pm = {
+            files,
+            create: async (p: string, t: 'file' | 'folder', content?: Uint8Array) => {
+                created.push([p, t, content ? norm(buffer.toString(content)) : '']);
+                files.set(p, {
+                    type: t,
+                    uniqueId: 10,
+                    doc: { text: content ? norm(buffer.toString(content)) : '' },
+                    dirty: false
+                });
+            }
+        } as unknown as ProjectManager;
+
+        await writeFile('local-only.js', 'local\n');
+        const e = engine();
+        await e.link({ folderUri: work, projectManager: pm, projectId: 1, branchId: 'main' });
+
+        assert.strictEqual(e.status('local-only.js'), 'added');
+        await e.push();
+        assert.deepStrictEqual(created, [['local-only.js', 'file', 'local\n']]);
+        assert.strictEqual(e.status('local-only.js'), 'clean');
+    });
+
     test('pull - fast-forward when no local edits', async () => {
         await writeFile('a.js', 'x\n');
         const doc = { text: 'x\n' };
@@ -399,6 +526,163 @@ suite('sync/sync-engine', () => {
         await e.pull();
         assert.strictEqual(await readFile('a.js'), 'x\ny\n');
         assert.strictEqual(e.status('a.js'), 'clean');
+    });
+
+    test('pull - applies content update through disk apply event', async () => {
+        await writeFile('a.js', 'x\n');
+        const events = new EventEmitter<EventMap>();
+        const doc = { text: 'x\n' };
+        const pm = {
+            files: new Map([['a.js', { type: 'file', uniqueId: 1, doc, dirty: false }]])
+        } as unknown as ProjectManager;
+        const e = new NativeSyncEngine({ events, storageUri: storage });
+        await e.link({ folderUri: work, projectManager: pm, projectId: 1, branchId: 'main' });
+        const applied: string[] = [];
+        events.on('sync:file:apply:update', async (path, content, done) => {
+            applied.push(path);
+            await writeFile(path, norm(buffer.toString(content)));
+            done();
+        });
+
+        doc.text = 'x\ny\n';
+        await e.pull();
+
+        assert.deepStrictEqual(applied, ['a.js']);
+        assert.strictEqual(await readFile('a.js'), 'x\ny\n');
+    });
+
+    test('push - ignores stale clean buffer after pull fast-forwards disk', async () => {
+        const applied: ShareDbTextOp[] = [];
+        const doc = {
+            text: 'x\n',
+            apply(op: ShareDbTextOp) {
+                applied.push(op);
+                doc.text = ottext.apply(doc.text, op) as string;
+            }
+        };
+        const file = { type: 'file', uniqueId: 9, doc, dirty: false };
+        const pm = {
+            files: new Map([['stale.js', file]]),
+            write: async (_p: string, content: Uint8Array) => {
+                const op = delta(doc.text, norm(buffer.toString(content)));
+                if (op) {
+                    doc.apply(op);
+                    file.dirty = true;
+                }
+            },
+            save: () => undefined
+        } as unknown as ProjectManager;
+        await writeFile('stale.js', 'x\n');
+        const uri = vscode.Uri.joinPath(work, 'stale.js');
+        const open = await vscode.workspace.openTextDocument(uri);
+        const e = engine();
+        const [err] = await tryCatch(async () => {
+            await e.link({ folderUri: work, projectManager: pm, projectId: 1, branchId: 'main' });
+            doc.text = 'x\nremote\n';
+
+            await e.pull();
+            await e.push();
+
+            assert.strictEqual(await readFile('stale.js'), 'x\nremote\n');
+            assert.strictEqual(open.isDirty, false);
+            assert.strictEqual(applied.length, 0);
+        });
+        await vscode.window.showTextDocument(open);
+        if (open.isDirty) {
+            await vscode.commands.executeCommand('workbench.action.files.revert');
+        }
+        await vscode.commands.executeCommand('workbench.action.closeActiveEditor');
+        if (err) {
+            throw err;
+        }
+    });
+
+    test('pull - writes disk without saving dirty open buffer', async () => {
+        const applied: ShareDbTextOp[] = [];
+        const doc = {
+            text: 'x\n',
+            apply(op: ShareDbTextOp) {
+                applied.push(op);
+                doc.text = ottext.apply(doc.text, op) as string;
+            }
+        };
+        const file = { type: 'file', uniqueId: 10, doc, dirty: false };
+        const pm = {
+            files: new Map([['dirty.js', file]]),
+            write: async (_p: string, content: Uint8Array) => {
+                const op = delta(doc.text, norm(buffer.toString(content)));
+                if (op) {
+                    doc.apply(op);
+                    file.dirty = true;
+                }
+            },
+            save: () => undefined
+        } as unknown as ProjectManager;
+        await writeFile('dirty.js', 'x\n');
+        const uri = vscode.Uri.joinPath(work, 'dirty.js');
+        const open = await vscode.workspace.openTextDocument(uri);
+        const e = engine();
+        const [err] = await tryCatch(async () => {
+            await e.link({ folderUri: work, projectManager: pm, projectId: 1, branchId: 'main' });
+            const editor = await vscode.window.showTextDocument(open);
+            const ok = await editor.edit((edit) => {
+                edit.replace(
+                    new vscode.Range(open.positionAt(0), open.positionAt(open.getText().length)),
+                    'x\nunsaved\n'
+                );
+            });
+            assert.strictEqual(ok, true);
+            assert.strictEqual(open.isDirty, true);
+            doc.text = 'x\nremote\n';
+
+            await e.pull();
+            await e.push();
+
+            assert.strictEqual(await readFile('dirty.js'), 'x\nremote\n');
+            assert.strictEqual(open.getText(), 'x\nunsaved\n');
+            assert.strictEqual(open.isDirty, true);
+            assert.strictEqual(applied.length, 0);
+        });
+        await vscode.window.showTextDocument(open);
+        if (open.isDirty) {
+            await vscode.commands.executeCommand('workbench.action.files.revert');
+        }
+        await vscode.commands.executeCommand('workbench.action.closeActiveEditor');
+        if (err) {
+            throw err;
+        }
+    });
+
+    test('status ignores unsaved open buffer until saved to disk', async () => {
+        await writeFile('dirty.js', 'x\n');
+        const file = { type: 'file', uniqueId: 11, doc: { text: 'x\n' }, dirty: false };
+        const pm = { files: new Map([['dirty.js', file]]) } as unknown as ProjectManager;
+        const uri = vscode.Uri.joinPath(work, 'dirty.js');
+        const open = await vscode.workspace.openTextDocument(uri);
+        const e = engine();
+        const [err] = await tryCatch(async () => {
+            await e.link({ folderUri: work, projectManager: pm, projectId: 1, branchId: 'main' });
+            const editor = await vscode.window.showTextDocument(open);
+            const ok = await editor.edit((edit) => {
+                edit.replace(
+                    new vscode.Range(open.positionAt(0), open.positionAt(open.getText().length)),
+                    'x\nunsaved\n'
+                );
+            });
+            assert.strictEqual(ok, true);
+            assert.strictEqual(open.isDirty, true);
+
+            await e.refresh('dirty.js');
+            assert.strictEqual(e.status('dirty.js'), 'clean');
+        });
+        await vscode.window.showTextDocument(open);
+        if (open.isDirty) {
+            await vscode.commands.executeCommand('workbench.action.files.revert');
+        }
+        await vscode.commands.executeCommand('workbench.action.closeActiveEditor');
+        if (err) {
+            throw err;
+        }
     });
 
     test('pull - leaves local edits when remote unchanged', async () => {
@@ -552,6 +836,27 @@ suite('sync/sync-engine', () => {
         assert.strictEqual(await readFile('a.js'), 'local\n');
     });
 
+    test('pull - blocks local delete over remote edit', async () => {
+        await writeFile('a.js', 'x\n');
+        const events = new EventEmitter<EventMap>();
+        const doc = { text: 'x\n' };
+        const pm = {
+            files: new Map([['a.js', { type: 'file', uniqueId: 1, doc, dirty: false }]])
+        } as unknown as ProjectManager;
+        const e = new NativeSyncEngine({ events, storageUri: storage });
+        await e.link({ folderUri: work, projectManager: pm, projectId: 1, branchId: 'main' });
+        await vscode.workspace.fs.delete(vscode.Uri.joinPath(work, 'a.js'), { recursive: false, useTrash: false });
+        events.emit('sync:file:delete', 'a.js', 'file');
+        doc.text = 'x\nremote\n';
+
+        await e.refresh('a.js');
+        assert.strictEqual(e.status('a.js'), 'conflicted');
+
+        const [err] = await tryCatch(() => e.pull());
+        assert.ok(err, 'pull should be blocked');
+        assert.strictEqual(await exists('a.js'), false);
+    });
+
     test('pull - blocks remote create over local add', async () => {
         const events = new EventEmitter<EventMap>();
         const files = new Map<string, unknown>();
@@ -569,6 +874,24 @@ suite('sync/sync-engine', () => {
         assert.strictEqual(await readFile('new.js'), 'local\n');
     });
 
+    test('remote create over identical empty disk file is not conflicted', async () => {
+        await writeFile('empty.js', '');
+        const events = new EventEmitter<EventMap>();
+        const files = new Map<string, unknown>();
+        const pm = { files } as unknown as ProjectManager;
+        const e = new NativeSyncEngine({ events, storageUri: storage });
+        await e.link({ folderUri: work, projectManager: pm, projectId: 1, branchId: 'main' });
+
+        files.set('empty.js', { type: 'file', uniqueId: 10, doc: { text: '' }, dirty: false });
+        events.emit('asset:file:create', 'empty.js', 'file', new Uint8Array());
+        for (let i = 0; i < 50 && e.status('empty.js') === 'clean'; i++) {
+            await wait(10);
+        }
+
+        assert.strictEqual(e.status('empty.js'), 'behind');
+        assert.strictEqual(e.structuralConflict('empty.js'), false);
+    });
+
     test('structural conflict - keep current add becomes modified against remote create', async () => {
         const events = new EventEmitter<EventMap>();
         const file = { type: 'file', uniqueId: 10, doc: { text: 'remote\n' }, dirty: false };
@@ -584,7 +907,10 @@ suite('sync/sync-engine', () => {
                     written.push(file.doc.text);
                 }
             },
-            save: (p: string) => saved.push(p)
+            save: (p: string) => {
+                saved.push(p);
+                events.emit('asset:file:save', p);
+            }
         } as unknown as ProjectManager;
         const e = new NativeSyncEngine({ events, storageUri: storage });
         await e.link({ folderUri: work, projectManager: pm, projectId: 1, branchId: 'main' });
@@ -650,9 +976,9 @@ suite('sync/sync-engine', () => {
     });
 
     test('push - submits delta, flushes, advances base', async () => {
-        const { pm, applied, saved } = pushPm();
+        const { events, pm, applied, saved } = pushPm();
         await writeFile('a.js', 'x\n');
-        const e = engine();
+        const e = engine(events);
         await e.link({ folderUri: work, projectManager: pm, projectId: 1, branchId: 'main' });
         await writeFile('a.js', 'x\nlocal\n');
         await e.refresh();
@@ -664,10 +990,51 @@ suite('sync/sync-engine', () => {
         assert.strictEqual(e.status('a.js'), 'clean');
     });
 
+    test('push - waits for save ack before advancing base', async () => {
+        await writeFile('a.js', 'x\nlocal\n');
+        const events = new EventEmitter<EventMap>();
+        const doc = {
+            text: 'x\n',
+            apply(op: ShareDbTextOp) {
+                doc.text = ottext.apply(doc.text, op) as string;
+            },
+            whenNothingPending(cb: () => void) {
+                cb();
+            }
+        };
+        const file = { type: 'file', uniqueId: 1, doc, dirty: false };
+        const saves: string[] = [];
+        const pm = {
+            files: new Map([['a.js', file]]),
+            write: async (_p: string, content: Uint8Array) => {
+                const op = delta(doc.text, norm(buffer.toString(content)));
+                if (op) {
+                    doc.apply(op);
+                    file.dirty = true;
+                }
+            },
+            save: (path: string) => {
+                saves.push(path);
+            }
+        } as unknown as ProjectManager;
+        const e = new NativeSyncEngine({ events, storageUri: storage });
+        await e.link({ folderUri: work, projectManager: pm, projectId: 1, branchId: 'main' });
+
+        const pushed = e.push();
+        await wait(25);
+
+        assert.deepStrictEqual(saves, ['a.js']);
+        assert.strictEqual(e.status('a.js'), 'modified');
+
+        events.emit('asset:file:save', 'a.js');
+        await pushed;
+        assert.strictEqual(e.status('a.js'), 'clean');
+    });
+
     test('push - no-op when nothing modified', async () => {
-        const { pm, applied, saved } = pushPm();
+        const { events, pm, applied, saved } = pushPm();
         await writeFile('a.js', 'x\n');
-        const e = engine();
+        const e = engine(events);
         await e.link({ folderUri: work, projectManager: pm, projectId: 1, branchId: 'main' });
         await e.push();
         assert.strictEqual(applied.length, 0);
@@ -675,9 +1042,9 @@ suite('sync/sync-engine', () => {
     });
 
     test('push - rejected when behind (no force push)', async () => {
-        const { pm, doc, applied } = pushPm();
+        const { events, pm, doc, applied } = pushPm();
         await writeFile('a.js', 'x\n');
-        const e = engine();
+        const e = engine(events);
         await e.link({ folderUri: work, projectManager: pm, projectId: 1, branchId: 'main' });
         doc.text = 'x\nremote\n';
         const [err] = await tryCatch(() => e.push());
@@ -813,9 +1180,11 @@ suite('sync/sync-engine', () => {
         await e.link({ folderUri: work, projectManager: pm, projectId: 1, branchId: 'main' });
         await writeFile('a.js', 'x\nlocal\n');
         await e.refresh();
-        await e.push();
+        const pushed = e.push();
+        await wait(25);
         assert.strictEqual((files.get('a.js') as { type: string }).type, 'file', 'subscribed until flush ack');
         events.emit('asset:file:save', 'a.js');
+        await pushed;
         for (let i = 0; i < 50 && (files.get('a.js') as { type: string }).type !== 'stub'; i++) {
             await new Promise((resolve) => setTimeout(resolve, 10));
         }
@@ -824,6 +1193,7 @@ suite('sync/sync-engine', () => {
 
     test('push - subscribes a modified stub and submits', async () => {
         await writeFile('a.js', 'x\n');
+        const events = new EventEmitter<EventMap>();
         const applied: ShareDbTextOp[] = [];
         const saved: string[] = [];
         const doc = {
@@ -850,9 +1220,12 @@ suite('sync/sync-engine', () => {
                 doc.apply(op);
                 file.dirty = true;
             },
-            save: (p: string) => saved.push(p)
+            save: (p: string) => {
+                saved.push(p);
+                events.emit('asset:file:save', p);
+            }
         } as unknown as ProjectManager;
-        const e = engine();
+        const e = engine(events);
         await e.link({ folderUri: work, projectManager: pm, projectId: 1, branchId: 'main' });
         await writeFile('a.js', 'x\nlocal\n');
         await e.refresh();
@@ -969,6 +1342,7 @@ suite('sync/sync-engine', () => {
         await writeFile('a.js', 'x\n');
         const e = new NativeSyncEngine({ events, storageUri: storage });
         await e.link({ folderUri: work, projectManager: pm, projectId: 1, branchId: 'main' });
+        await vscode.workspace.fs.delete(vscode.Uri.joinPath(work, 'a.js'), { recursive: false, useTrash: false });
         events.emit('sync:file:delete', 'a.js', 'file');
 
         assert.strictEqual(e.status('a.js'), 'deleted');
@@ -992,10 +1366,35 @@ suite('sync/sync-engine', () => {
         await writeFile('a.js', 'x\n');
         const e = new NativeSyncEngine({ events, storageUri: storage });
         await e.link({ folderUri: work, projectManager: pm, projectId: 1, branchId: 'main' });
+        await vscode.workspace.fs.delete(vscode.Uri.joinPath(work, 'a.js'), { recursive: false, useTrash: false });
         events.emit('sync:file:delete', 'a.js', 'file');
 
         await e.push();
         assert.strictEqual(e.status('a.js'), 'clean');
+    });
+
+    test('push - rejects local delete when remote changed', async () => {
+        const events = new EventEmitter<EventMap>();
+        const deleted: string[] = [];
+        const doc = { text: 'x\n' };
+        const file = { type: 'file', uniqueId: 1, doc, dirty: false };
+        const pm = {
+            files: new Map([['a.js', file]]),
+            delete: async (path: string) => {
+                deleted.push(path);
+            }
+        } as unknown as ProjectManager;
+        await writeFile('a.js', 'x\n');
+        const e = new NativeSyncEngine({ events, storageUri: storage });
+        await e.link({ folderUri: work, projectManager: pm, projectId: 1, branchId: 'main' });
+        await vscode.workspace.fs.delete(vscode.Uri.joinPath(work, 'a.js'), { recursive: false, useTrash: false });
+        events.emit('sync:file:delete', 'a.js', 'file');
+        doc.text = 'x\nremote\n';
+
+        const [err] = await tryCatch(() => e.push());
+
+        assert.ok(err, 'push should be blocked');
+        assert.deepStrictEqual(deleted, []);
     });
 
     test('push - renames local-only path', async () => {
@@ -1015,12 +1414,37 @@ suite('sync/sync-engine', () => {
         await writeFile('a.js', 'x\n');
         const e = new NativeSyncEngine({ events, storageUri: storage });
         await e.link({ folderUri: work, projectManager: pm, projectId: 1, branchId: 'main' });
+        await vscode.workspace.fs.rename(vscode.Uri.joinPath(work, 'a.js'), vscode.Uri.joinPath(work, 'b.js'));
         events.emit('sync:file:rename', 'a.js', 'b.js', 'file');
 
         assert.strictEqual(e.status('b.js'), 'renamed');
         await e.push();
         assert.deepStrictEqual(renamed, [['a.js', 'b.js']]);
         assert.strictEqual(e.status('b.js'), 'clean');
+    });
+
+    test('push - rejects local rename when remote changed', async () => {
+        const events = new EventEmitter<EventMap>();
+        const renamed: [string, string][] = [];
+        const doc = { text: 'x\n' };
+        const file = { type: 'file', uniqueId: 1, doc, dirty: false };
+        const pm = {
+            files: new Map([['a.js', file]]),
+            rename: async (from: string, to: string) => {
+                renamed.push([from, to]);
+            }
+        } as unknown as ProjectManager;
+        await writeFile('a.js', 'x\n');
+        const e = new NativeSyncEngine({ events, storageUri: storage });
+        await e.link({ folderUri: work, projectManager: pm, projectId: 1, branchId: 'main' });
+        await vscode.workspace.fs.rename(vscode.Uri.joinPath(work, 'a.js'), vscode.Uri.joinPath(work, 'b.js'));
+        events.emit('sync:file:rename', 'a.js', 'b.js', 'file');
+        doc.text = 'x\nremote\n';
+
+        const [err] = await tryCatch(() => e.push());
+
+        assert.ok(err, 'push should be blocked');
+        assert.deepStrictEqual(renamed, []);
     });
 
     test('push - consumes local rename echo', async () => {
@@ -1039,6 +1463,7 @@ suite('sync/sync-engine', () => {
         await writeFile('a.js', 'x\n');
         const e = new NativeSyncEngine({ events, storageUri: storage });
         await e.link({ folderUri: work, projectManager: pm, projectId: 1, branchId: 'main' });
+        await vscode.workspace.fs.rename(vscode.Uri.joinPath(work, 'a.js'), vscode.Uri.joinPath(work, 'b.js'));
         events.emit('sync:file:rename', 'a.js', 'b.js', 'file');
 
         await e.push();
@@ -1091,10 +1516,10 @@ suite('sync/sync-engine', () => {
     });
 
     test('resolve after conflict makes the file pushable (not stuck)', async () => {
-        const { pm, doc, applied } = pushPm();
+        const { events, pm, doc, applied } = pushPm();
         await writeFile('a.js', 'a\nb\nc\n');
         doc.text = 'a\nb\nc\n';
-        const e = engine();
+        const e = engine(events);
         await e.link({ folderUri: work, projectManager: pm, projectId: 1, branchId: 'main' });
 
         // local + remote change the same line -> conflict on pull

--- a/src/test/suite/utils.test.ts
+++ b/src/test/suite/utils.test.ts
@@ -442,4 +442,22 @@ suite('sync/sync-engine', () => {
         assert.ok(err, 'push should be rejected');
         assert.strictEqual(applied.length, 0, 'must not submit when behind');
     });
+
+    test('baseText returns the seeded base for a tracked file', async () => {
+        await writeFile('a.js', 'hello\n');
+        const e = engine();
+        await e.link({ folderUri: work, projectManager: pmWith({ text: 'hello\n' }), projectId: 1, branchId: 'main' });
+        assert.strictEqual(e.baseText('a.js'), 'hello\n');
+        assert.strictEqual(e.baseText('missing.js'), undefined);
+    });
+
+    test('remoteText returns the live doc text', async () => {
+        await writeFile('a.js', 'hello\n');
+        const doc = { text: 'hello\n' };
+        const e = engine();
+        await e.link({ folderUri: work, projectManager: pmWith(doc), projectId: 1, branchId: 'main' });
+        doc.text = 'hello\nremote\n';
+        assert.strictEqual(e.remoteText('a.js'), 'hello\nremote\n');
+        assert.strictEqual(e.remoteText('missing.js'), undefined);
+    });
 });

--- a/src/test/suite/utils.test.ts
+++ b/src/test/suite/utils.test.ts
@@ -4,6 +4,7 @@ import * as os from 'os';
 import { type as ottext } from 'ot-text';
 import * as vscode from 'vscode';
 
+import type { Rest, SyncItem, SyncPullResponse, SyncPushRequest } from '../../connections/rest';
 import { Disk } from '../../disk';
 import type { ProjectManager } from '../../project-manager';
 import { DecorationProvider } from '../../providers/decoration-provider';
@@ -322,6 +323,30 @@ suite('sync/base-store', () => {
         assert.strictEqual(b.get(2)?.text, 'second');
     });
 
+    test('persists sync metadata across reload', async () => {
+        const a = new BaseStore({ storageUri: dir });
+        await a.load(7, 'main');
+        a.setBase('base-1');
+        a.setSeq(5);
+        a.setItem({
+            kind: 'asset',
+            id: 10,
+            path: 'a.js',
+            type: 'file',
+            modifiedAt: '2026-06-25T00:00:00.000Z',
+            text: 'x\n'
+        });
+        const clientId = a.clientId;
+        await a.flush();
+
+        const b = new BaseStore({ storageUri: dir });
+        await b.load(7, 'main');
+        assert.strictEqual(b.base, 'base-1');
+        assert.strictEqual(b.seq, 5);
+        assert.strictEqual(b.clientId, clientId);
+        assert.strictEqual(b.byPath('a.js')?.text, 'x\n');
+    });
+
     test('load clears entries when no file exists', async () => {
         const store = new BaseStore({ storageUri: dir });
         store.set(99, 'stale');
@@ -446,6 +471,62 @@ suite('sync/sync-engine', () => {
             }
         } as unknown as ProjectManager;
         return { events, pm, doc, applied, saved };
+    };
+
+    const syncItem = (id: number, path: string, text = '', type: 'file' | 'folder' = 'file'): SyncItem => ({
+        kind: 'asset',
+        id,
+        path,
+        type,
+        modifiedAt: '2026-06-25T00:00:00.000Z',
+        text: type === 'file' ? text : undefined
+    });
+
+    const syncRest = (initial: SyncPullResponse) => {
+        let current = initial;
+        const pushes: SyncPushRequest[] = [];
+        const rest = {
+            syncPull: async () => current,
+            syncPush: async (_projectId: number, _branchId: string, body: SyncPushRequest) => {
+                pushes.push(body);
+                const op = body.ops[0];
+                const items = current.items.slice();
+                if (op.type === 'update_text') {
+                    current = {
+                        base: `base-${pushes.length}`,
+                        items: items.map((item) => (item.id === op.id ? { ...item, text: op.text } : item))
+                    };
+                } else if (op.type === 'create_file') {
+                    current = {
+                        base: `base-${pushes.length}`,
+                        items: items.concat(syncItem(100 + pushes.length, op.path, op.text))
+                    };
+                } else if (op.type === 'create_folder') {
+                    current = {
+                        base: `base-${pushes.length}`,
+                        items: items.concat(syncItem(100 + pushes.length, op.path, '', 'folder'))
+                    };
+                } else if (op.type === 'rename') {
+                    current = {
+                        base: `base-${pushes.length}`,
+                        items: items.map((item) => (item.id === op.id ? { ...item, path: op.path } : item))
+                    };
+                } else {
+                    current = {
+                        base: `base-${pushes.length}`,
+                        items: items.filter((item) => item.id !== op.id)
+                    };
+                }
+                return current;
+            }
+        } as unknown as Rest;
+        return {
+            rest,
+            pushes,
+            set(snapshot: SyncPullResponse) {
+                current = snapshot;
+            }
+        };
     };
 
     test('clean when working equals remote', async () => {
@@ -578,6 +659,93 @@ suite('sync/sync-engine', () => {
         await e.pull();
         assert.strictEqual(await readFile('a.js'), 'x\ny\n');
         assert.strictEqual(e.status('a.js'), 'clean');
+    });
+
+    test('rest pull - fast-forwards from remote snapshot', async () => {
+        await writeFile('a.js', 'x\n');
+        const api = syncRest({ base: 'base-0', items: [syncItem(10, 'a.js', 'x\n')] });
+        const e = engine();
+        await e.link({
+            folderUri: work,
+            projectManager: pmWith({ text: 'ignored\n' }),
+            projectId: 1,
+            branchId: 'main',
+            rest: api.rest
+        });
+
+        api.set({ base: 'base-1', items: [syncItem(10, 'a.js', 'x\nremote\n')] });
+        await e.pull();
+
+        assert.strictEqual(await readFile('a.js'), 'x\nremote\n');
+        assert.strictEqual(e.status('a.js'), 'clean');
+        assert.strictEqual(await e.remoteText('a.js'), 'x\nremote\n');
+    });
+
+    test('rest push - sends update_text with client seq and base', async () => {
+        await writeFile('a.js', 'x\n');
+        const api = syncRest({ base: 'base-0', items: [syncItem(10, 'a.js', 'x\n')] });
+        const e = engine();
+        await e.link({
+            folderUri: work,
+            projectManager: pmWith({ text: 'ignored\n' }),
+            projectId: 1,
+            branchId: 'main',
+            rest: api.rest
+        });
+
+        await writeFile('a.js', 'x\nlocal\n');
+        await e.refresh();
+        await e.push();
+
+        assert.strictEqual(api.pushes.length, 1);
+        assert.strictEqual(api.pushes[0].base, 'base-0');
+        assert.strictEqual(api.pushes[0].seq, 1);
+        assert.strictEqual(typeof api.pushes[0].clientId, 'string');
+        assert.deepStrictEqual(api.pushes[0].ops, [{ type: 'update_text', id: 10, text: 'x\nlocal\n' }]);
+        assert.strictEqual(e.status('a.js'), 'clean');
+    });
+
+    test('rest incoming - collaborator event refreshes incoming snapshot', async () => {
+        await writeFile('a.js', 'x\n');
+        const events = new EventEmitter<EventMap>();
+        const api = syncRest({ base: 'base-0', items: [syncItem(10, 'a.js', 'x\n')] });
+        const e = engine(events);
+        await e.link({
+            folderUri: work,
+            projectManager: pmWith({ text: 'ignored\n' }),
+            projectId: 1,
+            branchId: 'main',
+            rest: api.rest
+        });
+
+        api.set({ base: 'base-1', items: [syncItem(10, 'a.js', 'x\nremote\n')] });
+        events.emit('asset:file:update', 'a.js', [], 'x\nremote\n', 'x\n');
+        for (let i = 0; i < 80 && e.status('a.js') !== 'behind'; i++) {
+            await wait(10);
+        }
+
+        assert.strictEqual(e.status('a.js'), 'behind');
+        assert.strictEqual(await e.remoteText('a.js'), 'x\nremote\n');
+    });
+
+    test('rest pull - applies remote rename as one structural change', async () => {
+        await writeFile('a.js', 'x\n');
+        const api = syncRest({ base: 'base-0', items: [syncItem(10, 'a.js', 'x\n')] });
+        const e = engine();
+        await e.link({
+            folderUri: work,
+            projectManager: pmWith({ text: 'ignored\n' }),
+            projectId: 1,
+            branchId: 'main',
+            rest: api.rest
+        });
+
+        api.set({ base: 'base-1', items: [syncItem(10, 'b.js', 'x\n')] });
+        await e.pull();
+
+        assert.strictEqual(await exists('a.js'), false);
+        assert.strictEqual(await readFile('b.js'), 'x\n');
+        assert.strictEqual(e.status('b.js'), 'clean');
     });
 
     test('pull - applies content update through disk apply event', async () => {

--- a/src/test/suite/utils.test.ts
+++ b/src/test/suite/utils.test.ts
@@ -264,6 +264,9 @@ suite('sync/sync-engine', () => {
         await vscode.workspace.fs.writeFile(vscode.Uri.joinPath(work, name), buffer.from(text));
     };
 
+    const readFile = async (name: string) =>
+        buffer.toString(await vscode.workspace.fs.readFile(vscode.Uri.joinPath(work, name)));
+
     const engine = () => new NativeSyncEngine({ events: new EventEmitter<EventMap>(), storageUri: storage });
 
     const pmWith = (doc: { text: string }) => {
@@ -327,5 +330,50 @@ suite('sync/sync-engine', () => {
         const e2 = engine();
         await e2.link({ folderUri: work, projectManager: pmWith({ text: 'x\n' }), projectId: 1, branchId: 'main' });
         assert.strictEqual(e2.status('a.js'), 'modified');
+    });
+
+    test('pull - fast-forward when no local edits', async () => {
+        await writeFile('a.js', 'x\n');
+        const doc = { text: 'x\n' };
+        const e = engine();
+        await e.link({ folderUri: work, projectManager: pmWith(doc), projectId: 1, branchId: 'main' });
+        doc.text = 'x\ny\n';
+        await e.pull();
+        assert.strictEqual(await readFile('a.js'), 'x\ny\n');
+        assert.strictEqual(e.status('a.js'), 'clean');
+    });
+
+    test('pull - leaves local edits when remote unchanged', async () => {
+        await writeFile('a.js', 'x\n');
+        const e = engine();
+        await e.link({ folderUri: work, projectManager: pmWith({ text: 'x\n' }), projectId: 1, branchId: 'main' });
+        await writeFile('a.js', 'x\nlocal\n');
+        await e.pull();
+        assert.strictEqual(await readFile('a.js'), 'x\nlocal\n');
+        assert.strictEqual(e.status('a.js'), 'modified');
+    });
+
+    test('pull - clean 3-way merge of non-overlapping edits', async () => {
+        await writeFile('a.js', 'a\nb\nc\n');
+        const doc = { text: 'a\nb\nc\n' };
+        const e = engine();
+        await e.link({ folderUri: work, projectManager: pmWith(doc), projectId: 1, branchId: 'main' });
+        await writeFile('a.js', 'A\nb\nc\n');
+        doc.text = 'a\nb\nC\n';
+        await e.pull();
+        assert.strictEqual(await readFile('a.js'), 'A\nb\nC\n');
+        assert.strictEqual(e.status('a.js'), 'modified');
+    });
+
+    test('pull - conflict writes markers and stays conflicted', async () => {
+        await writeFile('a.js', 'a\nb\nc\n');
+        const doc = { text: 'a\nb\nc\n' };
+        const e = engine();
+        await e.link({ folderUri: work, projectManager: pmWith(doc), projectId: 1, branchId: 'main' });
+        await writeFile('a.js', 'a\nLOCAL\nc\n');
+        doc.text = 'a\nREMOTE\nc\n';
+        await e.pull();
+        assert.ok((await readFile('a.js')).includes('<<<<<<< Working (your changes)'), 'has markers');
+        assert.strictEqual(e.status('a.js'), 'conflicted');
     });
 });

--- a/src/test/suite/utils.test.ts
+++ b/src/test/suite/utils.test.ts
@@ -268,6 +268,11 @@ suite('sync/sync-engine', () => {
     const readFile = async (name: string) =>
         buffer.toString(await vscode.workspace.fs.readFile(vscode.Uri.joinPath(work, name)));
 
+    const exists = async (name: string) => {
+        const [err] = await tryCatch(async () => vscode.workspace.fs.stat(vscode.Uri.joinPath(work, name)));
+        return !err;
+    };
+
     const engine = () => new NativeSyncEngine({ events: new EventEmitter<EventMap>(), storageUri: storage });
 
     const pmWith = (doc: { text: string }) => {
@@ -407,6 +412,220 @@ suite('sync/sync-engine', () => {
         assert.strictEqual(e.status('a.js'), 'conflicted');
     });
 
+    test('pull - applies remote create only when pulled', async () => {
+        const events = new EventEmitter<EventMap>();
+        const files = new Map<string, unknown>();
+        const pm = { files } as unknown as ProjectManager;
+        const e = new NativeSyncEngine({ events, storageUri: storage });
+        await e.link({ folderUri: work, projectManager: pm, projectId: 1, branchId: 'main' });
+
+        files.set('new.js', { type: 'file', uniqueId: 10, doc: { text: 'remote\n' }, dirty: false });
+        events.emit('asset:file:create', 'new.js', 'file', buffer.from('remote\n'));
+        assert.strictEqual(await exists('new.js'), false);
+        assert.strictEqual(e.status('new.js'), 'behind');
+
+        events.on('sync:file:apply:create', async (path, _type, content, done) => {
+            await writeFile(path, norm(buffer.toString(content)));
+            done();
+        });
+        await e.pull();
+        assert.strictEqual(await readFile('new.js'), 'remote\n');
+        assert.strictEqual(e.status('new.js'), 'clean');
+    });
+
+    test('pull - applies remote delete only when pulled', async () => {
+        await writeFile('a.js', 'x\n');
+        const events = new EventEmitter<EventMap>();
+        const files = new Map<string, unknown>([
+            ['a.js', { type: 'file', uniqueId: 1, doc: { text: 'x\n' }, dirty: false }]
+        ]);
+        const pm = { files } as unknown as ProjectManager;
+        const e = new NativeSyncEngine({ events, storageUri: storage });
+        await e.link({ folderUri: work, projectManager: pm, projectId: 1, branchId: 'main' });
+
+        files.delete('a.js');
+        events.emit('asset:file:delete', 'a.js');
+        assert.strictEqual(await exists('a.js'), true);
+        assert.strictEqual(e.status('a.js'), 'behind');
+
+        events.on('sync:file:apply:delete', async (path, done) => {
+            await vscode.workspace.fs.delete(vscode.Uri.joinPath(work, path), { recursive: false, useTrash: false });
+            done();
+        });
+        await e.pull();
+        assert.strictEqual(await exists('a.js'), false);
+        assert.strictEqual(e.status('a.js'), 'clean');
+    });
+
+    test('pull - applies remote rename only when pulled', async () => {
+        await writeFile('a.js', 'x\n');
+        const events = new EventEmitter<EventMap>();
+        const file = { type: 'file', uniqueId: 1, doc: { text: 'x\n' }, dirty: false };
+        const files = new Map<string, unknown>([['a.js', file]]);
+        const pm = { files } as unknown as ProjectManager;
+        const e = new NativeSyncEngine({ events, storageUri: storage });
+        await e.link({ folderUri: work, projectManager: pm, projectId: 1, branchId: 'main' });
+
+        files.delete('a.js');
+        files.set('b.js', file);
+        events.emit('asset:file:rename', 'a.js', 'b.js');
+        assert.strictEqual(await exists('a.js'), true);
+        assert.strictEqual(await exists('b.js'), false);
+        assert.strictEqual(e.status('b.js'), 'behind');
+
+        events.on('sync:file:apply:rename', async (from, to, done) => {
+            await vscode.workspace.fs.rename(vscode.Uri.joinPath(work, from), vscode.Uri.joinPath(work, to));
+            done();
+        });
+        await e.pull();
+        assert.strictEqual(await exists('a.js'), false);
+        assert.strictEqual(await readFile('b.js'), 'x\n');
+        assert.strictEqual(e.status('b.js'), 'clean');
+    });
+
+    test('pull - applies remote rename over local edit as modified', async () => {
+        await writeFile('a.js', 'x\n');
+        const events = new EventEmitter<EventMap>();
+        const file = { type: 'file', uniqueId: 1, doc: { text: 'x\n' }, dirty: false };
+        const files = new Map<string, unknown>([['a.js', file]]);
+        const pm = { files } as unknown as ProjectManager;
+        const e = new NativeSyncEngine({ events, storageUri: storage });
+        await e.link({ folderUri: work, projectManager: pm, projectId: 1, branchId: 'main' });
+        await writeFile('a.js', 'local\n');
+        await e.refresh();
+
+        files.delete('a.js');
+        files.set('b.js', file);
+        events.emit('asset:file:rename', 'a.js', 'b.js');
+        assert.strictEqual(e.status('b.js'), 'behind');
+
+        events.on('sync:file:apply:rename', async (from, to, done) => {
+            await vscode.workspace.fs.rename(vscode.Uri.joinPath(work, from), vscode.Uri.joinPath(work, to));
+            done();
+        });
+        await e.pull();
+        assert.strictEqual(await exists('a.js'), false);
+        assert.strictEqual(await readFile('b.js'), 'local\n');
+        assert.strictEqual(e.status('b.js'), 'modified');
+    });
+
+    test('pull - blocks remote delete over local edit', async () => {
+        await writeFile('a.js', 'x\n');
+        const events = new EventEmitter<EventMap>();
+        const files = new Map<string, unknown>([
+            ['a.js', { type: 'file', uniqueId: 1, doc: { text: 'x\n' }, dirty: false }]
+        ]);
+        const pm = { files } as unknown as ProjectManager;
+        const e = new NativeSyncEngine({ events, storageUri: storage });
+        await e.link({ folderUri: work, projectManager: pm, projectId: 1, branchId: 'main' });
+        await writeFile('a.js', 'local\n');
+        await e.refresh();
+
+        files.delete('a.js');
+        events.emit('asset:file:delete', 'a.js');
+        assert.strictEqual(e.status('a.js'), 'conflicted');
+        const [err] = await tryCatch(() => e.pull());
+        assert.ok(err, 'pull should be blocked');
+        assert.strictEqual(await readFile('a.js'), 'local\n');
+    });
+
+    test('pull - blocks remote create over local add', async () => {
+        const events = new EventEmitter<EventMap>();
+        const files = new Map<string, unknown>();
+        const pm = { files } as unknown as ProjectManager;
+        const e = new NativeSyncEngine({ events, storageUri: storage });
+        await e.link({ folderUri: work, projectManager: pm, projectId: 1, branchId: 'main' });
+        await writeFile('new.js', 'local\n');
+        events.emit('sync:file:create', 'new.js', 'file');
+
+        files.set('new.js', { type: 'file', uniqueId: 10, doc: { text: 'remote\n' }, dirty: false });
+        events.emit('asset:file:create', 'new.js', 'file', buffer.from('remote\n'));
+        assert.strictEqual(e.status('new.js'), 'conflicted');
+        const [err] = await tryCatch(() => e.pull());
+        assert.ok(err, 'pull should be blocked');
+        assert.strictEqual(await readFile('new.js'), 'local\n');
+    });
+
+    test('structural conflict - keep current add becomes modified against remote create', async () => {
+        const events = new EventEmitter<EventMap>();
+        const file = { type: 'file', uniqueId: 10, doc: { text: 'remote\n' }, dirty: false };
+        const files = new Map<string, unknown>();
+        const written: string[] = [];
+        const saved: string[] = [];
+        const pm = {
+            files,
+            write: async (_p: string, content: Uint8Array) => {
+                const op = delta(file.doc.text, norm(buffer.toString(content)));
+                if (op) {
+                    file.doc.text = ottext.apply(file.doc.text, op) as string;
+                    written.push(file.doc.text);
+                }
+            },
+            save: (p: string) => saved.push(p)
+        } as unknown as ProjectManager;
+        const e = new NativeSyncEngine({ events, storageUri: storage });
+        await e.link({ folderUri: work, projectManager: pm, projectId: 1, branchId: 'main' });
+        await writeFile('new.js', 'local\n');
+        events.emit('sync:file:create', 'new.js', 'file');
+
+        files.set('new.js', file);
+        events.emit('asset:file:create', 'new.js', 'file', buffer.from('remote\n'));
+        assert.ok(e.structuralConflict('new.js'));
+
+        await e.keepCurrent(vscode.Uri.joinPath(work, 'new.js'));
+        assert.strictEqual(e.status('new.js'), 'modified');
+        await e.push();
+        assert.deepStrictEqual(written, ['local\n']);
+        assert.deepStrictEqual(saved, ['new.js']);
+    });
+
+    test('structural conflict - accept incoming create overwrites local add', async () => {
+        const events = new EventEmitter<EventMap>();
+        const files = new Map<string, unknown>();
+        const pm = { files } as unknown as ProjectManager;
+        const e = new NativeSyncEngine({ events, storageUri: storage });
+        await e.link({ folderUri: work, projectManager: pm, projectId: 1, branchId: 'main' });
+        await writeFile('new.js', 'local\n');
+        events.emit('sync:file:create', 'new.js', 'file');
+
+        files.set('new.js', { type: 'file', uniqueId: 10, doc: { text: 'remote\n' }, dirty: false });
+        events.emit('asset:file:create', 'new.js', 'file', buffer.from('remote\n'));
+        events.on('sync:file:apply:delete', async (path, done) => {
+            await vscode.workspace.fs.delete(vscode.Uri.joinPath(work, path), { recursive: false, useTrash: false });
+            done();
+        });
+        events.on('sync:file:apply:create', async (path, _type, content, done) => {
+            await writeFile(path, norm(buffer.toString(content)));
+            done();
+        });
+
+        await e.acceptIncoming(vscode.Uri.joinPath(work, 'new.js'));
+        assert.strictEqual(await readFile('new.js'), 'remote\n');
+        assert.strictEqual(e.status('new.js'), 'clean');
+    });
+
+    test('structural conflict - accept incoming delete removes local edit', async () => {
+        await writeFile('a.js', 'local\n');
+        const events = new EventEmitter<EventMap>();
+        const files = new Map<string, unknown>([
+            ['a.js', { type: 'file', uniqueId: 1, doc: { text: 'x\n' }, dirty: false }]
+        ]);
+        const pm = { files } as unknown as ProjectManager;
+        const e = new NativeSyncEngine({ events, storageUri: storage });
+        await e.link({ folderUri: work, projectManager: pm, projectId: 1, branchId: 'main' });
+        await e.refresh();
+        files.delete('a.js');
+        events.emit('asset:file:delete', 'a.js');
+        events.on('sync:file:apply:delete', async (path, done) => {
+            await vscode.workspace.fs.delete(vscode.Uri.joinPath(work, path), { recursive: false, useTrash: false });
+            done();
+        });
+
+        await e.acceptIncoming(vscode.Uri.joinPath(work, 'a.js'));
+        assert.strictEqual(await exists('a.js'), false);
+        assert.strictEqual(e.status('a.js'), 'clean');
+    });
+
     test('push - submits delta, flushes, advances base', async () => {
         const { pm, applied, saved } = pushPm();
         await writeFile('a.js', 'x\n');
@@ -461,27 +680,48 @@ suite('sync/sync-engine', () => {
         assert.strictEqual(await e.remoteText('missing.js'), undefined);
     });
 
-    test('stub - tracks remote via s3 hash without subscribing', async () => {
+    test('remoteText subscribes stub to read realtime doc', async () => {
         await writeFile('a.js', 'x\n');
-        let s3 = hash('x\n');
+        let subscribed = 0;
+        const file = { type: 'file', uniqueId: 1, doc: { text: 'x\nremote\n' }, dirty: false };
+        const files = new Map<string, unknown>([['a.js', { type: 'stub', uniqueId: 1, dirty: false }]]);
+        const pm = {
+            files,
+            subscribe: async (p: string) => {
+                subscribed++;
+                files.set(p, file);
+                return file;
+            },
+            unsubscribe: async (p: string) => {
+                files.set(p, { type: 'stub', uniqueId: 1, dirty: false });
+            }
+        } as unknown as ProjectManager;
+        const e = engine();
+        await e.link({ folderUri: work, projectManager: pm, projectId: 1, branchId: 'main' });
+        assert.strictEqual(await e.remoteText('a.js'), 'x\nremote\n');
+        assert.strictEqual(subscribed, 1);
+        assert.strictEqual((files.get('a.js') as { type: string }).type, 'stub');
+    });
+
+    test('stub - ignores s3 hash until realtime doc is subscribed', async () => {
+        await writeFile('a.js', 'x\n');
+        let remoteHash = hash('x\n');
         const files = new Map([['a.js', { type: 'stub', uniqueId: 1, dirty: false }]]);
-        const pm = { files, fileHash: () => s3 } as unknown as ProjectManager;
+        const pm = { files, fileHash: () => remoteHash } as unknown as ProjectManager;
         const e = engine();
         await e.link({ folderUri: work, projectManager: pm, projectId: 1, branchId: 'main' });
         assert.strictEqual(e.status('a.js'), 'clean');
-        s3 = hash('x\nremote\n');
+        remoteHash = hash('x\nremote\n');
         await e.refresh();
-        assert.strictEqual(e.status('a.js'), 'behind');
+        assert.strictEqual(e.status('a.js'), 'clean');
     });
 
-    test('pull - subscribes a behind stub and fast-forwards', async () => {
+    test('pull - subscribes an unloaded stub and fast-forwards from realtime doc', async () => {
         await writeFile('a.js', 'x\n');
-        let s3 = hash('x\n');
         const doc = { text: 'x\nremote\n' };
         const files = new Map<string, unknown>([['a.js', { type: 'stub', uniqueId: 1, dirty: false }]]);
         const pm = {
             files,
-            fileHash: () => s3,
             // mirrors ProjectManager.subscribe: promotes the stub in place
             subscribe: async (p: string) => {
                 const promoted = { type: 'file', uniqueId: 1, doc, dirty: false };
@@ -495,7 +735,6 @@ suite('sync/sync-engine', () => {
         } as unknown as ProjectManager;
         const e = engine();
         await e.link({ folderUri: work, projectManager: pm, projectId: 1, branchId: 'main' });
-        s3 = hash('x\nremote\n');
         await e.pull();
         assert.strictEqual(await readFile('a.js'), 'x\nremote\n');
         assert.strictEqual(e.status('a.js'), 'clean');
@@ -505,7 +744,7 @@ suite('sync/sync-engine', () => {
     test('subscribe upgrades stub status to the live doc', async () => {
         await writeFile('a.js', 'x\n');
         const files = new Map<string, unknown>([['a.js', { type: 'stub', uniqueId: 1, dirty: false }]]);
-        const pm = { files, fileHash: () => hash('x\n') } as unknown as ProjectManager;
+        const pm = { files } as unknown as ProjectManager;
         const events = new EventEmitter<EventMap>();
         const e = new NativeSyncEngine({ events, storageUri: storage });
         await e.link({ folderUri: work, projectManager: pm, projectId: 1, branchId: 'main' });
@@ -531,7 +770,6 @@ suite('sync/sync-engine', () => {
         const files = new Map<string, unknown>([['a.js', { type: 'stub', uniqueId: 1, dirty: false }]]);
         const pm = {
             files,
-            fileHash: () => hash('x\n'),
             subscribe: async (p: string) => {
                 files.set(p, file);
                 return file;
@@ -576,7 +814,6 @@ suite('sync/sync-engine', () => {
         const files = new Map<string, unknown>([['a.js', { type: 'stub', uniqueId: 1, dirty: false }]]);
         const pm = {
             files,
-            fileHash: () => hash('x\n'),
             subscribe: async (p: string) => {
                 files.set(p, file);
                 return file;
@@ -602,6 +839,120 @@ suite('sync/sync-engine', () => {
         assert.strictEqual(doc.text, 'x\nlocal\n');
         assert.deepStrictEqual(saved, ['a.js'], 'flushed to server');
         assert.strictEqual(e.status('a.js'), 'clean');
+    });
+
+    test('push - rejects modified stub when realtime doc moved', async () => {
+        await writeFile('a.js', 'x\n');
+        const applied: ShareDbTextOp[] = [];
+        const doc = {
+            text: 'x\nremote\n',
+            apply(op: ShareDbTextOp) {
+                applied.push(op);
+                doc.text = ottext.apply(doc.text, op) as string;
+            }
+        };
+        const file = { type: 'file', uniqueId: 1, doc, dirty: false };
+        const files = new Map<string, unknown>([['a.js', { type: 'stub', uniqueId: 1, dirty: false }]]);
+        const pm = {
+            files,
+            subscribe: async (p: string) => {
+                files.set(p, file);
+                return file;
+            },
+            write: async (_p: string, content: Uint8Array) => {
+                const op = delta(doc.text, norm(buffer.toString(content)));
+                if (op) {
+                    doc.apply(op);
+                }
+            },
+            save: () => undefined,
+            unsubscribe: async (p: string) => {
+                files.set(p, { type: 'stub', uniqueId: 1, dirty: false });
+            }
+        } as unknown as ProjectManager;
+        const e = engine();
+        await e.link({ folderUri: work, projectManager: pm, projectId: 1, branchId: 'main' });
+        await writeFile('a.js', 'x\nlocal\n');
+        await e.refresh();
+        const [err] = await tryCatch(() => e.push());
+        assert.ok(err, 'push should be rejected');
+        assert.strictEqual(applied.length, 0);
+    });
+
+    test('push - creates local-only file', async () => {
+        const events = new EventEmitter<EventMap>();
+        const created: [string, 'file' | 'folder', string][] = [];
+        const files = new Map<string, unknown>();
+        const pm = {
+            files,
+            create: async (p: string, t: 'file' | 'folder', content?: Uint8Array) => {
+                created.push([p, t, content ? norm(buffer.toString(content)) : '']);
+                files.set(p, {
+                    type: t,
+                    uniqueId: 10,
+                    doc: { text: content ? norm(buffer.toString(content)) : '' },
+                    dirty: false
+                });
+            }
+        } as unknown as ProjectManager;
+        const e = new NativeSyncEngine({ events, storageUri: storage });
+        await e.link({ folderUri: work, projectManager: pm, projectId: 1, branchId: 'main' });
+        await writeFile('new.js', 'new\n');
+        events.emit('sync:file:create', 'new.js', 'file');
+
+        assert.strictEqual(e.status('new.js'), 'added');
+        await e.push();
+        assert.deepStrictEqual(created, [['new.js', 'file', 'new\n']]);
+        assert.strictEqual(e.status('new.js'), 'clean');
+    });
+
+    test('push - deletes local-only file removal', async () => {
+        const events = new EventEmitter<EventMap>();
+        const deleted: [string, 'file' | 'folder'][] = [];
+        const files = new Map<string, unknown>([
+            ['a.js', { type: 'file', uniqueId: 1, doc: { text: 'x\n' }, dirty: false }]
+        ]);
+        const pm = {
+            files,
+            delete: async (p: string, t: 'file' | 'folder') => {
+                deleted.push([p, t]);
+                files.delete(p);
+            }
+        } as unknown as ProjectManager;
+        await writeFile('a.js', 'x\n');
+        const e = new NativeSyncEngine({ events, storageUri: storage });
+        await e.link({ folderUri: work, projectManager: pm, projectId: 1, branchId: 'main' });
+        events.emit('sync:file:delete', 'a.js', 'file');
+
+        assert.strictEqual(e.status('a.js'), 'deleted');
+        await e.push();
+        assert.deepStrictEqual(deleted, [['a.js', 'file']]);
+        assert.strictEqual(e.status('a.js'), 'clean');
+    });
+
+    test('push - renames local-only path', async () => {
+        const events = new EventEmitter<EventMap>();
+        const renamed: [string, string][] = [];
+        const files = new Map<string, unknown>([
+            ['a.js', { type: 'file', uniqueId: 1, doc: { text: 'x\n' }, dirty: false }]
+        ]);
+        const pm = {
+            files,
+            rename: async (from: string, to: string) => {
+                renamed.push([from, to]);
+                files.set(to, files.get(from));
+                files.delete(from);
+            }
+        } as unknown as ProjectManager;
+        await writeFile('a.js', 'x\n');
+        const e = new NativeSyncEngine({ events, storageUri: storage });
+        await e.link({ folderUri: work, projectManager: pm, projectId: 1, branchId: 'main' });
+        events.emit('sync:file:rename', 'a.js', 'b.js', 'file');
+
+        assert.strictEqual(e.status('b.js'), 'renamed');
+        await e.push();
+        assert.deepStrictEqual(renamed, [['a.js', 'b.js']]);
+        assert.strictEqual(e.status('b.js'), 'clean');
     });
 
     test('discard reverts the working file to base', async () => {

--- a/src/test/suite/utils.test.ts
+++ b/src/test/suite/utils.test.ts
@@ -457,8 +457,151 @@ suite('sync/sync-engine', () => {
         const e = engine();
         await e.link({ folderUri: work, projectManager: pmWith(doc), projectId: 1, branchId: 'main' });
         doc.text = 'hello\nremote\n';
-        assert.strictEqual(e.remoteText('a.js'), 'hello\nremote\n');
-        assert.strictEqual(e.remoteText('missing.js'), undefined);
+        assert.strictEqual(await e.remoteText('a.js'), 'hello\nremote\n');
+        assert.strictEqual(await e.remoteText('missing.js'), undefined);
+    });
+
+    test('stub - tracks remote via s3 hash without subscribing', async () => {
+        await writeFile('a.js', 'x\n');
+        let s3 = hash('x\n');
+        const files = new Map([['a.js', { type: 'stub', uniqueId: 1, dirty: false }]]);
+        const pm = { files, fileHash: () => s3 } as unknown as ProjectManager;
+        const e = engine();
+        await e.link({ folderUri: work, projectManager: pm, projectId: 1, branchId: 'main' });
+        assert.strictEqual(e.status('a.js'), 'clean');
+        s3 = hash('x\nremote\n');
+        await e.refresh();
+        assert.strictEqual(e.status('a.js'), 'behind');
+    });
+
+    test('pull - subscribes a behind stub and fast-forwards', async () => {
+        await writeFile('a.js', 'x\n');
+        let s3 = hash('x\n');
+        const doc = { text: 'x\nremote\n' };
+        const files = new Map<string, unknown>([['a.js', { type: 'stub', uniqueId: 1, dirty: false }]]);
+        const pm = {
+            files,
+            fileHash: () => s3,
+            // mirrors ProjectManager.subscribe: promotes the stub in place
+            subscribe: async (p: string) => {
+                const promoted = { type: 'file', uniqueId: 1, doc, dirty: false };
+                files.set(p, promoted);
+                return promoted;
+            },
+            // mirrors ProjectManager.unsubscribe: demotes back to a stub
+            unsubscribe: async (p: string) => {
+                files.set(p, { type: 'stub', uniqueId: 1, dirty: false });
+            }
+        } as unknown as ProjectManager;
+        const e = engine();
+        await e.link({ folderUri: work, projectManager: pm, projectId: 1, branchId: 'main' });
+        s3 = hash('x\nremote\n');
+        await e.pull();
+        assert.strictEqual(await readFile('a.js'), 'x\nremote\n');
+        assert.strictEqual(e.status('a.js'), 'clean');
+        assert.strictEqual((files.get('a.js') as { type: string }).type, 'stub', 'released after pull');
+    });
+
+    test('subscribe upgrades stub status to the live doc', async () => {
+        await writeFile('a.js', 'x\n');
+        const files = new Map<string, unknown>([['a.js', { type: 'stub', uniqueId: 1, dirty: false }]]);
+        const pm = { files, fileHash: () => hash('x\n') } as unknown as ProjectManager;
+        const events = new EventEmitter<EventMap>();
+        const e = new NativeSyncEngine({ events, storageUri: storage });
+        await e.link({ folderUri: work, projectManager: pm, projectId: 1, branchId: 'main' });
+        assert.strictEqual(e.status('a.js'), 'clean');
+        // editor open promotes the stub; the doc carries unflushed remote edits
+        files.set('a.js', { type: 'file', uniqueId: 1, doc: { text: 'x\nremote\n' }, dirty: true });
+        events.emit('asset:file:subscribed', 'a.js', 'x\nremote\n', true);
+        for (let i = 0; i < 50 && e.status('a.js') !== 'behind'; i++) {
+            await new Promise((resolve) => setTimeout(resolve, 10));
+        }
+        assert.strictEqual(e.status('a.js'), 'behind');
+    });
+
+    test('push - releases the promoted doc once the flush lands', async () => {
+        await writeFile('a.js', 'x\n');
+        const doc = {
+            text: 'x\n',
+            apply(op: ShareDbTextOp) {
+                doc.text = ottext.apply(doc.text, op) as string;
+            }
+        };
+        const file = { type: 'file', uniqueId: 1, doc, dirty: false };
+        const files = new Map<string, unknown>([['a.js', { type: 'stub', uniqueId: 1, dirty: false }]]);
+        const pm = {
+            files,
+            fileHash: () => hash('x\n'),
+            subscribe: async (p: string) => {
+                files.set(p, file);
+                return file;
+            },
+            write: async (_p: string, content: Uint8Array) => {
+                const op = delta(doc.text, norm(buffer.toString(content)));
+                if (op) {
+                    doc.apply(op);
+                }
+            },
+            save: () => undefined,
+            unsubscribe: async (p: string) => {
+                files.set(p, { type: 'stub', uniqueId: 1, dirty: file.dirty });
+            }
+        } as unknown as ProjectManager;
+        const events = new EventEmitter<EventMap>();
+        const e = new NativeSyncEngine({ events, storageUri: storage });
+        await e.link({ folderUri: work, projectManager: pm, projectId: 1, branchId: 'main' });
+        await writeFile('a.js', 'x\nlocal\n');
+        await e.refresh();
+        await e.push();
+        assert.strictEqual((files.get('a.js') as { type: string }).type, 'file', 'subscribed until flush ack');
+        events.emit('asset:file:save', 'a.js');
+        for (let i = 0; i < 50 && (files.get('a.js') as { type: string }).type !== 'stub'; i++) {
+            await new Promise((resolve) => setTimeout(resolve, 10));
+        }
+        assert.strictEqual((files.get('a.js') as { type: string }).type, 'stub', 'released after flush ack');
+    });
+
+    test('push - subscribes a modified stub and submits', async () => {
+        await writeFile('a.js', 'x\n');
+        const applied: ShareDbTextOp[] = [];
+        const saved: string[] = [];
+        const doc = {
+            text: 'x\n',
+            apply(op: ShareDbTextOp) {
+                applied.push(op);
+                doc.text = ottext.apply(doc.text, op) as string;
+            }
+        };
+        const file = { type: 'file', uniqueId: 1, doc, dirty: false };
+        const files = new Map<string, unknown>([['a.js', { type: 'stub', uniqueId: 1, dirty: false }]]);
+        const pm = {
+            files,
+            fileHash: () => hash('x\n'),
+            subscribe: async (p: string) => {
+                files.set(p, file);
+                return file;
+            },
+            // mirrors ProjectManager.write: delta vs live doc, mark dirty
+            write: async (_p: string, content: Uint8Array) => {
+                const op = delta(doc.text, norm(buffer.toString(content)));
+                if (!op) {
+                    return;
+                }
+                doc.apply(op);
+                file.dirty = true;
+            },
+            save: (p: string) => saved.push(p)
+        } as unknown as ProjectManager;
+        const e = engine();
+        await e.link({ folderUri: work, projectManager: pm, projectId: 1, branchId: 'main' });
+        await writeFile('a.js', 'x\nlocal\n');
+        await e.refresh();
+        assert.strictEqual(e.status('a.js'), 'modified');
+        await e.push();
+        assert.strictEqual(applied.length, 1, 'one op submitted');
+        assert.strictEqual(doc.text, 'x\nlocal\n');
+        assert.deepStrictEqual(saved, ['a.js'], 'flushed to server');
+        assert.strictEqual(e.status('a.js'), 'clean');
     });
 
     test('discard reverts the working file to base', async () => {

--- a/src/test/suite/utils.test.ts
+++ b/src/test/suite/utils.test.ts
@@ -382,10 +382,30 @@ suite('sync/sync-engine', () => {
     };
 
     const engine = (events = new EventEmitter<EventMap>()) => {
+        events.on('sync:file:apply:create', (path, type, content, done) => {
+            void tryCatch(async () => {
+                const uri = vscode.Uri.joinPath(work, path);
+                if (type === 'folder') {
+                    await vscode.workspace.fs.createDirectory(uri);
+                    return;
+                }
+                await writeFile(path, norm(buffer.toString(content)));
+            }).then(([err]) => done(err ?? undefined));
+        });
         events.on('sync:file:apply:update', (path, content, done) => {
             void tryCatch(async () => writeFile(path, norm(buffer.toString(content)))).then(([err]) =>
                 done(err ?? undefined)
             );
+        });
+        events.on('sync:file:apply:delete', (path, done) => {
+            void tryCatch(async () =>
+                vscode.workspace.fs.delete(vscode.Uri.joinPath(work, path), { recursive: false, useTrash: false })
+            ).then(([err]) => done(err ?? undefined));
+        });
+        events.on('sync:file:apply:rename', (from, path, done) => {
+            void tryCatch(async () =>
+                vscode.workspace.fs.rename(vscode.Uri.joinPath(work, from), vscode.Uri.joinPath(work, path))
+            ).then(([err]) => done(err ?? undefined));
         });
         return new NativeSyncEngine({ events, storageUri: storage });
     };
@@ -1527,6 +1547,57 @@ suite('sync/sync-engine', () => {
         assert.strictEqual(e.status('a.js'), 'modified');
         await e.discard(vscode.Uri.joinPath(work, 'a.js'));
         assert.strictEqual(await readFile('a.js'), 'x\n');
+        assert.strictEqual(e.status('a.js'), 'clean');
+    });
+
+    test('discard removes a local add', async () => {
+        const events = new EventEmitter<EventMap>();
+        const e = engine(events);
+        await e.link({
+            folderUri: work,
+            projectManager: { files: new Map() } as unknown as ProjectManager,
+            projectId: 1,
+            branchId: 'main'
+        });
+        await writeFile('new.js', 'new\n');
+        events.emit('sync:file:create', 'new.js', 'file');
+
+        assert.strictEqual(e.status('new.js'), 'added');
+        await e.discard(vscode.Uri.joinPath(work, 'new.js'));
+
+        assert.strictEqual(await exists('new.js'), false);
+        assert.strictEqual(e.status('new.js'), 'clean');
+    });
+
+    test('discard restores a local delete', async () => {
+        const events = new EventEmitter<EventMap>();
+        await writeFile('a.js', 'x\n');
+        const e = engine(events);
+        await e.link({ folderUri: work, projectManager: pmWith({ text: 'x\n' }), projectId: 1, branchId: 'main' });
+        await vscode.workspace.fs.delete(vscode.Uri.joinPath(work, 'a.js'), { recursive: false, useTrash: false });
+        events.emit('sync:file:delete', 'a.js', 'file');
+
+        assert.strictEqual(e.status('a.js'), 'deleted');
+        await e.discard(vscode.Uri.joinPath(work, 'a.js'));
+
+        assert.strictEqual(await readFile('a.js'), 'x\n');
+        assert.strictEqual(e.status('a.js'), 'clean');
+    });
+
+    test('discard reverts a local rename', async () => {
+        const events = new EventEmitter<EventMap>();
+        await writeFile('a.js', 'x\n');
+        const e = engine(events);
+        await e.link({ folderUri: work, projectManager: pmWith({ text: 'x\n' }), projectId: 1, branchId: 'main' });
+        await vscode.workspace.fs.rename(vscode.Uri.joinPath(work, 'a.js'), vscode.Uri.joinPath(work, 'b.js'));
+        events.emit('sync:file:rename', 'a.js', 'b.js', 'file');
+
+        assert.strictEqual(e.status('b.js'), 'renamed');
+        await e.discard(vscode.Uri.joinPath(work, 'b.js'));
+
+        assert.strictEqual(await readFile('a.js'), 'x\n');
+        assert.strictEqual(await exists('b.js'), false);
+        assert.strictEqual(e.status('b.js'), 'clean');
         assert.strictEqual(e.status('a.js'), 'clean');
     });
 

--- a/src/test/suite/utils.test.ts
+++ b/src/test/suite/utils.test.ts
@@ -460,4 +460,16 @@ suite('sync/sync-engine', () => {
         assert.strictEqual(e.remoteText('a.js'), 'hello\nremote\n');
         assert.strictEqual(e.remoteText('missing.js'), undefined);
     });
+
+    test('discard reverts the working file to base', async () => {
+        await writeFile('a.js', 'x\n');
+        const e = engine();
+        await e.link({ folderUri: work, projectManager: pmWith({ text: 'x\n' }), projectId: 1, branchId: 'main' });
+        await writeFile('a.js', 'x\nlocal\n');
+        await e.refresh();
+        assert.strictEqual(e.status('a.js'), 'modified');
+        await e.discard(vscode.Uri.joinPath(work, 'a.js'));
+        assert.strictEqual(await readFile('a.js'), 'x\n');
+        assert.strictEqual(e.status('a.js'), 'clean');
+    });
 });

--- a/src/test/suite/utils.test.ts
+++ b/src/test/suite/utils.test.ts
@@ -929,6 +929,30 @@ suite('sync/sync-engine', () => {
         assert.strictEqual(e.status('new.js'), 'clean');
     });
 
+    test('push - consumes local create echo', async () => {
+        const events = new EventEmitter<EventMap>();
+        const files = new Map<string, unknown>();
+        const pm = {
+            files,
+            create: async (p: string, t: 'file' | 'folder', content?: Uint8Array) => {
+                files.set(p, {
+                    type: t,
+                    uniqueId: 10,
+                    doc: { text: content ? norm(buffer.toString(content)) : '' },
+                    dirty: false
+                });
+                events.emit('asset:file:create', p, t, content ?? new Uint8Array());
+            }
+        } as unknown as ProjectManager;
+        const e = new NativeSyncEngine({ events, storageUri: storage });
+        await e.link({ folderUri: work, projectManager: pm, projectId: 1, branchId: 'main' });
+        await writeFile('new.js', 'new\n');
+        events.emit('sync:file:create', 'new.js', 'file');
+
+        await e.push();
+        assert.strictEqual(e.status('new.js'), 'clean');
+    });
+
     test('push - deletes local-only file removal', async () => {
         const events = new EventEmitter<EventMap>();
         const deleted: [string, 'file' | 'folder'][] = [];
@@ -950,6 +974,27 @@ suite('sync/sync-engine', () => {
         assert.strictEqual(e.status('a.js'), 'deleted');
         await e.push();
         assert.deepStrictEqual(deleted, [['a.js', 'file']]);
+        assert.strictEqual(e.status('a.js'), 'clean');
+    });
+
+    test('push - consumes local delete echo', async () => {
+        const events = new EventEmitter<EventMap>();
+        const files = new Map<string, unknown>([
+            ['a.js', { type: 'file', uniqueId: 1, doc: { text: 'x\n' }, dirty: false }]
+        ]);
+        const pm = {
+            files,
+            delete: async (p: string) => {
+                files.delete(p);
+                events.emit('asset:file:delete', p);
+            }
+        } as unknown as ProjectManager;
+        await writeFile('a.js', 'x\n');
+        const e = new NativeSyncEngine({ events, storageUri: storage });
+        await e.link({ folderUri: work, projectManager: pm, projectId: 1, branchId: 'main' });
+        events.emit('sync:file:delete', 'a.js', 'file');
+
+        await e.push();
         assert.strictEqual(e.status('a.js'), 'clean');
     });
 
@@ -975,6 +1020,28 @@ suite('sync/sync-engine', () => {
         assert.strictEqual(e.status('b.js'), 'renamed');
         await e.push();
         assert.deepStrictEqual(renamed, [['a.js', 'b.js']]);
+        assert.strictEqual(e.status('b.js'), 'clean');
+    });
+
+    test('push - consumes local rename echo', async () => {
+        const events = new EventEmitter<EventMap>();
+        const files = new Map<string, unknown>([
+            ['a.js', { type: 'file', uniqueId: 1, doc: { text: 'x\n' }, dirty: false }]
+        ]);
+        const pm = {
+            files,
+            rename: async (from: string, to: string) => {
+                files.set(to, files.get(from));
+                files.delete(from);
+                events.emit('asset:file:rename', from, to);
+            }
+        } as unknown as ProjectManager;
+        await writeFile('a.js', 'x\n');
+        const e = new NativeSyncEngine({ events, storageUri: storage });
+        await e.link({ folderUri: work, projectManager: pm, projectId: 1, branchId: 'main' });
+        events.emit('sync:file:rename', 'a.js', 'b.js', 'file');
+
+        await e.push();
         assert.strictEqual(e.status('b.js'), 'clean');
     });
 

--- a/src/test/suite/utils.test.ts
+++ b/src/test/suite/utils.test.ts
@@ -472,4 +472,47 @@ suite('sync/sync-engine', () => {
         assert.strictEqual(await readFile('a.js'), 'x\n');
         assert.strictEqual(e.status('a.js'), 'clean');
     });
+
+    test('resolve after conflict makes the file pushable (not stuck)', async () => {
+        const { pm, doc, applied } = pushPm();
+        await writeFile('a.js', 'a\nb\nc\n');
+        doc.text = 'a\nb\nc\n';
+        const e = engine();
+        await e.link({ folderUri: work, projectManager: pm, projectId: 1, branchId: 'main' });
+
+        // local + remote change the same line -> conflict on pull
+        await writeFile('a.js', 'a\nLOCAL\nc\n');
+        doc.text = 'a\nREMOTE\nc\n';
+        await e.pull();
+        assert.strictEqual(e.status('a.js'), 'conflicted');
+
+        // resolve: remove markers, keep a resolution
+        await writeFile('a.js', 'a\nRESOLVED\nc\n');
+        await e.refresh();
+        assert.strictEqual(e.status('a.js'), 'modified', 'resolved file must be pushable, not stuck in both');
+
+        await e.push();
+        assert.ok(applied.length >= 1, 'resolution is pushed');
+        assert.strictEqual(e.status('a.js'), 'clean');
+    });
+
+    test('mergeInputs exposes ancestor/local/remote during conflict, cleared on resolve', async () => {
+        const doc = { text: 'a\nb\nc\n' };
+        await writeFile('a.js', 'a\nb\nc\n');
+        const e = engine();
+        await e.link({ folderUri: work, projectManager: pmWith(doc), projectId: 1, branchId: 'main' });
+        await writeFile('a.js', 'a\nLOCAL\nc\n');
+        doc.text = 'a\nREMOTE\nc\n';
+        await e.pull();
+
+        const m = e.mergeInputs('a.js');
+        assert.ok(m, 'merge inputs present during conflict');
+        assert.strictEqual(m.base, 'a\nb\nc\n');
+        assert.strictEqual(m.local, 'a\nLOCAL\nc\n');
+        assert.strictEqual(m.remote, 'a\nREMOTE\nc\n');
+
+        await writeFile('a.js', 'a\nRESOLVED\nc\n');
+        await e.refresh();
+        assert.strictEqual(e.mergeInputs('a.js'), undefined, 'cleared after resolve');
+    });
 });

--- a/src/test/suite/utils.test.ts
+++ b/src/test/suite/utils.test.ts
@@ -200,7 +200,7 @@ suite('decoration-provider', () => {
     test('badges pullpush scm uris without decorating real files', async () => {
         const sync = {
             changed: { get: () => 0 },
-            status: (path: string) => (path === 'new.js' ? 'added' : 'clean')
+            decorationStatus: (path: string) => (path === 'new.js' ? 'added' : 'clean')
         } as unknown as NativeSyncEngine;
         const provider = new DecorationProvider({ events: new EventEmitter<EventMap>(), syncEngine: sync });
         await provider.link({ folderUri: dir, projectManager: { files: new Map() } as unknown as ProjectManager });
@@ -1043,6 +1043,39 @@ suite('sync/sync-engine', () => {
 
         await e.push();
         assert.strictEqual(e.status('b.js'), 'clean');
+    });
+
+    test('incoming structural ops keep git-style decoration states', async () => {
+        await writeFile('a.js', 'x\n');
+        const events = new EventEmitter<EventMap>();
+        const files = new Map<string, unknown>([
+            ['a.js', { type: 'file', uniqueId: 1, doc: { text: 'x\n' }, dirty: false }]
+        ]);
+        const e = new NativeSyncEngine({
+            events,
+            storageUri: storage
+        });
+        await e.link({
+            folderUri: work,
+            projectManager: { files } as unknown as ProjectManager,
+            projectId: 1,
+            branchId: 'main'
+        });
+
+        events.emit('asset:file:create', 'new.js', 'file', buffer.from('remote\n'));
+        for (let i = 0; i < 50 && e.status('new.js') !== 'behind'; i++) {
+            await new Promise((resolve) => setTimeout(resolve, 10));
+        }
+        assert.strictEqual(e.status('new.js'), 'behind');
+        assert.strictEqual(e.decorationStatus('new.js'), 'added');
+
+        events.emit('asset:file:delete', 'a.js');
+        assert.strictEqual(e.status('a.js'), 'behind');
+        assert.strictEqual(e.decorationStatus('a.js'), 'deleted');
+
+        events.emit('asset:file:rename', 'a.js', 'b.js');
+        assert.strictEqual(e.status('b.js'), 'behind');
+        assert.strictEqual(e.decorationStatus('b.js'), 'renamed');
     });
 
     test('discard reverts the working file to base', async () => {

--- a/src/test/suite/utils.test.ts
+++ b/src/test/suite/utils.test.ts
@@ -12,9 +12,10 @@ import { classify } from '../../sync/status';
 import { NativeSyncEngine } from '../../sync/sync-engine';
 import type { EventMap } from '../../typings/event-map';
 import type { Project } from '../../typings/models';
+import type { ShareDbTextOp } from '../../typings/sharedb';
 import * as buffer from '../../utils/buffer';
 import { EventEmitter } from '../../utils/event-emitter';
-import { delta } from '../../utils/text';
+import { delta, norm } from '../../utils/text';
 import { sanitizeName, projectToName, hash, tryCatch } from '../../utils/utils';
 
 suite('utils', () => {
@@ -274,6 +275,35 @@ suite('sync/sync-engine', () => {
         return { files } as unknown as ProjectManager;
     };
 
+    // pm whose doc records submitted ops and applies them (simulating the server)
+    const pushPm = () => {
+        const applied: ShareDbTextOp[] = [];
+        const saved: string[] = [];
+        const doc = {
+            text: 'x\n',
+            apply(op: ShareDbTextOp) {
+                applied.push(op);
+                doc.text = ottext.apply(doc.text, op) as string;
+            }
+        };
+        const file = { type: 'file', uniqueId: 1, doc, dirty: false };
+        const files = new Map([['a.js', file]]);
+        const pm = {
+            files,
+            // mirrors ProjectManager.write: delta vs live doc, mark dirty
+            write: async (_p: string, content: Uint8Array) => {
+                const op = delta(doc.text, norm(buffer.toString(content)));
+                if (!op) {
+                    return;
+                }
+                doc.apply(op);
+                file.dirty = true;
+            },
+            save: (p: string) => saved.push(p)
+        } as unknown as ProjectManager;
+        return { pm, doc, applied, saved };
+    };
+
     test('clean when working equals remote', async () => {
         await writeFile('a.js', 'x\n');
         const e = engine();
@@ -375,5 +405,41 @@ suite('sync/sync-engine', () => {
         await e.pull();
         assert.ok((await readFile('a.js')).includes('<<<<<<< Working (your changes)'), 'has markers');
         assert.strictEqual(e.status('a.js'), 'conflicted');
+    });
+
+    test('push - submits delta, flushes, advances base', async () => {
+        const { pm, applied, saved } = pushPm();
+        await writeFile('a.js', 'x\n');
+        const e = engine();
+        await e.link({ folderUri: work, projectManager: pm, projectId: 1, branchId: 'main' });
+        await writeFile('a.js', 'x\nlocal\n');
+        await e.refresh();
+        assert.strictEqual(e.status('a.js'), 'modified');
+        await e.push();
+        assert.strictEqual(applied.length, 1, 'one op submitted');
+        assert.deepStrictEqual(applied[0], delta('x\n', 'x\nlocal\n'));
+        assert.deepStrictEqual(saved, ['a.js'], 'flushed to server');
+        assert.strictEqual(e.status('a.js'), 'clean');
+    });
+
+    test('push - no-op when nothing modified', async () => {
+        const { pm, applied, saved } = pushPm();
+        await writeFile('a.js', 'x\n');
+        const e = engine();
+        await e.link({ folderUri: work, projectManager: pm, projectId: 1, branchId: 'main' });
+        await e.push();
+        assert.strictEqual(applied.length, 0);
+        assert.strictEqual(saved.length, 0);
+    });
+
+    test('push - rejected when behind (no force push)', async () => {
+        const { pm, doc, applied } = pushPm();
+        await writeFile('a.js', 'x\n');
+        const e = engine();
+        await e.link({ folderUri: work, projectManager: pm, projectId: 1, branchId: 'main' });
+        doc.text = 'x\nremote\n';
+        const [err] = await tryCatch(() => e.push());
+        assert.ok(err, 'push should be rejected');
+        assert.strictEqual(applied.length, 0, 'must not submit when behind');
     });
 });

--- a/src/test/suite/utils.test.ts
+++ b/src/test/suite/utils.test.ts
@@ -1122,65 +1122,102 @@ suite('sync/sync-engine', () => {
         assert.strictEqual(await e.remoteText('missing.js'), undefined);
     });
 
-    test('remoteText subscribes stub to read realtime doc', async () => {
+    test('remoteText returns saved content for a closed file (no subscribe)', async () => {
         await writeFile('a.js', 'x\n');
         let subscribed = 0;
-        const file = { type: 'file', uniqueId: 1, doc: { text: 'x\nremote\n' }, dirty: false };
         const files = new Map<string, unknown>([['a.js', { type: 'stub', uniqueId: 1, dirty: false }]]);
         const pm = {
             files,
-            subscribe: async (p: string) => {
+            savedHash: () => hash('x\n'),
+            savedContent: async () => 'x\nremote\n',
+            subscribe: async () => {
                 subscribed++;
-                files.set(p, file);
-                return file;
-            },
-            unsubscribe: async (p: string) => {
-                files.set(p, { type: 'stub', uniqueId: 1, dirty: false });
+                return undefined;
             }
         } as unknown as ProjectManager;
         const e = engine();
         await e.link({ folderUri: work, projectManager: pm, projectId: 1, branchId: 'main' });
         assert.strictEqual(await e.remoteText('a.js'), 'x\nremote\n');
-        assert.strictEqual(subscribed, 1);
+        assert.strictEqual(subscribed, 0, 'closed file read without subscribing');
         assert.strictEqual((files.get('a.js') as { type: string }).type, 'stub');
     });
 
-    test('stub - ignores s3 hash until realtime doc is subscribed', async () => {
+    test('stub - shows behind when the saved hash advances', async () => {
         await writeFile('a.js', 'x\n');
-        let remoteHash = hash('x\n');
+        let savedHash = hash('x\n');
         const files = new Map([['a.js', { type: 'stub', uniqueId: 1, dirty: false }]]);
-        const pm = { files, fileHash: () => remoteHash } as unknown as ProjectManager;
+        const pm = { files, savedHash: () => savedHash, savedContent: async () => 'x\n' } as unknown as ProjectManager;
         const e = engine();
         await e.link({ folderUri: work, projectManager: pm, projectId: 1, branchId: 'main' });
         assert.strictEqual(e.status('a.js'), 'clean');
-        remoteHash = hash('x\nremote\n');
+        savedHash = hash('x\nremote\n');
         await e.refresh();
-        assert.strictEqual(e.status('a.js'), 'clean');
+        assert.strictEqual(e.status('a.js'), 'behind');
     });
 
-    test('pull - subscribes an unloaded stub and fast-forwards from realtime doc', async () => {
+    test('pull - fetches saved content for a closed file (no subscribe)', async () => {
         await writeFile('a.js', 'x\n');
-        const doc = { text: 'x\nremote\n' };
+        let subscribed = 0;
+        let savedHash = hash('x\n');
         const files = new Map<string, unknown>([['a.js', { type: 'stub', uniqueId: 1, dirty: false }]]);
         const pm = {
             files,
-            // mirrors ProjectManager.subscribe: promotes the stub in place
-            subscribe: async (p: string) => {
-                const promoted = { type: 'file', uniqueId: 1, doc, dirty: false };
-                files.set(p, promoted);
-                return promoted;
-            },
-            // mirrors ProjectManager.unsubscribe: demotes back to a stub
-            unsubscribe: async (p: string) => {
-                files.set(p, { type: 'stub', uniqueId: 1, dirty: false });
+            savedHash: () => savedHash,
+            savedContent: async () => 'x\nremote\n',
+            subscribe: async () => {
+                subscribed++;
+                return undefined;
+            }
+        } as unknown as ProjectManager;
+        const e = engine();
+        await e.link({ folderUri: work, projectManager: pm, projectId: 1, branchId: 'main' });
+        savedHash = hash('x\nremote\n');
+        await e.pull();
+        assert.strictEqual(await readFile('a.js'), 'x\nremote\n');
+        assert.strictEqual(e.status('a.js'), 'clean');
+        assert.strictEqual(subscribed, 0, 'pulled without subscribing');
+        assert.strictEqual((files.get('a.js') as { type: string }).type, 'stub', 'still a stub after pull');
+    });
+
+    test('pull - skips a closed file whose saved hash is unchanged (no fetch)', async () => {
+        await writeFile('a.js', 'x\n');
+        let fetched = 0;
+        const files = new Map([['a.js', { type: 'stub', uniqueId: 1, dirty: false }]]);
+        const pm = {
+            files,
+            savedHash: () => hash('x\n'),
+            savedContent: async () => {
+                fetched++;
+                return 'x\n';
             }
         } as unknown as ProjectManager;
         const e = engine();
         await e.link({ folderUri: work, projectManager: pm, projectId: 1, branchId: 'main' });
         await e.pull();
-        assert.strictEqual(await readFile('a.js'), 'x\nremote\n');
+        assert.strictEqual(fetched, 0, 'unchanged closed file not fetched');
         assert.strictEqual(e.status('a.js'), 'clean');
-        assert.strictEqual((files.get('a.js') as { type: string }).type, 'stub', 'released after pull');
+    });
+
+    test('close - no phantom behind when disk is ahead of the saved hash', async () => {
+        await writeFile('a.js', 'x\nlive\n');
+        const events = new EventEmitter<EventMap>();
+        const doc = { text: 'x\nlive\n' };
+        const files = new Map<string, unknown>([['a.js', { type: 'file', uniqueId: 1, doc, dirty: false }]]);
+        const pm = {
+            files,
+            savedHash: () => hash('x\n'), // saved lags the realtime/disk content
+            savedContent: async () => 'x\n',
+            unsubscribe: async (p: string) => {
+                files.set(p, { type: 'stub', uniqueId: 1, dirty: false });
+                events.emit('asset:file:unsubscribed', p);
+            }
+        } as unknown as ProjectManager;
+        const e = engine(events);
+        await e.link({ folderUri: work, projectManager: pm, projectId: 1, branchId: 'main' });
+        assert.strictEqual(e.status('a.js'), 'clean');
+        await pm.unsubscribe('a.js');
+        await e.refresh('a.js');
+        assert.strictEqual(e.status('a.js'), 'clean', 'closed view compares saved-vs-saved, not vs realtime base');
     });
 
     test('subscribe upgrades stub status to the live doc', async () => {

--- a/src/typings/event-map.d.ts
+++ b/src/typings/event-map.d.ts
@@ -13,6 +13,8 @@ export type EventMap = {
     'asset:file:dirty': [string, boolean];
     'asset:file:failed': [string];
     'asset:file:subscribed': [string, string, boolean];
+    'asset:file:unsubscribed': [string];
+    'asset:file:hash': [string];
 
     'sync:file:create': [string, 'file' | 'folder'];
     'sync:file:update': [string];

--- a/src/typings/event-map.d.ts
+++ b/src/typings/event-map.d.ts
@@ -14,6 +14,14 @@ export type EventMap = {
     'asset:file:failed': [string];
     'asset:file:subscribed': [string, string, boolean];
 
+    'sync:file:create': [string, 'file' | 'folder'];
+    'sync:file:update': [string];
+    'sync:file:delete': [string, 'file' | 'folder'];
+    'sync:file:rename': [string, string, 'file' | 'folder'];
+    'sync:file:apply:create': [string, 'file' | 'folder', Uint8Array, (err?: Error) => void];
+    'sync:file:apply:delete': [string, (err?: Error) => void];
+    'sync:file:apply:rename': [string, string, (err?: Error) => void];
+
     'asset:doc:open': [string];
     'asset:doc:close': [string];
 };

--- a/src/typings/event-map.d.ts
+++ b/src/typings/event-map.d.ts
@@ -19,6 +19,7 @@ export type EventMap = {
     'sync:file:delete': [string, 'file' | 'folder'];
     'sync:file:rename': [string, string, 'file' | 'folder'];
     'sync:file:apply:create': [string, 'file' | 'folder', Uint8Array, (err?: Error) => void];
+    'sync:file:apply:update': [string, Uint8Array, (err?: Error) => void];
     'sync:file:apply:delete': [string, (err?: Error) => void];
     'sync:file:apply:rename': [string, string, (err?: Error) => void];
 

--- a/src/typings/node-diff3.d.ts
+++ b/src/typings/node-diff3.d.ts
@@ -1,0 +1,25 @@
+declare module 'node-diff3' {
+    export type MergeRegion<T> = {
+        ok?: T[];
+        conflict?: {
+            a: T[];
+            aIndex: number;
+            b: T[];
+            bIndex: number;
+            o: T[];
+            oIndex: number;
+        };
+    };
+
+    export type IMergeOptions = {
+        excludeFalseConflicts?: boolean;
+        stringSeparator?: string | RegExp;
+    };
+
+    export function diff3Merge<T>(
+        a: string | T[],
+        o: string | T[],
+        b: string | T[],
+        options?: IMergeOptions
+    ): MergeRegion<T>[];
+}


### PR DESCRIPTION
Summary:
- Adds opt-in pullpush sync mode for native VS Code users.
- Adds PlayCanvas Source Control groups for local, incoming, and merge states.
- Syncs over the existing realtime document — no server-side changes required.
- Detects incoming changes on closed files, not just open ones, without holding a live subscription to every asset — so it scales to large projects.
- Keeps realtime mode as the default path.

Manual smoke test steps:
1. Set `playcanvas.syncMode` to `pullpush`, reload/link a native project that already has local files, and confirm the PlayCanvas SCM view appears without overwriting existing local disk files.
2. Type in an open VS Code file without saving; confirm SCM stays clean. Save it, confirm it becomes Modified, then discard/revert it from SCM and confirm it returns clean.
3. Edit and save a file in VS Code, push with Cmd+Option+Up, and confirm the online IDE/launcher sees the update only after push completes.
4. Edit and save a file in the online IDE, confirm Incoming Changes appears in VS Code, pull with Cmd+Option+Down, and confirm local disk content updates without a self-conflict.
5. Create, rename, and delete a file and folder in VS Code, including one empty file, push, and confirm remote matches. Repeat create, rename, and delete remotely, then pull and confirm local matches.
6. Make saved local and remote edits to the same line, pull, confirm conflict markers/SCM conflict, resolve and save, then push and confirm remote sees the resolution.
7. Use two files for stale structural checks: remote-edit one then delete it locally and pull; remote-edit another then rename/delete it locally and push. Confirm the operation blocks as a conflict/remote-changed state and no content is lost.

## How this relates to Git

A native VS Code **Source Control** provider implementing Git's pull/push workflow over the realtime cloud — Git's working-tree-and-sync model, not its commit/history model.

| Aspect | Git | This SCM |
|---|---|---|
| Model | distributed commit DAG | centralized working-copy sync (working tree vs last-synced base) |
| Pull | fetch + merge/rebase | fetch + 3-way diff3 merge into the working tree |
| Push | rejects non-fast-forward | fast-forward only, rejects on stale base (no force push) |
| Conflicts | `<<<<<<< ======= >>>>>>>` + merge editor | same markers + native merge editor |
| Discard / rename | `git restore`; heuristic rename detection | revert file to base; explicit rename by stable asset id |
| Commits / staging / history | yes | intentionally omitted — cloud holds only live state |

**TL;DR:** Git's verbs, a centralized-sync backend with no commits/history by design, and exact (not heuristic) rename tracking.
