### PR TITLE
fix: harden realtime sync recovery

### DIFF
--- a/src/disk.ts
+++ b/src/disk.ts
@@ -205,6 +205,9 @@ class Disk extends Linker<{ folderUri: vscode.Uri; projectManager: ProjectManage
         if (h === this._diskHash.get(uri.path) || h === this._echo.get(`${uri}:change`)) {
             return;
         }
+        if (this._warnedExternal) {
+            return;
+        }
         this._warnedExternal = true;
         this._log.info(`external edit ignored ${uri}`);
         const res = await vscode.window.showWarningMessage(
@@ -339,6 +342,52 @@ class Disk extends Linker<{ folderUri: vscode.Uri; projectManager: ProjectManage
         return vscode.workspace.textDocuments.some((d) => d.uri.toString() === uri.toString());
     }
 
+    private _recover(path: string, base: string, observed: string) {
+        const file = this._projectManager?.files.get(path);
+        if (!file || file.type !== 'file') {
+            return;
+        }
+        const op = delta(base, observed);
+        if (!op) {
+            return;
+        }
+        const adv = delta(base, file.doc.text);
+        file.doc.apply(adv ? (ottext.transform(op, adv, 'left') as ShareDbTextOp) : op);
+        const dirty = file.dirty;
+        file.dirty = true;
+        if (!dirty) {
+            this._events.emit('asset:file:dirty', path, true);
+        }
+        this._log.info(`sync.recovered ${path} ${stat(op)}`);
+    }
+
+    private async _resetCanonical(document: vscode.TextDocument, uri: vscode.Uri, path: string) {
+        const pm = this._projectManager;
+        const file = pm?.files.get(path);
+        if (!pm || !file || file.type !== 'file') {
+            return false;
+        }
+
+        const raw = document.getText();
+        const before = norm(raw);
+        const target = file.doc.text;
+        const edit = new vscode.WorkspaceEdit();
+        edit.replace(uri, new vscode.Range(document.positionAt(0), document.positionAt(raw.length)), target);
+        const [err, applied] = await tryCatch(Promise.resolve(vscode.workspace.applyEdit(edit)));
+        const observed = norm(document.getText());
+        if (err || !applied) {
+            this._recover(path, before, observed);
+            this._blocked.add(`${uri}`);
+            pm.desync.set(() => true);
+            this._log.warn(`sync.resync failed ${uri}`);
+            return false;
+        }
+
+        this._recover(path, target, observed);
+        this._blocked.delete(`${uri}`);
+        return true;
+    }
+
     private _update(uri: vscode.Uri, op: ShareDbTextOp, content: string, prev: string) {
         const snapshot = norm(content);
         return this._writeMutex.atomic([`${uri}`], async () => {
@@ -410,7 +459,7 @@ class Disk extends Linker<{ folderUri: vscode.Uri; projectManager: ProjectManage
                 // transform remote op into buffer-space so positions align
                 const bufferOp = fullUserOp ? (ottext.transform(op, fullUserOp, 'right') as ShareDbTextOp) : op;
                 const edit = sharedb2vscode(document, uri, [bufferOp], bufferText);
-                const applied = await vscode.workspace.applyEdit(edit);
+                const [editErr, applied] = await tryCatch(Promise.resolve(vscode.workspace.applyEdit(edit)));
 
                 if (this._projectManager && this._folderUri) {
                     const path = relativePath(uri, this._folderUri);
@@ -427,13 +476,10 @@ class Disk extends Linker<{ folderUri: vscode.Uri; projectManager: ProjectManage
                             }
                         }
 
-                        // applyEdit failed — force-reset to canonical state
-                        if (!applied) {
-                            const curRaw = document.getText();
-                            const reset = new vscode.WorkspaceEdit();
-                            const range = new vscode.Range(document.positionAt(0), document.positionAt(curRaw.length));
-                            reset.replace(uri, range, file.doc.text);
-                            await vscode.workspace.applyEdit(reset);
+                        // applyEdit failed — preserve concurrent typing, then reset to canonical state
+                        if (editErr || !applied) {
+                            this._recover(path, bufferText, norm(document.getText()));
+                            await this._resetCanonical(document, uri, path);
                             this._log.warn(`sync.remote.resync ${uri} applied=false`);
                             return;
                         }
@@ -444,21 +490,8 @@ class Disk extends Linker<{ folderUri: vscode.Uri; projectManager: ProjectManage
                         const postText = norm(postRaw);
                         const expected = ottext.apply(bufferText, bufferOp) as string;
 
-                        const late = delta(expected, postText);
-                        if (late) {
-                            // transform recovered keystrokes against canonical advancement
-                            // (queued remote ops that OTDocument processed but _update hasn't applied yet)
-                            const adv = delta(expected, file.doc.text);
-                            const adjusted = adv ? (ottext.transform(late, adv, 'left') as ShareDbTextOp) : late;
-                            file.doc.apply(adjusted);
-                            const wasDirty = file.dirty;
-                            file.dirty = true;
-                            if (!wasDirty) {
-                                this._events.emit('asset:file:dirty', path, true);
-                            }
-                            this._log.info(`sync.remote.recovered ${uri} ${stat(op)} recovered=${stat(late)}`);
-                            return;
-                        }
+                        this._recover(path, expected, postText);
+                        this._blocked.delete(`${uri}`);
                     }
                 }
             });
@@ -589,18 +622,26 @@ class Disk extends Linker<{ folderUri: vscode.Uri; projectManager: ProjectManage
 
                     // server is authoritative — apply live ShareDB doc to buffer on any divergence
                     if (file.doc.text !== bufferText) {
-                        const { prefix, suffix } = diff(bufferText, file.doc.text);
+                        const target = file.doc.text;
+                        const { prefix, suffix } = diff(bufferText, target);
                         const edit = new vscode.WorkspaceEdit();
                         edit.replace(
                             uri,
                             new vscode.Range(doc.positionAt(prefix), doc.positionAt(bufferText.length - suffix)),
-                            file.doc.text.substring(prefix, file.doc.text.length - suffix)
+                            target.substring(prefix, target.length - suffix)
                         );
-                        const applied = await vscode.workspace.applyEdit(edit);
-                        if (!applied) {
+                        const [err, applied] = await tryCatch(Promise.resolve(vscode.workspace.applyEdit(edit)));
+                        if (err || !applied) {
+                            this._recover(path, bufferText, norm(doc.getText()));
+                            await this._resetCanonical(doc, uri, path);
                             this._log.warn(`subscribe.resync applyEdit failed for ${uri}`);
+                        } else {
+                            this._recover(path, target, norm(doc.getText()));
+                            this._blocked.delete(`${uri}`);
                         }
                         this._log.info(`subscribe.resync ${uri}`);
+                    } else {
+                        this._blocked.delete(`${uri}`);
                     }
                 });
                 this._locks.delete(`${uri}`);
@@ -677,7 +718,7 @@ class Disk extends Linker<{ folderUri: vscode.Uri; projectManager: ProjectManage
 
             this._locks.add(`${doc.uri}`);
             await tryCatch(async () => {
-                const current = doc.getText();
+                const current = norm(doc.getText());
                 const expected = file.doc.text;
                 if (current !== expected) {
                     // buffer has stale content -- apply minimal diff
@@ -688,18 +729,28 @@ class Disk extends Linker<{ folderUri: vscode.Uri; projectManager: ProjectManage
                         new vscode.Range(doc.positionAt(prefix), doc.positionAt(current.length - suffix)),
                         expected.substring(prefix, expected.length - suffix)
                     );
-                    if (!(await vscode.workspace.applyEdit(edit))) {
+                    const [err, applied] = await tryCatch(Promise.resolve(vscode.workspace.applyEdit(edit)));
+                    if (err || !applied) {
+                        this._recover(path, current, norm(doc.getText()));
+                        await this._resetCanonical(doc, doc.uri, path);
                         this._log.warn(`dirty applyEdit failed for ${doc.uri}`);
+                    } else {
+                        this._recover(path, expected, norm(doc.getText()));
+                        this._blocked.delete(`${doc.uri}`);
                     }
                 } else {
-                    // content matches -- make a reversible edit to mark dirty without final text change
-                    const pos = doc.positionAt(0);
+                    // content matches -- append a marker, recover concurrent edits, then reset
+                    const target = `${expected} `;
                     const add = new vscode.WorkspaceEdit();
-                    add.insert(doc.uri, pos, ' ');
-                    if (await vscode.workspace.applyEdit(add)) {
-                        const remove = new vscode.WorkspaceEdit();
-                        remove.delete(doc.uri, new vscode.Range(pos, doc.positionAt(1)));
-                        await vscode.workspace.applyEdit(remove);
+                    add.insert(doc.uri, doc.positionAt(doc.getText().length), ' ');
+                    const [err, applied] = await tryCatch(Promise.resolve(vscode.workspace.applyEdit(add)));
+                    if (err || !applied) {
+                        this._recover(path, current, norm(doc.getText()));
+                        await this._resetCanonical(doc, doc.uri, path);
+                        this._log.warn(`dirty marker applyEdit failed for ${doc.uri}`);
+                    } else {
+                        this._recover(path, target, norm(doc.getText()));
+                        await this._resetCanonical(doc, doc.uri, path);
                     }
                 }
             });
@@ -1166,7 +1217,7 @@ class Disk extends Linker<{ folderUri: vscode.Uri; projectManager: ProjectManage
             // check if locked (from remote update) or remote op pending in
             // the sync-to-microtask gap before _update's mutex body runs
             const lockKey = `${document.uri}`;
-            if (this._locks.has(lockKey) || this._opLocks.has(lockKey)) {
+            if (this._locks.has(lockKey) || this._opLocks.has(lockKey) || this._blocked.has(lockKey)) {
                 return;
             }
 
@@ -1672,38 +1723,47 @@ class Disk extends Linker<{ folderUri: vscode.Uri; projectManager: ProjectManage
         // show progress notification early so users see feedback during REST prefetch
         const folders = ordered.filter(([, f]) => f.type === 'folder');
         const files = ordered.filter(([, f]) => f.type !== 'folder');
-        const updatingDiskNext = await progressNotification('Updating Disk', folders.length + files.length);
+        const [updatingDiskNext, updatingDiskDone] = await progressNotification(
+            'Updating Disk',
+            folders.length + files.length
+        );
 
-        // prefetch REST content for stubs (pooled — continuous worker saturation under concurrency cap)
-        const stubs = ordered.filter(([, f]) => f.type === 'stub');
-        const fetched = new Map<number, Uint8Array>();
-        await pool(stubs, FETCH_CONCURRENCY, async ([, f]) => {
-            const [err, buf] = await tryCatch(projectManager.fetchContent(f.uniqueId));
-            // normalize REST content to LF — S3 may hold CRLF from pre-fix uploads
-            fetched.set(f.uniqueId, err ? new Uint8Array() : buffer.from(norm(buffer.toString(buf))));
-        });
-
-        // write files to disk — folders first (parents before descendants), then files, via worker pool
-        const writeAll = (entries: typeof ordered, type: 'file' | 'folder') =>
-            pool(entries, WRITE_CONCURRENCY, async ([path, file]) => {
-                const uri = vscode.Uri.joinPath(folderUri, path);
-                if (!bootstrap && !(await fileExists(uri))) {
-                    updatingDiskNext();
-                    return;
-                }
-                let content: Uint8Array;
-                if (file.type === 'file') {
-                    content = buffer.from(file.doc.text);
-                } else if (file.type === 'stub') {
-                    content = fetched.get(file.uniqueId) ?? new Uint8Array();
-                } else {
-                    content = new Uint8Array();
-                }
-                await this._create(uri, type, content);
-                updatingDiskNext();
+        const [writeErr] = await tryCatch(async () => {
+            // prefetch REST content for stubs (pooled — continuous worker saturation under concurrency cap)
+            const stubs = ordered.filter(([, f]) => f.type === 'stub');
+            const fetched = new Map<number, Uint8Array>();
+            await pool(stubs, FETCH_CONCURRENCY, async ([, f]) => {
+                const [err, buf] = await tryCatch(projectManager.fetchContent(f.uniqueId));
+                // normalize REST content to LF — S3 may hold CRLF from pre-fix uploads
+                fetched.set(f.uniqueId, err ? new Uint8Array() : buffer.from(norm(buffer.toString(buf))));
             });
-        await writeAll(folders, 'folder');
-        await writeAll(files, 'file');
+
+            // write files to disk — folders first (parents before descendants), then files, via worker pool
+            const writeAll = (entries: typeof ordered, type: 'file' | 'folder') =>
+                pool(entries, WRITE_CONCURRENCY, async ([path, file]) => {
+                    const uri = vscode.Uri.joinPath(folderUri, path);
+                    if (!bootstrap && !(await fileExists(uri))) {
+                        updatingDiskNext();
+                        return;
+                    }
+                    let content: Uint8Array;
+                    if (file.type === 'file') {
+                        content = buffer.from(file.doc.text);
+                    } else if (file.type === 'stub') {
+                        content = fetched.get(file.uniqueId) ?? new Uint8Array();
+                    } else {
+                        content = new Uint8Array();
+                    }
+                    await this._create(uri, type, content);
+                    updatingDiskNext();
+                });
+            await writeAll(folders, 'folder');
+            await writeAll(files, 'file');
+        });
+        updatingDiskDone();
+        if (writeErr) {
+            throw writeErr;
+        }
 
         // parse ignore file (after disk write so stub content is available)
         const ignoreFile = projectManager.files.get(Disk.IGNORE_FILE);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -909,10 +909,13 @@ export const activate = async (context: vscode.ExtensionContext) => {
             );
         }
 
-        // save/desync status surfaces
+        // save/desync status surfaces — desync toast is one-shot per false→true transition
+        let wasDesynced = projectManager.desync.get();
         effect(() => {
             const desynced = projectManager.desync.get();
             const saving = projectManager.saving.get();
+            const toast = desynced && !wasDesynced;
+            wasDesynced = desynced;
             if (!desynced && saving) {
                 desyncStatusItem.color = undefined;
                 desyncStatusItem.command = undefined;
@@ -937,6 +940,9 @@ export const activate = async (context: vscode.ExtensionContext) => {
 
             desyncStatusItem.command = `${NAME}.reloadProject`;
             desyncStatusItem.tooltip = 'PlayCanvas project is out of sync — click to reload';
+            if (!toast) {
+                return;
+            }
             void vscode.window
                 .showWarningMessage(
                     'PlayCanvas project is out of sync. Reload to recover.',

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -909,32 +909,29 @@ export const activate = async (context: vscode.ExtensionContext) => {
             );
         }
 
-        // desync surfaces — sticky status-bar item + one-shot toast per
-        // false→true transition. signal resets to false on project unlink.
+        // save/desync status surfaces
         effect(() => {
             const desynced = projectManager.desync.get();
-            if (desynced) {
+            const saving = projectManager.saving.get();
+            if (!desynced && saving) {
+                desyncStatusItem.color = undefined;
+                desyncStatusItem.command = undefined;
+                desyncStatusItem.text = '$(sync~spin) Saving…';
+                desyncStatusItem.tooltip = 'Saving PlayCanvas changes';
                 desyncStatusItem.show();
-            } else {
+                return;
+            }
+            if (!desynced) {
                 desyncStatusItem.hide();
-                desyncStatusItem.command = `${NAME}.reloadProject`;
-                desyncStatusItem.tooltip = 'PlayCanvas project is out of sync — click to reload';
                 return;
             }
 
+            desyncStatusItem.color = COLORS.warning;
+            desyncStatusItem.text = '$(warning) Out of Sync';
+            desyncStatusItem.show();
             if (projectManager.saveFailed()) {
                 desyncStatusItem.command = `${NAME}.reportIssue`;
                 desyncStatusItem.tooltip = 'PlayCanvas could not save changes — click to report';
-                void vscode.window
-                    .showWarningMessage('PlayCanvas could not save changes.', 'Report Issue')
-                    .then((choice) => {
-                        if (choice === 'Report Issue') {
-                            void vscode.commands.executeCommand(
-                                `${NAME}.reportIssue`,
-                                'PlayCanvas could not save changes'
-                            );
-                        }
-                    });
                 return;
             }
 
@@ -956,6 +953,22 @@ export const activate = async (context: vscode.ExtensionContext) => {
                             void vscode.commands.executeCommand(`${NAME}.reportIssue`, 'Out of sync');
                             break;
                         }
+                    }
+                });
+        });
+
+        let saveFailure = projectManager.saveFailure.get();
+        effect(() => {
+            const count = projectManager.saveFailure.get();
+            if (count === saveFailure) {
+                return;
+            }
+            saveFailure = count;
+            void vscode.window
+                .showWarningMessage('PlayCanvas could not save changes.', 'Report Issue')
+                .then((choice) => {
+                    if (choice === 'Report Issue') {
+                        void vscode.commands.executeCommand(`${NAME}.reportIssue`, 'PlayCanvas could not save changes');
                     }
                 });
         });

--- a/src/notification.ts
+++ b/src/notification.ts
@@ -20,7 +20,7 @@ export const simpleNotification = (message: string) => {
 };
 
 export const progressNotification = (message: string, total: number) => {
-    return new Promise<() => void>((resolve) => {
+    return new Promise<[() => void, () => void]>((resolve) => {
         vscode.window.withProgress(
             {
                 location: vscode.ProgressLocation.Notification,
@@ -29,7 +29,7 @@ export const progressNotification = (message: string, total: number) => {
             },
             (progress) => {
                 const deferred = new Deferred<void>();
-                const increment = 100 / total;
+                const increment = total ? 100 / total : 0;
                 let i = 0;
 
                 progress.report({ message: `${i}/${total}` });
@@ -40,7 +40,7 @@ export const progressNotification = (message: string, total: number) => {
                         deferred.resolve();
                     }
                 };
-                resolve(next);
+                resolve([next, deferred.resolve]);
 
                 if (total === 0) {
                     deferred.resolve();

--- a/src/project-manager.ts
+++ b/src/project-manager.ts
@@ -101,6 +101,10 @@ class ProjectManager extends Linker<{ projectId: number; branchId: string }> {
 
     desync = signal<boolean>(false);
 
+    saving = signal<boolean>(false);
+
+    saveFailure = signal<number>(0);
+
     constructor({
         events,
         sharedb,
@@ -320,6 +324,7 @@ class ProjectManager extends Linker<{ projectId: number; branchId: string }> {
         // exactly the failure mode we need to alarm on; a genuine offline stretch is
         // also worth surfacing so users don't assume their edits are syncing.
         otdoc.on('stuck', () => {
+            this._failWaitingSave(uniqueId);
             this.desync.set(() => true);
         });
 
@@ -395,11 +400,16 @@ class ProjectManager extends Linker<{ projectId: number; branchId: string }> {
         return this._assetPath(uniqueId);
     }
 
+    private _updateSaving() {
+        this.saving.set(() => this._saveInflight.size > 0 || this._savePending.size > 0 || this._saveAttempts.size > 0);
+    }
+
     private _clearSaveAttempt(uniqueId: number) {
         const entry = this._saveAttempts.get(uniqueId);
         clearTimeout(entry?.ack);
         clearTimeout(entry?.retry);
         this._saveAttempts.delete(uniqueId);
+        this._updateSaving();
     }
 
     private _clearSaveFailure(uniqueId: number) {
@@ -420,7 +430,17 @@ class ProjectManager extends Linker<{ projectId: number; branchId: string }> {
             }
         }
         this._saveFailed.add(uniqueId);
+        this.saveFailure.set((count) => count + 1);
         this.desync.set(() => true);
+    }
+
+    private _failWaitingSave(uniqueId: number) {
+        if (!this._saveInflight.delete(uniqueId) && !this._saveAttempts.has(uniqueId)) {
+            return;
+        }
+        this._savePending.delete(uniqueId);
+        this._clearSaveAttempt(uniqueId);
+        this._failSave(uniqueId);
     }
 
     private _sendSave(uniqueId: number) {
@@ -433,6 +453,7 @@ class ProjectManager extends Linker<{ projectId: number; branchId: string }> {
             }
             current.ack = undefined;
             this._saveInflight.delete(uniqueId);
+            this._updateSaving();
             this._verifySave('error', uniqueId);
         }, ProjectManager.SAVE_ACK_TIMEOUT_MS);
         entry.ack = ack;
@@ -448,6 +469,7 @@ class ProjectManager extends Linker<{ projectId: number; branchId: string }> {
                 current.ack = undefined;
             }
             this._saveInflight.delete(uniqueId);
+            this._updateSaving();
             this._log.warn(`failed to send save for document ${uniqueId}: ${err.message}`);
             this._verifySave('error', uniqueId);
         });
@@ -473,8 +495,9 @@ class ProjectManager extends Linker<{ projectId: number; branchId: string }> {
         const attempt = (entry?.attempt ?? 0) + 1;
         if (attempt > ProjectManager.SAVE_MAX_RETRIES) {
             this._log.error(`giving up saving document ${uniqueId} after ${ProjectManager.SAVE_MAX_RETRIES} retries`);
-            this._clearSaveAttempt(uniqueId);
             this._savePending.delete(uniqueId);
+            this._saveInflight.delete(uniqueId);
+            this._clearSaveAttempt(uniqueId);
             this._failSave(uniqueId);
             return false;
         }
@@ -505,6 +528,7 @@ class ProjectManager extends Linker<{ projectId: number; branchId: string }> {
             }
 
             this._saveInflight.add(uniqueId);
+            this._updateSaving();
             this._sendSave(uniqueId);
             this._log.debug(`retried save for document ${uniqueId} (attempt ${attempt})`);
         }, ProjectManager.SAVE_RETRY_DELAY_MS);
@@ -512,6 +536,7 @@ class ProjectManager extends Linker<{ projectId: number; branchId: string }> {
         entry.retry = retry;
         entry.attempt = attempt;
         this._saveAttempts.set(uniqueId, entry);
+        this._updateSaving();
         return false;
     }
 
@@ -521,6 +546,7 @@ class ProjectManager extends Linker<{ projectId: number; branchId: string }> {
         }
         this._savePending.delete(uniqueId);
         this.save(path);
+        this._updateSaving();
     }
 
     private _finishSave(uniqueId: number, path: string) {
@@ -1297,19 +1323,33 @@ class ProjectManager extends Linker<{ projectId: number; branchId: string }> {
         // ack drive the follow-up (Code Editor save.ts:159-162)
         if (this._saveInflight.has(file.uniqueId) || this._saveAttempts.has(file.uniqueId)) {
             this._savePending.add(file.uniqueId);
+            this._updateSaving();
             return;
         }
+
+        if (file.doc.pending && file.doc.stuck) {
+            this._failSave(file.uniqueId);
+            return;
+        }
+
+        const entry = { attempt: 0 };
+        this._saveAttempts.set(file.uniqueId, entry);
         this._saveInflight.add(file.uniqueId);
+        this._updateSaving();
 
         // wait for pending ops to be acknowledged before saving,
         // matching the Code Editor's behavior (save.ts:144-150).
         // prevents saving stale content while ops are in-flight.
         file.doc.whenNothingPending(() => {
+            if (this._saveAttempts.get(file.uniqueId) !== entry) {
+                return;
+            }
             // re-check after pending drains: a remote op may have brought the
             // doc back in line with S3 (file.dirty is kept live in the 'op' and
             // 'reload' handlers), in which case skip the server round-trip
             if (!file.dirty) {
                 this._saveInflight.delete(file.uniqueId);
+                this._clearSaveAttempt(file.uniqueId);
                 this._events.emit('asset:file:save', path);
                 this._drainSaves(file.uniqueId, path);
                 return;
@@ -1464,6 +1504,7 @@ class ProjectManager extends Linker<{ projectId: number; branchId: string }> {
         // local ops unacked past the stuck threshold — surface desync unconditionally
         // (see _addFile for rationale). 'drained' clears desync when the queue recovers.
         otdoc.on('stuck', () => {
+            this._failWaitingSave(uniqueId);
             this.desync.set(() => true);
         });
         otdoc.on('drained', () => {
@@ -1546,34 +1587,40 @@ class ProjectManager extends Linker<{ projectId: number; branchId: string }> {
             uniqueId: 0
         });
 
-        const loadAssetNext = await progressNotification('Loading Assets', assets.length);
+        const [loadAssetNext, loadAssetDone] = await progressNotification('Loading Assets', assets.length);
 
         // subscribe to all assets in batches
         const ordered: { uniqueId: number; data: Record<string, unknown> }[] = [];
-        for (let i = 0; i < assets.length; i += BATCH_SIZE) {
-            const batch = assets.slice(i, i + BATCH_SIZE);
-            const subscriptions: [string, string][] = batch.map((asset) => ['assets', `${asset.uniqueId}`]);
-            const docs = await this._sharedb.bulkSubscribe(subscriptions);
-            this._cleanup.push(async () => {
-                await this._sharedb.bulkUnsubscribe(subscriptions);
-            });
-            for (let j = 0; j < docs.length; j++) {
-                const doc = docs[j];
-                const uniqueId = batch[j].uniqueId;
-                if (!doc) {
-                    this._log.error(fail`failed to subscribe to asset ${uniqueId}`);
+        const [assetErr] = await tryCatch(async () => {
+            for (let i = 0; i < assets.length; i += BATCH_SIZE) {
+                const batch = assets.slice(i, i + BATCH_SIZE);
+                const subscriptions: [string, string][] = batch.map((asset) => ['assets', `${asset.uniqueId}`]);
+                const docs = await this._sharedb.bulkSubscribe(subscriptions);
+                this._cleanup.push(async () => {
+                    await this._sharedb.bulkUnsubscribe(subscriptions);
+                });
+                for (let j = 0; j < docs.length; j++) {
+                    const doc = docs[j];
+                    const uniqueId = batch[j].uniqueId;
+                    if (!doc) {
+                        this._log.error(fail`failed to subscribe to asset ${uniqueId}`);
+                        loadAssetNext();
+                        continue;
+                    }
+
+                    // add asset
+                    this._addAsset(uniqueId, doc);
+
+                    // store in list for ordered processing
+                    ordered.push({ uniqueId, data: doc.data });
+
                     loadAssetNext();
-                    continue;
                 }
-
-                // add asset
-                this._addAsset(uniqueId, doc);
-
-                // store in list for ordered processing
-                ordered.push({ uniqueId, data: doc.data });
-
-                loadAssetNext();
             }
+        });
+        loadAssetDone();
+        if (assetErr) {
+            throw assetErr;
         }
 
         // split folder and files
@@ -1649,28 +1696,34 @@ class ProjectManager extends Linker<{ projectId: number; branchId: string }> {
         const folders = folders0.filter(reachable);
         const files = files0.filter(reachable);
 
-        const loadFileNext = await progressNotification('Loading Files', folders.length + files.length);
+        const [loadFileNext, loadFileDone] = await progressNotification('Loading Files', folders.length + files.length);
         let skipsDirty = false;
 
-        // add all folders first
-        for (const asset of folders) {
-            if (this._addFolder(asset.uniqueId).changed) {
-                skipsDirty = true;
+        const [fileErr] = await tryCatch(async () => {
+            // add all folders first
+            for (const asset of folders) {
+                if (this._addFolder(asset.uniqueId).changed) {
+                    skipsDirty = true;
+                }
+                loadFileNext();
             }
-            loadFileNext();
-        }
 
-        // add file stubs (lazy — document subscribed on open)
-        for (const asset of files) {
-            if (this._addStub(asset.uniqueId).changed) {
-                skipsDirty = true;
+            // add file stubs (lazy — document subscribed on open)
+            for (const asset of files) {
+                if (this._addStub(asset.uniqueId).changed) {
+                    skipsDirty = true;
+                }
+                loadFileNext();
             }
-            loadFileNext();
-        }
 
-        // show collisions if dirty
-        if (skipsDirty) {
-            this.collisions.refresh();
+            // show collisions if dirty
+            if (skipsDirty) {
+                this.collisions.refresh();
+            }
+        });
+        loadFileDone();
+        if (fileErr) {
+            throw fileErr;
         }
 
         // watchers
@@ -1694,6 +1747,7 @@ class ProjectManager extends Linker<{ projectId: number; branchId: string }> {
             this._saveInflight.clear();
             this._savePending.clear();
             this._saveFailed.clear();
+            this._updateSaving();
 
             this._files.clear();
             this._assets.clear();

--- a/src/test/suite/extension.test.ts
+++ b/src/test/suite/extension.test.ts
@@ -100,6 +100,7 @@ const debounces = createRecordChannel<{ settled: Promise<void> }>();
 const originalAtomic = Mutex.prototype.atomic;
 const originalDebounce = Debouncer.prototype.debounce;
 const originalApplyEdit = vscode.workspace.applyEdit.bind(vscode.workspace);
+let applyEditOverride: typeof originalApplyEdit | undefined;
 
 guardSandbox.stub(EventEmitter.prototype, 'emit').callsFake(function (
     this: unknown,
@@ -157,7 +158,7 @@ guardSandbox.stub(Debouncer.prototype, 'debounce').callsFake(function (
 });
 
 guardSandbox.stub(vscode.workspace, 'applyEdit').callsFake((edit, metadata) => {
-    const result = Promise.resolve(originalApplyEdit(edit, metadata));
+    const result = Promise.resolve((applyEditOverride ?? originalApplyEdit)(edit, metadata));
     const settled = result.then(() => undefined);
     edits.push({
         uris: edit.entries().map(([uri]) => uri.toString()),
@@ -519,6 +520,7 @@ suite('extension', () => {
         // clear per-doc test-injection flags (_latency, _rejectNext) so a stuck/desync
         // test in one slot doesn't bleed into the next test's first submit.
         sharedb.resetAdversarial();
+        applyEditOverride = undefined;
         // clear per-method REST failure queues so a failNext from one test doesn't
         // get consumed by the next test's first call.
         rest.resetFailures();
@@ -1508,17 +1510,24 @@ suite('extension', () => {
         const warnings = () =>
             warningMessageStub.getCalls().filter((c) => /do not sync in realtime/i.test(`${c.args[0]}`)).length;
 
-        // external edit to closed file A
-        await vscode.workspace.fs.writeFile(uriA, buffer.from('// EXTERNAL EDIT A\n'));
+        // an identical atomic replacement must not consume the one-shot warning
+        const tmp = vscode.Uri.file('/tmp/claude/change_closed_local_remote.js');
+        await vscode.workspace.fs.createDirectory(vscode.Uri.file('/tmp/claude'));
+        await vscode.workspace.fs.writeFile(tmp, buffer.from('// SAMPLE CONTENT'));
+        await vscode.workspace.fs.rename(tmp, uriA, { overwrite: true });
+        await waitForIdle('identical atomic write settle');
+        assert.strictEqual(warnings(), 0, 'identical content should not warn');
+
+        // concurrent external edits race through the async hash check but still warn once
+        await Promise.all([
+            vscode.workspace.fs.writeFile(uriA, buffer.from('// EXTERNAL EDIT A\n')),
+            vscode.workspace.fs.writeFile(uriB, buffer.from('// EXTERNAL EDIT B\n'))
+        ]);
         await waitForWarning(/do not sync in realtime/i, 'external edit warning');
+        await waitForIdle('concurrent external edits settle');
 
         assert.strictEqual(docA.submitOp.callCount, 0, 'external closed edit should not submit an OT op');
         assert.strictEqual(warnings(), 1, 'warning should be shown exactly once');
-
-        // second external edit to a different closed file — one-shot, no second toast
-        await vscode.workspace.fs.writeFile(uriB, buffer.from('// EXTERNAL EDIT B\n'));
-        await waitForIdle('second external edit settle');
-        assert.strictEqual(warnings(), 1, 'warning should not be shown a second time');
     });
 
     test('file change - atomic write does not sync or duplicate', async () => {
@@ -1572,7 +1581,6 @@ suite('extension', () => {
         const doc = sharedb.subscriptions.get(`documents:${asset.uniqueId}`);
         assert.ok(doc, 'sharedb document should exist');
         doc.submitOp.resetHistory();
-        warningMessageStub.resetHistory();
 
         // snapshot assetCreate call count after setup
         const createsBefore = rest.assetCreate.callCount;
@@ -1589,10 +1597,6 @@ suite('extension', () => {
 
         // verify no new asset was created
         assert.strictEqual(rest.assetCreate.callCount, createsBefore, 'should not call assetCreate for atomic write');
-
-        // identical content must not trigger the external-edit warning (echo/diskHash match)
-        const warnings = warningMessageStub.getCalls().filter((c) => /do not sync in realtime/i.test(`${c.args[0]}`));
-        assert.strictEqual(warnings.length, 0, 'identical content should not warn');
     });
 
     test('file change - no auto-save on external', async () => {
@@ -1689,6 +1693,50 @@ suite('extension', () => {
         assert.strictEqual(tdoc.getText(), original, 'blocked edit should be reverted to disk content');
         assert.strictEqual(doc.submitOp.callCount, 0, 'blocked edit should not submit OT');
         assert.ok(warningMessageStub.calledWith(sinon.match(/still loading/i)), 'loading warning should be shown');
+    });
+
+    test('file open - subscribe reconciliation preserves concurrent typing', async () => {
+        const folderUri = vscode.workspace.workspaceFolders?.[0]?.uri;
+        assert.ok(folderUri, 'workspace folder should exist');
+
+        const original = '// ORIG\n';
+        const replaced = '// SERVER REPLACED\n';
+        const asset = await assetCreate({ name: 'subscribe_reconcile_typing.js', content: original });
+        const uri = vscode.Uri.joinPath(folderUri, asset.name);
+        const tdoc = await vscode.workspace.openTextDocument(uri);
+        await vscode.window.showTextDocument(tdoc);
+        const doc = sharedb.subscriptions.get(`documents:${asset.uniqueId}`);
+        assert.ok(doc, 'sharedb doc should exist');
+
+        let injected = '';
+        applyEditOverride = async (edit, metadata) => {
+            if (!edit.entries().some(([entry]) => entry.toString() === uri.toString())) {
+                return originalApplyEdit(edit, metadata);
+            }
+            applyEditOverride = undefined;
+            const applied = await originalApplyEdit(edit, metadata);
+            const user = new vscode.WorkspaceEdit();
+            user.insert(uri, new vscode.Position(0, 0), '// USER\n');
+            await originalApplyEdit(user);
+            injected = (await vscode.workspace.openTextDocument(uri)).getText();
+            return applied;
+        };
+
+        const subscribed = waitForEmit(
+            'asset:file:subscribed',
+            (args) => args[0] === asset.name,
+            'reconcile subscribe',
+            RETRY_TIMEOUT
+        );
+        documents.set(asset.uniqueId, replaced);
+        doc.reload(replaced);
+        await subscribed;
+        await waitForIdle('reconcile typing settle');
+
+        const expected = `// USER\n${replaced}`;
+        assert.strictEqual(injected, expected, 'test hook should inject typing during subscribe applyEdit');
+        assert.strictEqual(tdoc.getText(), expected, 'buffer should retain typing during subscribe applyEdit');
+        assert.strictEqual(documents.get(asset.uniqueId), expected, 'recovered typing should reach ShareDB');
     });
 
     test('file close - discard after first-keystroke does not roll back doc', async () => {
@@ -3584,6 +3632,45 @@ suite('extension', () => {
         assert.ok(
             warningMessageStub.calledWith(sinon.match(/out of sync/i)),
             'desync toast must fire after submit rejection'
+        );
+    });
+
+    test('save waiting on a rejected op fails instead of hanging', async () => {
+        const folderUri = vscode.workspace.workspaceFolders?.[0]?.uri;
+        assert.ok(folderUri, 'workspace folder should exist');
+
+        const asset = await assetCreate({ name: 'save_rejected_pending.js', content: '// ORIG\n' });
+        const uri = vscode.Uri.joinPath(folderUri, asset.name);
+        const tdoc = await vscode.workspace.openTextDocument(uri);
+        await vscode.window.showTextDocument(tdoc);
+
+        const doc = sharedb.subscriptions.get(`documents:${asset.uniqueId}`);
+        assert.ok(doc, 'sharedb doc should exist');
+        doc._latency = 50;
+        doc._rejectNext = 'forbidden(5)';
+        sharedb.sendRaw.resetHistory();
+        warningMessageStub.resetHistory();
+
+        const failed = waitForEmit(
+            'asset:file:failed',
+            (args) => args[0] === asset.name,
+            'pending save failure',
+            RETRY_TIMEOUT
+        );
+        const edit = new vscode.WorkspaceEdit();
+        edit.insert(uri, new vscode.Position(0, 0), '// REJECTED\n');
+        await vscode.workspace.applyEdit(edit);
+        await tdoc.save();
+        await failed;
+
+        assert.ok(
+            warningMessageStub.calledWith(sinon.match(/could not save/i)),
+            'save failure should be reported even after desync'
+        );
+        assert.strictEqual(
+            sharedb.sendRaw.getCalls().filter((call) => `${call.args[0]}` === `doc:save:${asset.uniqueId}`).length,
+            0,
+            'save should not send while the op queue is stuck'
         );
     });
 

--- a/src/utils/ot-document.ts
+++ b/src/utils/ot-document.ts
@@ -102,6 +102,10 @@ class OTDocument extends EventEmitter<OTDocumentEvents> {
         return this._doc.hasPending();
     }
 
+    get stuck() {
+        return this._stuck;
+    }
+
     whenNothingPending(fn: () => void) {
         this._doc.whenNothingPending(fn);
     }


### PR DESCRIPTION
## Summary

- preserve edits made while remote, subscribe, and dirty-buffer updates are applied
- bound stalled saves and surface saving or failed-save state
- close interrupted loading progress and keep external-edit warnings one-shot

## Manual smoke test

1. Open the same script in VS Code and Code Editor, edit from both clients, and confirm both changes remain synchronized.
2. Save a modified script and confirm the Saving status clears after the save completes.
3. Modify two closed project files concurrently with an external tool and confirm only one realtime-mode warning appears.
4. Reload the project and confirm the asset and disk loading notifications dismiss.