### PR TITLE
feat: add discard all changes for pull/push mode

### DIFF
--- a/package.json
+++ b/package.json
@@ -123,6 +123,11 @@
                 "icon": "$(discard)"
             },
             {
+                "command": "playcanvas.discardAll",
+                "title": "PlayCanvas: Discard All Changes",
+                "icon": "$(discard)"
+            },
+            {
                 "command": "playcanvas.resolveMerge",
                 "title": "PlayCanvas: Resolve in Merge Editor",
                 "icon": "$(git-merge)"
@@ -145,6 +150,13 @@
                 {
                     "command": "playcanvas.discard",
                     "when": "scmProvider == playcanvas",
+                    "group": "inline"
+                }
+            ],
+            "scm/resourceGroup/context": [
+                {
+                    "command": "playcanvas.discardAll",
+                    "when": "scmProvider == playcanvas && scmResourceGroup == changes",
                     "group": "inline"
                 }
             ]

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -325,6 +325,27 @@ export const activate = async (context: vscode.ExtensionContext) => {
                     void vscode.window.showWarningMessage(`PlayCanvas Discard: ${err.message}`);
                 }
             }),
+            vscode.commands.registerCommand(`${NAME}.discardAll`, async () => {
+                const count = [...nativeSync.statuses()].filter(([, s]) => s !== 'clean' && s !== 'behind').length;
+                if (!count) {
+                    void vscode.window.showInformationMessage('PlayCanvas: no local changes to discard');
+                    return;
+                }
+                const choice = await vscode.window.showWarningMessage(
+                    `Discard all ${count} local change${count === 1 ? '' : 's'}? This cannot be undone.`,
+                    { modal: true },
+                    'Discard All'
+                );
+                if (choice !== 'Discard All') {
+                    return;
+                }
+                const [err] = await tryCatch(() => nativeSync.discardAll());
+                if (err) {
+                    void vscode.window.showWarningMessage(`PlayCanvas Discard All: ${err.message}`);
+                } else {
+                    void vscode.window.showInformationMessage('PlayCanvas: discarded all local changes');
+                }
+            }),
             vscode.commands.registerCommand(
                 `${NAME}.resolveMerge`,
                 async (arg?: vscode.Uri | vscode.SourceControlResourceState) => {

--- a/src/sync/sync-engine.ts
+++ b/src/sync/sync-engine.ts
@@ -903,15 +903,32 @@ class NativeSyncEngine extends Linker<LinkParams> {
 
     // revert a file's working copy to the base (git restore). destructive.
     async discard(uri: vscode.Uri) {
-        return this._locked(() => this._discard(uri));
+        return this._locked(async () => {
+            await this._discardOne(this._path(uri));
+            await this._refreshAll();
+        });
     }
 
-    private async _discard(uri: vscode.Uri) {
-        const folderUri = this._folderUri;
-        if (!folderUri) {
+    // revert every outgoing local change in one pass (git restore .). destructive.
+    // deepest-first so a non-recursive folder delete only fires once its children
+    // are gone. incoming-only (behind) files are left untouched.
+    async discardAll() {
+        const outgoing = [...this._status]
+            .filter(([, s]) => s !== 'clean' && s !== 'behind')
+            .map(([path]) => path)
+            .sort((a, b) => b.split('/').length - a.split('/').length);
+        if (!outgoing.length) {
             return;
         }
-        const path = relativePath(uri, folderUri);
+        return this._locked(async () => {
+            for (const path of outgoing) {
+                await this._discardOne(path);
+            }
+            await this._refreshAll();
+        });
+    }
+
+    private async _discardOne(path: string) {
         const op = this._local.get(path);
         const base = this.baseText(path);
 
@@ -919,7 +936,6 @@ class NativeSyncEngine extends Linker<LinkParams> {
             await this._applyDelete(path);
             this._local.delete(path);
             this._status.delete(path);
-            await this._refreshAll();
             return;
         }
 
@@ -931,7 +947,6 @@ class NativeSyncEngine extends Linker<LinkParams> {
             }
             this._local.delete(path);
             this._status.delete(path);
-            await this._refreshAll();
             return;
         }
 
@@ -943,7 +958,6 @@ class NativeSyncEngine extends Linker<LinkParams> {
             if (op.type === 'file' && base !== undefined) {
                 await this._applyUpdate(op.from, base);
             }
-            await this._refreshAll();
             return;
         }
 
@@ -951,7 +965,6 @@ class NativeSyncEngine extends Linker<LinkParams> {
             return;
         }
         await this._applyUpdate(path, base);
-        await this._refreshAll();
     }
 
     async link({ folderUri, projectManager, projectId, branchId }: LinkParams) {

--- a/src/test/suite/utils.test.ts
+++ b/src/test/suite/utils.test.ts
@@ -1845,6 +1845,50 @@ suite('sync/sync-engine', () => {
         assert.strictEqual(e.status('a.js'), 'clean');
     });
 
+    test('discardAll reverts every outgoing change, leaves incoming alone', async () => {
+        const events = new EventEmitter<EventMap>();
+        await writeFile('a.js', 'x\n');
+        await writeFile('b.js', 'y\n');
+        await writeFile('c.js', 'z\n');
+        const cdoc = { text: 'z\n' };
+        const files = new Map<string, unknown>([
+            ['a.js', { type: 'file', uniqueId: 1, doc: { text: 'x\n' }, dirty: false }],
+            ['b.js', { type: 'file', uniqueId: 2, doc: { text: 'y\n' }, dirty: false }],
+            ['c.js', { type: 'file', uniqueId: 3, doc: cdoc, dirty: false }]
+        ]);
+        const e = engine(events);
+        await e.link({
+            folderUri: work,
+            projectManager: { files } as unknown as ProjectManager,
+            projectId: 1,
+            branchId: 'main'
+        });
+
+        await writeFile('a.js', 'x\nlocal\n'); // modified
+        await writeFile('new.js', 'new\n'); // added
+        events.emit('sync:file:create', 'new.js', 'file');
+        await vscode.workspace.fs.delete(vscode.Uri.joinPath(work, 'b.js'), { recursive: false, useTrash: false });
+        events.emit('sync:file:delete', 'b.js', 'file'); // deleted
+        cdoc.text = 'z\nremote\n'; // remote advances past base -> incoming only
+        await e.refresh();
+
+        assert.strictEqual(e.status('a.js'), 'modified');
+        assert.strictEqual(e.status('new.js'), 'added');
+        assert.strictEqual(e.status('b.js'), 'deleted');
+        assert.strictEqual(e.status('c.js'), 'behind');
+
+        await e.discardAll();
+
+        assert.strictEqual(await readFile('a.js'), 'x\n');
+        assert.strictEqual(await exists('new.js'), false);
+        assert.strictEqual(await readFile('b.js'), 'y\n');
+        assert.strictEqual(await readFile('c.js'), 'z\n'); // incoming not pulled
+        assert.strictEqual(e.status('a.js'), 'clean');
+        assert.strictEqual(e.status('new.js'), 'clean');
+        assert.strictEqual(e.status('b.js'), 'clean');
+        assert.strictEqual(e.status('c.js'), 'behind'); // incoming untouched
+    });
+
     test('resolve after conflict makes the file pushable (not stuck)', async () => {
         const { events, pm, doc, applied } = pushPm();
         await writeFile('a.js', 'a\nb\nc\n');


### PR DESCRIPTION
## Summary

Adds **PlayCanvas: Discard All Changes** (`playcanvas.discardAll`) for pull/push sync mode — reverts every outgoing local change (modified, added, deleted, renamed, both, conflicted) back to the last-pulled base in one action, behind a count-aware modal confirm. Incoming-only files are left untouched.

Useful after a branch switch, where the working tree often carries 20–30 stale changes from the previous branch that need clearing before you start on the new one.

## Details

- `NativeSyncEngine`: `_discard` refactored into `_discardOne` (no per-file refresh); both `discard` and the new `discardAll` run under a single lock and refresh once at the end. Bulk revert is deepest-first so a non-recursive folder delete only fires once its children are gone.
- Command exposed on the **Changes** group header in the PlayCanvas SCM view (matching VS Code's native "Discard All Changes" placement) and in the command palette.
- Unit test covers modified + added + deleted in one pass and asserts incoming-only files stay `behind`.

## Scope

This is a focused version of #335 — same feature, minus the unrelated "Saving…" status-indicator changes bundled there (which touch OT-critical paths and warrant separate review). Credit to @IgorIFGD for the feature.

## Test plan

- [x] `playcanvas.syncMode` = `pullpush`, reload, link a project
- [x] Make local changes on branch A, switch to branch B — stale changes appear under **Changes**
- [x] **Discard All Changes** from the Changes header — all outgoing changes clear, tree matches base
- [x] Modal shows the correct count; cancel does nothing
- [x] Per-file **Discard Changes** still works; incoming-only files unaffected
