### PR TITLE
fix: register sync engine listeners before the initial refresh

### DIFF
--- a/src/sync/sync-engine.ts
+++ b/src/sync/sync-engine.ts
@@ -968,8 +968,8 @@ class NativeSyncEngine extends Linker<LinkParams> {
         this._branchId = branchId;
         this._ignoring = Disk.ignoreMatcher(await this._ignoreText(folderUri), folderUri);
 
-        await this._refreshAll();
-
+        // listeners before the initial refresh — a subscribe or remote op
+        // landing mid-refresh must recompute its file, not vanish
         const recompute = (path: string) => void this.refresh(path);
         const onUpdate = this._events.on('asset:file:update', recompute);
         const onCreate = this._events.on(
@@ -1010,6 +1010,8 @@ class NativeSyncEngine extends Linker<LinkParams> {
             this._events.off('asset:file:hash', onHash);
             this._events.off('asset:file:save', onSave);
         });
+
+        await this._refreshAll();
 
         await this._base.flush();
 

--- a/src/test/suite/utils.test.ts
+++ b/src/test/suite/utils.test.ts
@@ -574,6 +574,34 @@ suite('sync/sync-engine', () => {
         assert.strictEqual(e.statuses().has('ignored_file.js'), false);
     });
 
+    test('link sees a subscribe that lands during the initial refresh', async () => {
+        await writeFile('a.js', 'x\n');
+        const events = new EventEmitter<EventMap>();
+        const files = new Map<string, unknown>([['a.js', { type: 'stub', uniqueId: 1, dirty: false }]]);
+        // subscribe round-trip completes mid-link: promote the stub during the
+        // local-only walk, after a.js was already refreshed at stub granularity
+        let promoted = false;
+        files.has = (key: string) => {
+            if (!promoted) {
+                promoted = true;
+                files.set('a.js', { type: 'file', uniqueId: 1, doc: { text: 'x\nremote\n' }, dirty: false });
+                events.emit('asset:file:subscribed', 'a.js', 'x\nremote\n', false);
+            }
+            return Map.prototype.has.call(files, key);
+        };
+        const e = engine(events);
+        await e.link({
+            folderUri: work,
+            projectManager: { files } as unknown as ProjectManager,
+            projectId: 1,
+            branchId: 'main'
+        });
+        for (let i = 0; i < 20 && e.status('a.js') !== 'behind'; i++) {
+            await wait(10);
+        }
+        assert.strictEqual(e.status('a.js'), 'behind');
+    });
+
     test('pull - fast-forward when no local edits', async () => {
         await writeFile('a.js', 'x\n');
         const doc = { text: 'x\n' };


### PR DESCRIPTION
On reload, the open tab's ShareDB subscribe races `NativeSyncEngine.link()`: if it completed during the initial `_refreshAll()` — after the file was refreshed as a stub, before listeners were registered — the event was lost and unsaved remote edits never surfaced as incoming. Intermittent by timing.

Registering the listeners before the initial refresh closes the window; handlers are idempotent recomputes. Adds a deterministic repro test.