### PR TITLE
feat: explorer badges for sync state

### DIFF
--- a/src/providers/decoration-provider.ts
+++ b/src/providers/decoration-provider.ts
@@ -31,6 +31,17 @@ const SYNC_DECORATION: Record<
     renamed: { badge: 'R', color: 'gitDecoration.renamedResourceForeground', tooltip: 'Renamed' }
 };
 
+// explorer badges compose with git's (badges merge across providers); no
+// color so the filename tint stays with git's decorations
+const EXPLORER_BADGE: Partial<Record<SyncState, vscode.FileDecoration>> = {
+    behind: { badge: '↓', tooltip: 'Incoming — pull to apply' },
+    modified: { badge: '↑', tooltip: 'Outgoing — push to share' },
+    both: { badge: '↓↑', tooltip: 'Incoming and outgoing' },
+    conflicted: { badge: '!', tooltip: 'Conflict — resolve' },
+    added: { badge: '↑', tooltip: 'Added — push to share' },
+    renamed: { badge: '↑', tooltip: 'Renamed — push to share' }
+};
+
 const syncDecoration = (state: SyncState) => {
     if (state === 'clean') {
         return undefined;
@@ -92,11 +103,12 @@ class DecorationProvider
         }
 
         const file = pm.files.get(path);
-        if (!file || file.type !== 'file' || !file.dirty) {
-            return undefined;
+        const dirty = file?.type === 'file' && file.dirty;
+        const sync = EXPLORER_BADGE[this._syncEngine?.status(path) ?? 'clean'];
+        if (sync) {
+            return dirty ? { ...sync, color: DIRTY_COLOR } : sync;
         }
-
-        return { color: DIRTY_COLOR };
+        return dirty ? { color: DIRTY_COLOR } : undefined;
     }
 
     private _fire(path: string) {

--- a/src/test/suite/utils.test.ts
+++ b/src/test/suite/utils.test.ts
@@ -198,9 +198,10 @@ suite('sync/scm', () => {
 suite('decoration-provider', () => {
     const dir = vscode.Uri.joinPath(vscode.Uri.file(os.tmpdir()), 'pc-decoration-provider-test');
 
-    test('badges pullpush scm uris without decorating real files', async () => {
+    test('badges pullpush scm uris and explorer files', async () => {
         const sync = {
             changed: { get: () => 0 },
+            status: (path: string) => (path === 'new.js' ? 'added' : 'clean'),
             decorationStatus: (path: string) => (path === 'new.js' ? 'added' : 'clean')
         } as unknown as NativeSyncEngine;
         const provider = new DecorationProvider({ events: new EventEmitter<EventMap>(), syncEngine: sync });
@@ -208,7 +209,11 @@ suite('decoration-provider', () => {
 
         const real = vscode.Uri.joinPath(dir, 'new.js');
         assert.strictEqual(provider.provideFileDecoration(scmUri(real))?.badge, 'A');
-        assert.strictEqual(provider.provideFileDecoration(real), undefined);
+        // explorer: arrow badge, no color — git's filename tint must survive
+        const explorer = provider.provideFileDecoration(real);
+        assert.strictEqual(explorer?.badge, '↑');
+        assert.strictEqual(explorer?.color, undefined);
+        assert.strictEqual(provider.provideFileDecoration(vscode.Uri.joinPath(dir, 'clean.js')), undefined);
 
         await provider.unlink();
     });


### PR DESCRIPTION
Adds Explorer file-decoration badges for pullpush sync states: `↓` incoming, `↑` outgoing/added/renamed, `↓↑` diverged, `!` conflicted.

Badge-only (no color) so git's filename tint and letter badges render untouched alongside ours — VS Code merges decorations across providers.